### PR TITLE
Adding MPI (and cmake) dependency to README.md

### DIFF
--- a/src/CLIMA-atmos/Dycore/README.md
+++ b/src/CLIMA-atmos/Dycore/README.md
@@ -23,3 +23,20 @@ mpirun -n 4 julia --project=. drivers/rising_thermal_bubble.jl
 ```bash
 mpirun -n 4 julia --project=env/gpu drivers/rising_thermal_bubble.jl
 ```
+
+## CLIMA-atmos Dycore build problems?
+CLIMA-atmos Dycore depends on
+[`MPI.jl`](https://github.com/JuliaParallel/MPI.jl) which in turn requires
+`cmake`. If you have a failed build with the message `MPI not properly
+installed` you should try to manually build MPI and check the error message:
+
+```bash
+julia --project
+]build MPI
+```
+
+Common problems are:
+
+  - a lack of `cmake` being on the system
+  - the need for environment variables to be set; see the
+    [`MPI.jl`](https://github.com/JuliaParallel/MPI.jl) website for more details


### PR DESCRIPTION
Here we are adding some information concerning the `MPI.jl` and `cmake`
dependency of the CLIMA-atmos Dycore. We also offer some advice on how to begin
tackling MPI related build issues.