### PR TITLE
[AtmosDycore] Implementation of tracers and (passive) moist variables

### DIFF
--- a/src/CLIMA-atmos/Dycore/TODO.md
+++ b/src/CLIMA-atmos/Dycore/TODO.md
@@ -1,13 +1,14 @@
 # TODO:
 
- - Consider how to do logging with MPI
- - Restart files
- - pretty print time info (and track performance issues)
- - asynchronous GPU memory/compute
- - asynchronous i/o
- - callbacks for spatial discretization / each stage of time stepper? (maybe
-   needed to handle passive advection)
- - Other time steppers
- - more ICs (error rates)
- - tests?
- 
+ - [ ] Better logging with MPI
+ - [ ] Restart files
+ - [ ] pretty print time info (and track performance issues)
+ - [ ] asynchronous GPU memory/compute
+ - [ ] asynchronous i/o
+ - [ ] callbacks for spatial discretization / each stage of time stepper?
+ - [ ] passive advection
+ - [ ] passive tracers
+ - [ ] moisture
+ - [ ] Standard RK timestepping
+ - [ ] Adaptive RK timestepping
+ - [ ] 1-D IMEX

--- a/src/CLIMA-atmos/Dycore/drivers/tracers_test.jl
+++ b/src/CLIMA-atmos/Dycore/drivers/tracers_test.jl
@@ -1,0 +1,195 @@
+# TODO:
+# - Switch to logging
+# - Add vtk
+# - timestep calculation clean
+# - Move stuff to device (to kill transfers back from GPU)
+# - Check that Float32 is really being used in all the kernels properly
+
+using CLIMAAtmosDycore
+const AD = CLIMAAtmosDycore
+using Canary
+using MPI
+
+using ParametersType
+using PlanetParameters: R_d, cp_d, grav, cv_d
+@parameter gamma_d cp_d/cv_d "Heat capcity ratio of dry air"
+@parameter gdm1 R_d/cv_d "(equivalent to gamma_d-1)"
+
+const HAVE_CUDA = try
+  using CUDAdrv
+  using CUDAnative
+  true
+catch
+  false
+end
+
+macro hascuda(ex)
+  return HAVE_CUDA ? :($(esc(ex))) : :(nothing)
+end
+
+meshgenerator(part, numparts, Ne, dim, DFloat) =
+brickmesh(ntuple(j->range(DFloat(0); length=Ne+1, stop=1000), dim),
+          (true, ntuple(j->false, dim-1)...),
+          part=part, numparts=numparts)
+
+function main(;spacemethod=:VanillaEuler, DFloat=Float64, dim=3, backend=Array,
+              N=4, Ne=10, timeend=0.1, ntrace = 0, nmoist = 0)
+  MPI.Initialized() || MPI.Init()
+  MPI.finalize_atexit()
+
+  mpicomm = MPI.COMM_WORLD
+  mpirank = MPI.Comm_rank(mpicomm)
+  mpisize = MPI.Comm_size(mpicomm)
+
+  # FIXME: query via hostname
+  @hascuda device!(mpirank % length(devices()))
+
+  runner = AD.Runner(mpicomm,
+                     #Space Discretization and Parameters
+                     spacemethod,
+                     (DFloat = DFloat,
+                      DeviceArray = backend,
+                      meshgenerator = (part, numparts) ->
+                      meshgenerator(part, numparts, Ne, dim,
+                                    DFloat),
+                      dim = dim,
+                      gravity = true,
+                      N = N,
+                      nmoist = nmoist,
+                      ntrace = ntrace,
+                     ),
+                     # Time Discretization and Parameters
+                     :LSRK,
+                     (),
+                    )
+
+  # Set the initial condition with a function
+  @assert runner[:spacerunner][:stateid] == (ρ=1,U=2,V=3,W=4,E=5)
+  @assert runner[:spacerunner][:moistid] == 5 .+ (1:nmoist)
+  @assert runner[:spacerunner][:traceid] == 5 + nmoist .+ (1:ntrace)
+  AD.initspacestate!(runner, host=true) do (x...)
+    DFloat = eltype(x)
+    γ::DFloat       = gamma_d
+    p0::DFloat      = 100000
+    R_gas::DFloat   = R_d
+    c_p::DFloat     = cp_d
+    c_v::DFloat     = cv_d
+    gravity::DFloat = grav
+
+    r = sqrt((x[1] - 500)^2 + (x[dim] - 350)^2)
+    rc::DFloat = 250
+    θ_ref::DFloat = 300
+    θ_c::DFloat = 0.5
+    Δθ::DFloat = 0
+    if r <= rc
+      Δθ = θ_c * (1 + cos(π * r / rc)) / 2
+    end
+    θ_k = θ_ref + Δθ
+    π_k = 1 - gravity / (c_p * θ_k) * x[dim]
+    c = c_v / R_gas
+    ρ_k = p0 / (R_gas * θ_k) * (π_k)^c
+    ρ = ρ_k
+    u = zero(DFloat)
+    v = zero(DFloat)
+    w = zero(DFloat)
+    U = ρ * u
+    V = ρ * v
+    W = ρ * w
+    Θ = ρ * θ_k
+    P = p0 * (R_gas * Θ / p0)^(c_p / c_v)
+    T = P / (ρ * R_gas)
+    E = ρ * (c_v * T + (u^2 + v^2 + w^2) / 2 + gravity * x[dim])
+    ρ, U, V, W, E, ntuple(j->ρ, nmoist + ntrace)...
+  end
+
+  # Compute a (bad guess) for the time step
+  base_dt = AD.estimatedt(runner, host=true)
+  nsteps = ceil(Int64, timeend / base_dt)
+  dt = timeend / nsteps
+
+  # Set the time step
+  AD.inittimestate!(runner, dt)
+
+  eng0 = AD.L2solutionnorm(runner; host=true)
+  # mpirank == 0 && @show eng0
+
+  # Setup the info callback
+  io = mpirank == 0 ? stdout : open("/dev/null", "w")
+  show(io, "text/plain", runner[:spacerunner])
+  cbinfo = AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10) do
+    println(io, runner[:spacerunner])
+  end
+
+  # Setup the vtk callback
+  mkpath("viz")
+  dump_vtk(step) = AD.writevtk(runner,
+                               "viz/RTB"*
+                               "_dim_$(dim)"*
+                               "_DFloat_$(DFloat)"*
+                               "_backend_$(backend)"*
+                               "_mpirank_$(mpirank)"*
+                               "_step_$(step)")
+  step = 0
+  cbvtk = AD.GenericCallbacks.EveryXSimulationSteps(10) do
+    # TODO: We should add queries back to time stepper for this
+    step += 1
+    dump_vtk(step)
+    nothing
+  end
+
+  let
+    Q = Array(runner[:Q])
+    stateid = runner[:spacerunner][:stateid]
+    moistid = runner[:spacerunner][:moistid]
+    traceid = runner[:spacerunner][:traceid]
+    @assert (@view Q[:, stateid.ρ, :]) == (@view Q[:, moistid[1], :])
+    @assert (@view Q[:, stateid.ρ, :]) == (@view Q[:, traceid[1], :])
+  end
+
+  dump_vtk(0)
+  AD.run!(runner; numberofsteps=nsteps, callbacks=(cbinfo, cbvtk))
+  dump_vtk(nsteps)
+
+  engf = AD.L2solutionnorm(runner; host=true)
+
+  mpirank == 0 && @show engf
+  mpirank == 0 && @show eng0 - engf
+  mpirank == 0 && @show engf/eng0
+  mpirank == 0 && println()
+  nothing
+end
+
+let
+  inputs = Dict{Symbol, Any}()
+  inputs[:spacemethod] = :VanillaEuler
+  inputs[:DFloat] = (Float64, Float32)
+  inputs[:dim] = (2, 3)
+  inputs[:backend] = (HAVE_CUDA ? (CuArray, Array) : (Array,))
+  inputs[:N] = 4
+  inputs[:Ne] = 10
+  inputs[:timeend] = 0.1
+  inputs[:ntrace] = 3
+  inputs[:nmoist] = 2
+
+  foreach(ARGS) do (A)
+    sp = split(A, '='; limit=2)
+    kw = Symbol(sp[1])
+    if kw == :spacemethod
+      inputs[kw] = Symbol(sp[2])
+    else
+      error("Nope")
+    end
+  end
+
+  (DFloats, dims, backends) = (inputs[:DFloat], inputs[:dim], inputs[:backend])
+  for DFloat in DFloats
+    for dim in dims
+      for backend in backends
+        inputs[:DFloat] = DFloat
+        inputs[:dim] = dim
+        inputs[:backend] = backend
+        main(;inputs...)
+      end
+    end
+  end
+end

