### PR TITLE
Change `bc` to `boundary` in sphere topology

### DIFF
--- a/src/Mesh/Topologies.jl
+++ b/src/Mesh/Topologies.jl
@@ -784,14 +784,14 @@ end
 
 """
    StackedCubedSphereTopology(mpicomm, Nhorz, Rrange;
-                              bc=(1,1)) <: AbstractTopology{3}
+                              boundary=(1,1)) <: AbstractTopology{3}
 
 Generate a stacked cubed sphere topology with `Nhorz` by `Nhorz` cells for each
 horizontal face and `Rrange` is the radius edges of the stacked elements.  This
 topology actual creates a cube mesh, and the warping should be done after the
 grid is created using the `cubedshellwarp` function. The coordinates of the
 points will be of type `eltype(Rrange)`. The inner boundary condition type is
-`bc[1]` and the outer boundary condition type is `bc[2]`.
+`boundary[1]` and the outer boundary condition type is `boundary[2]`.
 
 The elements are stacked such that the vertical elements are contiguous in the
 element ordering.
@@ -822,7 +822,7 @@ MPI.Finalize()
 ```
 Note that the faces are listed in Cartesian order.
 """
-function StackedCubedSphereTopology(mpicomm, Nhorz, Rrange; bc = (1, 1),
+function StackedCubedSphereTopology(mpicomm, Nhorz, Rrange; boundary = (1, 1),
                                     connectivity=:face, ghostsize=1)
   T = eltype(Rrange)
 
@@ -925,8 +925,8 @@ function StackedCubedSphereTopology(mpicomm, Nhorz, Rrange; bc = (1, 1),
     eb = stacksize*(i-1) + 1
     et = stacksize*(i-1) + stacksize
 
-    elemtobndy[2(dim-1)+1, eb] = bc[1]
-    elemtobndy[2(dim-1)+2, et] = bc[2]
+    elemtobndy[2(dim-1)+1, eb] = boundary[1]
+    elemtobndy[2(dim-1)+2, et] = boundary[2]
   end
 
   nabrtorank = basetopo.nabrtorank

--- a/src/Mesh/test/mpi_connect_sphere.jl
+++ b/src/Mesh/test/mpi_connect_sphere.jl
@@ -19,7 +19,8 @@ function main()
   csize = MPI.Comm_size(comm)
 
   Rrange = T.(accumulate(+,1:Nstack+1))
-  topology = StackedCubedSphereTopology(MPI.COMM_SELF, Nhorz, Rrange; bc=(1,2))
+  topology = StackedCubedSphereTopology(MPI.COMM_SELF, Nhorz, Rrange;
+                                        boundary=(1,2))
   grid = DiscontinuousSpectralElementGrid(topology; FloatType=T,
                                           DeviceArray=DA, polynomialorder=N,
                                           meshwarp=Topologies.cubedshellwarp)


### PR DESCRIPTION
Brick mesh uses `boundary` as its keyword argument for boundary conditions so unifying StackedCubedSphereTopology to do the same