### PR TITLE
[BL] Refactor of inviscid in prep for viscous

### DIFF
--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
@@ -56,10 +56,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -125,8 +125,8 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
   # spacedisc = data needed for evaluating the right-hand side function
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = (x...) ->
+                           flux! = eulerflux!,
+                           numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
                                                     wavespeed,
                                                     preflux))

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
@@ -67,10 +67,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q, aux, t)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q, aux, t)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, Uδ, Vδ, Wδ, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
     U, V, W = Uδ-aux[1], Vδ-aux[2], Wδ-aux[3]
@@ -137,8 +137,8 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
   # spacedisc = data needed for evaluating the right-hand side function
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = (x...) ->
+                           flux! = eulerflux!,
+                           numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
                                                     wavespeed,
                                                     preflux,

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
@@ -56,10 +56,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -75,7 +75,7 @@ end
   @inbounds aux[1], aux[2], aux[3] = x, y, z
 end
 
-@inline function bcstate!(QP, _, _, auxM, bctype, t, _...)
+@inline function bcstate!(QP, _, _, _, _, auxM, bctype, t, _...)
   @inbounds begin
     x, y, z = auxM[1], auxM[2], auxM[3]
     isentropicvortex!(QP, t, x, y, z)
@@ -142,12 +142,12 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                                                            preflux)
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = numflux!,
+                           flux! = eulerflux!,
+                           numerical_flux! = numflux!,
                            auxiliary_state_length = 3,
                            auxiliary_state_initialization! =
                            auxiliary_state_initialization!,
-                           inviscid_numerical_boundary_flux! = numbcflux!,
+                           numerical_boundary_flux! = numbcflux!,
                           )
 
   # This is a actual state/function that lives on the grid

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
@@ -80,10 +80,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -149,8 +149,8 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
   # spacedisc = data needed for evaluating the right-hand side function
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = (x...) ->
+                           flux! = eulerflux!,
+                           numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
                                                     wavespeed,
                                                     preflux),

--- a/src/DGmethods/test/util/grad_test.jl
+++ b/src/DGmethods/test/util/grad_test.jl
@@ -41,8 +41,8 @@ function run(dim, Ne, N, DFloat)
 
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = 0,
-                           inviscid_flux! = (x...) -> (),
-                           inviscid_numerical_flux! = (x...) -> (),
+                           flux! = (x...) -> (),
+                           numerical_flux! = (x...) -> (),
                            auxiliary_state_length = 7,
                            auxiliary_state_initialization! = (x...) ->
                            auxiliary_state_initialization!(x..., dim))


### PR DESCRIPTION
Several things happening here:
- inviscid_X -> X (since function will be inviscid + some viscous). All
  these function now get passed the viscous state as well
- Qgrad -> QV (for Q viscous flux state)
- adding some more callbacks and sizes needed for viscous handling
  (nviscstate, nviscfluxstate, viscous_transform!, viscous_flux!,
  viscous_numerical_flux!, viscous_boundary_numerical_flux!)