### PR TITLE
[AtmosDycore] Fix deadlock in wall time callback

### DIFF
--- a/src/CLIMA-atmos/Dycore/drivers/isentropic_vortex.jl
+++ b/src/CLIMA-atmos/Dycore/drivers/isentropic_vortex.jl
@@ -131,7 +131,7 @@ function main()
         io = mpirank == 0 ? stdout : open("/dev/null", "w")
         show(io, "text/plain", runner[:spacerunner])
         cbinfo =
-          AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10, mpicomm) do
+          AD.GenericCallbacks.EveryXWallTimeSeconds(10, mpicomm) do
             println(io, runner[:spacerunner])
           end
 
@@ -153,7 +153,7 @@ function main()
         end
 
         cberr =
-          AD.GenericCallbacks.EveryXWallTimeSecondsCallback(2, mpicomm) do
+          AD.GenericCallbacks.EveryXWallTimeSeconds(2, mpicomm) do
             err = AD.L2errornorm(runner, isentropicvortex; host=true)
             println(io, "VanillaEuler with errnorm2(Q) = ", err, " at time = ",
                     runner[:time])

--- a/src/CLIMA-atmos/Dycore/drivers/isentropic_vortex.jl
+++ b/src/CLIMA-atmos/Dycore/drivers/isentropic_vortex.jl
@@ -130,9 +130,10 @@ function main()
         # Setup the info callback
         io = mpirank == 0 ? stdout : open("/dev/null", "w")
         show(io, "text/plain", runner[:spacerunner])
-        cbinfo = AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10) do
-          println(io, runner[:spacerunner])
-        end
+        cbinfo =
+          AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10, mpicomm) do
+            println(io, runner[:spacerunner])
+          end
 
         # Setup the vtk callback
         mkpath("viz")
@@ -151,11 +152,12 @@ function main()
           nothing
         end
 
-        cberr = AD.GenericCallbacks.EveryXWallTimeSecondsCallback(2) do
-          err = AD.L2errornorm(runner, isentropicvortex; host=true)
-          println(io, "VanillaEuler with errnorm2(Q) = ", err, " at time = ",
-                  runner[:time])
-        end
+        cberr =
+          AD.GenericCallbacks.EveryXWallTimeSecondsCallback(2, mpicomm) do
+            err = AD.L2errornorm(runner, isentropicvortex; host=true)
+            println(io, "VanillaEuler with errnorm2(Q) = ", err, " at time = ",
+                    runner[:time])
+          end
 
         dump_vtk(0)
         AD.run!(runner; numberofsteps=nsteps, callbacks=(cbinfo, cbvtk,

--- a/src/CLIMA-atmos/Dycore/drivers/rising_thermal_bubble.jl
+++ b/src/CLIMA-atmos/Dycore/drivers/rising_thermal_bubble.jl
@@ -120,7 +120,7 @@ function main()
         io = mpirank == 0 ? stdout : open("/dev/null", "w")
         show(io, "text/plain", runner[:spacerunner])
         cbinfo =
-          AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10, mpicomm) do
+          AD.GenericCallbacks.EveryXWallTimeSeconds(10, mpicomm) do
             println(io, runner[:spacerunner])
           end
 

--- a/src/CLIMA-atmos/Dycore/drivers/rising_thermal_bubble.jl
+++ b/src/CLIMA-atmos/Dycore/drivers/rising_thermal_bubble.jl
@@ -119,9 +119,10 @@ function main()
         # Setup the info callback
         io = mpirank == 0 ? stdout : open("/dev/null", "w")
         show(io, "text/plain", runner[:spacerunner])
-        cbinfo = AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10) do
-          println(io, runner[:spacerunner])
-        end
+        cbinfo =
+          AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10, mpicomm) do
+            println(io, runner[:spacerunner])
+          end
 
         # Setup the vtk callback
         mkpath("viz")

--- a/src/CLIMA-atmos/Dycore/src/GenericCallbacks.jl
+++ b/src/CLIMA-atmos/Dycore/src/GenericCallbacks.jl
@@ -1,6 +1,7 @@
 module GenericCallbacks
 using ..CLIMAAtmosDycore
 AD = CLIMAAtmosDycore
+using MPI
 
 """
    EveryXWallTimeSecondsCallback(f, time)
@@ -12,11 +13,13 @@ struct EveryXWallTimeSecondsCallback
   lastcbtime_ns::Array{UInt64}
   "time between callbacks"
   Δtime::Real
+  "MPI communicator"
+  mpicomm
   "function to execute for callback"
   func::Function
-  function EveryXWallTimeSecondsCallback(func, Δtime)
+  function EveryXWallTimeSecondsCallback(func, Δtime, mpicomm)
     lastcbtime_ns = [time_ns()]
-    new(lastcbtime_ns, Δtime, func)
+    new(lastcbtime_ns, Δtime, mpicomm, func)
   end
 end
 function (cb::EveryXWallTimeSecondsCallback)(initialize::Bool=false)
@@ -34,6 +37,7 @@ function (cb::EveryXWallTimeSecondsCallback)(initialize::Bool=false)
   # Check whether we should do a callback
   currtime_ns = time_ns()
   runtime = (currtime_ns - cb.lastcbtime_ns[1]) * 1e-9
+  runtime = MPI.Allreduce(runtime, MPI.MAX, cb.mpicomm)
   if runtime < cb.Δtime
     return 0
   else

--- a/src/CLIMA-atmos/Dycore/src/GenericCallbacks.jl
+++ b/src/CLIMA-atmos/Dycore/src/GenericCallbacks.jl
@@ -4,11 +4,11 @@ AD = CLIMAAtmosDycore
 using MPI
 
 """
-   EveryXWallTimeSecondsCallback(f, time)
+   EveryXWallTimeSeconds(f, time)
 
 This callback will run the function 'f()' every `time` wallclock time seconds
 """
-struct EveryXWallTimeSecondsCallback
+struct EveryXWallTimeSeconds
   "time of the last callback"
   lastcbtime_ns::Array{UInt64}
   "time between callbacks"
@@ -17,12 +17,12 @@ struct EveryXWallTimeSecondsCallback
   mpicomm
   "function to execute for callback"
   func::Function
-  function EveryXWallTimeSecondsCallback(func, Δtime, mpicomm)
+  function EveryXWallTimeSeconds(func, Δtime, mpicomm)
     lastcbtime_ns = [time_ns()]
     new(lastcbtime_ns, Δtime, mpicomm, func)
   end
 end
-function (cb::EveryXWallTimeSecondsCallback)(initialize::Bool=false)
+function (cb::EveryXWallTimeSeconds)(initialize::Bool=false)
   # Is this an initialization call? If so, start the timers
   if initialize
     cb.lastcbtime_ns[1] = time_ns()


### PR DESCRIPTION
Ensure that all ranks call a wall time callback.  Before only some ranks
would call the callback and some would execute the next step.  When this
happened a reduction (e.g, L2 error calculation) in the callback would
cause a deadlock.