### PR TITLE
[AtmosDycore] Removing erroneous `inittimestate!`

### DIFF
--- a/src/CLIMA-atmos/Dycore/src/types.jl
+++ b/src/CLIMA-atmos/Dycore/src/types.jl
@@ -56,8 +56,6 @@ inittimestate!(f::Function, r::Runner; a...) = initstate!(r[:timerunner], f;
                                                           a...)
 inittimestate!(r::Runner, x; a...) = initstate!(r[:timerunner], x; a...)
 
-inittimestate!(f::Function, r::Runner; a...) = initstate!(r[:timerunner], f;
-                                                          a...)
 initstate!(f::Function, r::Union{AbstractSpaceRunner, AbstractTimeRunner};
            a...) = initstate!(r, f; a...)
 


### PR DESCRIPTION
There was an erroneous definition of `inittimestate!` in `types.jl`