### PR TITLE
Use _ for unused return values

### DIFF
--- a/src/ClimaAtmos/Dycore/src/AtmosStateArrays.jl
+++ b/src/ClimaAtmos/Dycore/src/AtmosStateArrays.jl
@@ -194,7 +194,7 @@ end
 
 function knl_norm2(::Val{Np}, Q, elems) where {Np}
   DFloat = eltype(Q)
-  (~, nstate, nelem) = size(Q)
+  (_, nstate, nelem) = size(Q)
 
   energy = zero(DFloat)
 
@@ -207,7 +207,7 @@ end
 
 function knl_L2norm(::Val{Np}, Q, weights, elems) where {Np}
   DFloat = eltype(Q)
-  (~, nstate, nelem) = size(Q)
+  (_, nstate, nelem) = size(Q)
 
   energy = zero(DFloat)
 
@@ -250,7 +250,7 @@ function L2errornorm(::Val{dim}, ::Val{N}, time, Q, vgeo, elems,
   {dim, N}
   DFloat = eltype(Q)
   Np = (N+1)^dim
-  (~, nstate, nelem) = size(Q)
+  (_, nstate, nelem) = size(Q)
 
   errorsq = zero(DFloat)
 

--- a/src/ClimaAtmos/Dycore/src/VanillaAtmosDiscretizations.jl
+++ b/src/ClimaAtmos/Dycore/src/VanillaAtmosDiscretizations.jl
@@ -182,7 +182,7 @@ function estimatedt(::Val{dim}, ::Val{N}, G, gravity, Q, vgeo,
   DFloat = eltype(Q)
 
   Np = (N+1)^dim
-  (~, ~, nelem) = size(Q)
+  (_, _, nelem) = size(Q)
 
   dt = [floatmax(DFloat)]
 

--- a/src/ClimaAtmos/Dycore/src/vtk.jl
+++ b/src/ClimaAtmos/Dycore/src/vtk.jl
@@ -4,7 +4,7 @@ using WriteVTK
 This is the 1D WriteMesh routine
 =#
 function writemesh(base_name, x; fields=(), realelems=1:size(x)[end])
-  (Nqr, ~) = size(x)
+  (Nqr, _) = size(x)
   Nsubcells = (Nqr-1)
 
   cells = Array{MeshCell{Array{Int,1}}, 1}(undef, Nsubcells * length(realelems))
@@ -28,7 +28,7 @@ This is the 2D WriteMesh routine
 =#
 function writemesh(base_name, x, y; fields=(), realelems=1:size(x)[end])
   @assert size(x) == size(y)
-  (Nqr, Nqs, ~) = size(x)
+  (Nqr, Nqs, _) = size(x)
   Nsubcells = (Nqr-1) * (Nqs-1)
 
   cells = Array{MeshCell{Array{Int,1}}, 1}(undef, Nsubcells * length(realelems))
@@ -55,7 +55,7 @@ end
 This is the 3D WriteMesh routine
 =#
 function writemesh(base_name, x, y, z; fields=(), realelems=1:size(x)[end])
-  (Nqr, Nqs, Nqt, ~) = size(x)
+  (Nqr, Nqs, Nqt, _) = size(x)
   (Nr, Ns, Nt) = (Nqr-1, Nqs-1, Nqt-1)
   Nsubcells = Nr * Ns * Nt
   cells = Array{MeshCell{Array{Int,1}}, 1}(undef, Nsubcells * length(realelems))


### PR DESCRIPTION
This uses underscore where the return values are unused.  This address the comment @simonbyrne had on https://github.com/climate-machine/CLIMA/pull/97.