--- a/src/CLIMA-atmos/Dycore/drivers/tracers_test.jl
+++ b/src/CLIMA-atmos/Dycore/drivers/tracers_test.jl
@@ -116,30 +116,11 @@ function main(;spacemethod=:VanillaEuler, DFloat=Float64, dim=3, backend=Array,
   # Setup the info callback
   io = mpirank == 0 ? stdout : open("/dev/null", "w")
   show(io, "text/plain", runner[:spacerunner])
-  cbinfo = AD.GenericCallbacks.EveryXWallTimeSecondsCallback(10) do
+  cbinfo = AD.GenericCallbacks.EveryXWallTimeSeconds(10, mpicomm) do
     println(io, runner[:spacerunner])
   end
 
-  # Setup the vtk callback
-  mkpath("viz")
-  dump_vtk(step) = AD.writevtk(runner,
-                               "viz/RTB"*
-                               "_dim_$(dim)"*
-                               "_DFloat_$(DFloat)"*
-                               "_backend_$(backend)"*
-                               "_mpirank_$(mpirank)"*
-                               "_step_$(step)")
-  step = 0
-  cbvtk = AD.GenericCallbacks.EveryXSimulationSteps(10) do
-    # TODO: We should add queries back to time stepper for this
-    step += 1
-    dump_vtk(step)
-    nothing
-  end
-
-  dump_vtk(0)
-  AD.run!(runner; numberofsteps=nsteps, callbacks=(cbinfo, cbvtk))
-  dump_vtk(nsteps)
+  AD.run!(runner; numberofsteps=nsteps, callbacks=(cbinfo, ))
 
   let
     Q = Array(runner[:Q])

--- a/src/CLIMA-atmos/Dycore/src/GenericCallbacks.jl
+++ b/src/CLIMA-atmos/Dycore/src/GenericCallbacks.jl
@@ -4,9 +4,10 @@ AD = CLIMAAtmosDycore
 using MPI
 
 """
-   EveryXWallTimeSeconds(f, time)
+    EveryXWallTimeSeconds(f, time, mpicomm)
 
-This callback will run the function 'f()' every `time` wallclock time seconds
+This callback will run the function 'f()' every `time` wallclock time seconds.
+The `mpicomm` is used to syncronize runtime across MPI ranks.
 """
 struct EveryXWallTimeSeconds
   "time of the last callback"

--- a/src/CLIMA-atmos/Dycore/src/VanillaEuler.jl
+++ b/src/CLIMA-atmos/Dycore/src/VanillaEuler.jl
@@ -690,7 +690,6 @@ function volumerhs!(::Val{2}, ::Val{N}, ::Val{nmoist}, ::Val{ntrace},
 
   s_F = Array{DFloat}(undef, Nq, Nq, _nstate)
   s_G = Array{DFloat}(undef, Nq, Nq, _nstate)
-  MJI = Array{DFloat}(undef, Nq, Nq, _nstate)
 
   @inbounds for e in elems
     for j = 1:Nq, i = 1:Nq

--- a/src/CLIMA-atmos/Dycore/src/VanillaEuler.jl
+++ b/src/CLIMA-atmos/Dycore/src/VanillaEuler.jl
@@ -25,8 +25,8 @@ using Base: @kwdef
 
 # note the order of the fields below is also assumed in the code.
 const _nstate = 5
-const _U, _V, _W, _ρ, _E = 1:_nstate
-const stateid = (U = _U, V = _V, W = _W, ρ = _ρ, E = _E)
+const _ρ, _U, _V, _W, _E = 1:_nstate
+const stateid = (ρ = _ρ, U = _U, V = _V, W = _W, E = _E)
 
 const _nvgeo = 14
 const _ξx, _ηx, _ζx, _ξy, _ηy, _ζy, _ξz, _ηz, _ζz, _MJ, _MJI,

--- a/src/CLIMA-atmos/Dycore/src/VanillaEuler.jl
+++ b/src/CLIMA-atmos/Dycore/src/VanillaEuler.jl
@@ -636,7 +636,7 @@ function AD.rhs!(rhs::DeviceArray,
   MPI.Waitall!(sendreq)
 
   # pack data in send buffer
-  fillsendQ!(Val(dim), Val(N), host_sendQ, device_sendQ, Q, sendelems)
+  fillsendQ!(host_sendQ, device_sendQ, Q, sendelems)
 
   # post MPI sends
   for n = 1:nnabr
@@ -652,7 +652,7 @@ function AD.rhs!(rhs::DeviceArray,
   MPI.Waitall!(recvreq)
 
   # copy data to state vectors
-  transferrecvQ!(Val(dim), Val(N), device_recvQ, host_recvQ, Q, nrealelem)
+  transferrecvQ!(device_recvQ, host_recvQ, Q, nrealelem)
 
   # face RHS computation
   facerhs!(Val(dim), Val(N), Val(nmoist), Val(ntrace), rhs, Q, vgeo, sgeo,
@@ -661,13 +661,11 @@ end
 # }}}
 
 # {{{ MPI Buffer handling
-function fillsendQ!(::Val{dim}, ::Val{N}, host_sendQ,
-                            device_sendQ::Array, Q, sendelems) where {dim, N}
+function fillsendQ!(host_sendQ, device_sendQ::Array, Q, sendelems)
   host_sendQ[:, :, :] .= Q[:, :, sendelems]
 end
 
-function transferrecvQ!(::Val{dim}, ::Val{N}, device_recvQ::Array,
-                                host_recvQ, Q, nrealelem) where {dim, N}
+function transferrecvQ!(device_recvQ::Array, host_recvQ, Q, nrealelem)
   Q[:, :, nrealelem+1:end] .= host_recvQ[:, :, :]
 end
 # }}}

--- a/src/CLIMA-atmos/Dycore/src/VanillaEuler_cuda.jl
+++ b/src/CLIMA-atmos/Dycore/src/VanillaEuler_cuda.jl
@@ -418,9 +418,10 @@ function volumerhs!(::Val{dim}, ::Val{N}, ::Val{nmoist}, ::Val{ntrace},
                        d_vgeoC, gravity, d_D, nelem))
 end
 
-function facerhs!(::Val{dim}, ::Val{N}, d_rhsL::CuArray, d_QL, d_vgeo, d_sgeo,
-                  gravity, elems, d_vmapM, d_vmapP,
-                  d_elemtobndy) where {dim, N}
+function facerhs!(::Val{dim}, ::Val{N}, ::Val{nmoist}, ::Val{ntrace},
+                  d_rhsL::CuArray, d_QL, d_vgeo, d_sgeo, gravity, elems,
+                  d_vmapM, d_vmapP, d_elemtobndy) where {dim, N, nmoist,
+                                                         ntrace}
   nelem = length(elems)
   @cuda(threads=(ntuple(j->N+1, dim-1)..., 1), blocks=nelem,
         knl_facerhs!(Val(dim), Val(N), d_rhsL, d_QL, d_vgeo, d_sgeo, gravity,

--- a/src/CLIMA-atmos/Dycore/src/VanillaEuler_cuda.jl
+++ b/src/CLIMA-atmos/Dycore/src/VanillaEuler_cuda.jl
@@ -2,8 +2,8 @@
 # advection (also update the license)
 
 # {{{ Volume RHS for 2-D
-function knl_volumerhs!(::Val{2}, ::Val{N}, rhs, Q, vgeo, gravity, D,
-                        nelem) where N
+function knl_volumerhs!(::Val{2}, ::Val{N}, ::Val{nmoist}, ::Val{ntrace}, rhs,
+                        Q, vgeo, gravity, D, nelem) where {N, nmoist, ntrace}
   DFloat = eltype(D)
 
   Nq = N + 1
@@ -92,8 +92,8 @@ end
 # }}}
 
 # {{{ Volume RHS for 3-D
-function knl_volumerhs!(::Val{3}, ::Val{N}, rhs, Q, vgeo, gravity, D,
-                        nelem) where N
+function knl_volumerhs!(::Val{3}, ::Val{N}, ::Val{nmoist}, ::Val{ntrace}, rhs,
+                        Q, vgeo, gravity, D, nelem) where {N, nmoist, ntrace}
   DFloat = eltype(D)
 
   Nq = N + 1
@@ -402,8 +402,9 @@ end
 # }}}
 
 # {{{ Kernel wrappers
-function volumerhs!(::Val{dim}, ::Val{N}, d_rhsL::CuArray, d_QL, d_vgeoL,
-                    gravity, d_D, elems) where {dim, N}
+function volumerhs!(::Val{dim}, ::Val{N}, ::Val{nmoist}, ::Val{ntrace},
+                    d_rhsL::CuArray, d_QL, d_vgeoL, gravity, d_D,
+                    elems) where {dim, N, nmoist, ntrace}
   Qshape    = (ntuple(j->N+1, dim)..., size(d_QL, 2), size(d_QL, 3))
   vgeoshape = (ntuple(j->N+1, dim)..., _nvgeo, size(d_QL, 3))
 
@@ -413,8 +414,8 @@ function volumerhs!(::Val{dim}, ::Val{N}, d_rhsL::CuArray, d_QL, d_vgeoL,
 
   nelem = length(elems)
   @cuda(threads=ntuple(j->N+1, dim), blocks=nelem,
-        knl_volumerhs!(Val(dim), Val(N), d_rhsC, d_QC, d_vgeoC, gravity, d_D,
-                       nelem))
+        knl_volumerhs!(Val(dim), Val(N), Val(nmoist), Val(ntrace), d_rhsC, d_QC,
+                       d_vgeoC, gravity, d_D, nelem))
 end
 
 function facerhs!(::Val{dim}, ::Val{N}, d_rhsL::CuArray, d_QL, d_vgeo, d_sgeo,


### PR DESCRIPTION
This primarily implements tracers and moist variables for the AtmosDycore on both the CPU and GPU. Right now the moist variables have no physics and are just passively advected. As a test we make sure that if the tracers are initialized to be the scaled density that they remain this through out the simulation.

A few other things that are caught up in commits with this pull-request:

- In `VanillaEuler` the  Euler state variable storage order now matches the input function ordering
- In `VanillaEuler` the `facerhs!` on the CPU is now unified for 2- and 3-D
- In `GenericCallbacks` there is a comment fix for `EveryXWallTimeSeconds`
- In `VanillaEuler` an unneeded `MJI` array is removed on the CPU
- In `VanillaEuler` some postscript `L` are removed in the device arrays for the GPU kernel wrapper functions
- In `VanillaEuler` the `Val`s in the MPI buffer functions are removed