### PR TITLE
Add test for conservation

### DIFF
--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -266,7 +266,7 @@ function transferrecvbuf!(device_recvbuf::Array, host_recvbuf, buf::Array,
 end
 # }}}
 
-# {{{ L2 Energy (for all dimensions)
+# Integral based metrics
 function LinearAlgebra.norm(Q::MPIStateArray; p::Real=2)
 
   @assert p == 2
@@ -288,26 +288,26 @@ function knl_norm2(::Val{Np}, Q, elems) where {Np}
   DFloat = eltype(Q)
   (_, nstate, nelem) = size(Q)
 
-  energy = zero(DFloat)
+  nrm = zero(DFloat)
 
   @inbounds for e = elems, q = 1:nstate, i = 1:Np
-    energy += Q[i, q, e]^2
+    nrm += Q[i, q, e]^2
   end
 
-  energy
+  nrm
 end
 
 function knl_L2norm(::Val{Np}, Q, weights, elems) where {Np}
   DFloat = eltype(Q)
   (_, nstate, nelem) = size(Q)
 
-  energy = zero(DFloat)
+  nrm = zero(DFloat)
 
   @inbounds for e = elems, q = 1:nstate, i = 1:Np
-    energy += weights[i, e] * Q[i, q, e]^2
+    nrm += weights[i, e] * Q[i, q, e]^2
   end
 
-  energy
+  nrm
 end
 
 function euclidean_distance(A::MPIStateArray, B::MPIStateArray)
@@ -354,8 +354,6 @@ function knl_L2dist(::Val{Np}, A, B, weights, elems) where {Np}
 
   dist
 end
-
-# }}}
 
 using Requires
 

--- a/src/DGmethods/DGBalanceLawDiscretizations.jl
+++ b/src/DGmethods/DGBalanceLawDiscretizations.jl
@@ -156,7 +156,7 @@ The numerical flux function is called with data from two DOFs as
 numerical_flux!(F, nM, QM, VM, auxM, QP, VP, auxP, t)
 ```
 where
-- `F` is an `MArray` of size `(dim, length_state_vector)` to be filled with the
+- `F` is an `MVector` of length `length_state_vector` to be filled with the
   numerical flux across the face (note that this is uninitialized so user must
   set to zero if is this desired)
 - `nM` is the unit outward normal to the face with respect to the minus side

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
@@ -56,10 +56,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -125,8 +125,8 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
   # spacedisc = data needed for evaluating the right-hand side function
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = (x...) ->
+                           flux! = eulerflux!,
+                           numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
                                                     wavespeed,
                                                     preflux))

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
@@ -67,10 +67,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q, aux, t)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q, aux, t)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, Uδ, Vδ, Wδ, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
     U, V, W = Uδ-aux[1], Vδ-aux[2], Wδ-aux[3]
@@ -137,8 +137,8 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
   # spacedisc = data needed for evaluating the right-hand side function
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = (x...) ->
+                           flux! = eulerflux!,
+                           numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
                                                     wavespeed,
                                                     preflux,

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
@@ -56,10 +56,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -75,7 +75,7 @@ end
   @inbounds aux[1], aux[2], aux[3] = x, y, z
 end
 
-@inline function bcstate!(QP, _, _, auxM, bctype, t, _...)
+@inline function bcstate!(QP, _, _, _, auxM, bctype, t, _...)
   @inbounds begin
     x, y, z = auxM[1], auxM[2], auxM[3]
     isentropicvortex!(QP, t, x, y, z)
@@ -142,12 +142,12 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                                                            preflux)
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = numflux!,
+                           flux! = eulerflux!,
+                           numerical_flux! = numflux!,
                            auxiliary_state_length = 3,
                            auxiliary_state_initialization! =
                            auxiliary_state_initialization!,
-                           inviscid_numerical_boundary_flux! = numbcflux!,
+                           numerical_boundary_flux! = numbcflux!,
                           )
 
   # This is a actual state/function that lives on the grid

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
@@ -80,10 +80,10 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, aux, t) =
-eulerflux!(F, Q, aux, t, preflux(Q)...)
+eulerflux!(F, Q, QV, aux, t) =
+eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
 
-@inline function eulerflux!(F, Q, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -149,8 +149,8 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
   # spacedisc = data needed for evaluating the right-hand side function
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
-                           inviscid_flux! = eulerflux!,
-                           inviscid_numerical_flux! = (x...) ->
+                           flux! = eulerflux!,
+                           numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
                                                     wavespeed,
                                                     preflux),

--- a/src/DGmethods/test/conservation/sphere.jl
+++ b/src/DGmethods/test/conservation/sphere.jl
@@ -1,0 +1,176 @@
+#=
+Here we solve the equation:
+```math
+ q + dot(∇, uq) = 0
+ p - dot(∇, up) = 0
+```
+on a sphere to test the conservation of the numerics
+
+The boundary conditions are `p = q` when `dot(n, u) > 0` and
+`q = p` when `dot(n, u) < 0` (i.e., `p` flows into `q` and vice-sersa).
+=#
+
+using MPI
+using CLIMA.Topologies
+using CLIMA.Grids
+using CLIMA.DGBalanceLawDiscretizations
+using CLIMA.DGBalanceLawDiscretizations.NumericalFluxes
+using CLIMA.MPIStateArrays
+using CLIMA.LowStorageRungeKuttaMethod
+using CLIMA.ODESolvers
+using CLIMA.GenericCallbacks
+using LinearAlgebra
+using StaticArrays
+using Logging, Printf, Dates
+using Random
+
+const _nstate = 2
+const _q, _p = 1:_nstate
+const stateid = (qid = _q, pid = _p)
+const statenames = ("q", "p")
+
+const _nauxstate = 3
+# use a random velocity field
+@inline function velocity_initialization!(vel, x, y, z)
+  @inbounds begin
+    vel[1] = rand()
+    vel[2] = rand()
+    vel[3] = rand()
+  end
+end
+
+# physical flux function
+@inline function flux!(F, Q, _, vel, _)
+  @inbounds begin
+    u, v, w = vel[1], vel[2], vel[3]
+    q, p = Q[_q], Q[_p]
+
+    F[1, _q], F[2, _q], F[3, _q] =  u*q,  v*q,  w*q
+    F[1, _p], F[2, _p], F[3, _p] = -u*p, -v*p, -w*p
+  end
+end
+# physical flux function
+@inline function numerical_flux!(F, nM, QM, _, velM, QP, _, velP, _)
+  @inbounds begin
+    uM, vM, wM = velM[1], velM[2], velM[3]
+    unM = nM[1] * uM + nM[2] * vM + nM[3] * wM
+    uP, vP, wP = velP[1], velP[2], velP[3]
+    unP = nM[1] * uP + nM[2] * vP + nM[3] * wP
+    # since the velocity field is random we average here the two sides
+    un = (unP + unM) / 2
+
+    if un > 0
+      F[_q], F[_p] = un * QM[_q], -un * QP[_p]
+    else
+      F[_q], F[_p] = un * QP[_q], -un * QM[_p]
+    end
+  end
+end
+@inline function numerical_boundary_flux!(F, nM, QM, _, vel, QP, _, _, _, _)
+  @inbounds begin
+    u, v, w = vel[1], vel[2], vel[3]
+    un = nM[1] * vel[1] + nM[2] * vel[2] + nM[3] * vel[3]
+
+    if un > 0
+      F[_q], F[_p] = un * QM[_q], -un * QM[_q]
+    else
+      F[_q], F[_p] = un * QM[_p], -un * QM[_p]
+    end
+  end
+end
+
+function run(mpicomm, N, Nhorz, Rrange, timeend, DFloat, dt)
+  ArrayType = Array
+
+  topl = StackedCubedSphereTopology(mpicomm, Nhorz, Rrange)
+
+  grid = DiscontinuousSpectralElementGrid(topl,
+                                          FloatType = DFloat,
+                                          DeviceArray = ArrayType,
+                                          polynomialorder = N,
+                                          meshwarp = Topologies.cubedshellwarp
+                                         )
+
+  # spacedisc = data needed for evaluating the right-hand side function
+  spacedisc = DGBalanceLaw(grid = grid,
+                           length_state_vector = _nstate,
+                           flux! = flux!,
+                           numerical_flux! = numerical_flux!,
+                           numerical_boundary_flux! = numerical_boundary_flux!,
+                           auxiliary_state_length = _nauxstate,
+                           auxiliary_state_initialization! =
+                           velocity_initialization!,
+                          )
+
+  # This is a actual state/function that lives on the grid
+  initialcondition!(Q, x, y, z, _...) = begin
+    @inbounds Q[_q], Q[_p] = rand(), rand()
+  end
+  Q = MPIStateArray(spacedisc, initialcondition!)
+
+  lsrk = LowStorageRungeKutta(spacedisc, Q; dt = dt, t0 = 0)
+
+  eng0 = norm(Q)
+  sum0 = weightedsum(Q)
+  @info @sprintf """Starting
+  norm(Q₀) = %.16e
+  sum(Q₀) = %.16e""" eng0 sum0
+
+  max_mass_loss = DFloat(0)
+  max_mass_gain = DFloat(0)
+  cbmass = GenericCallbacks.EveryXSimulationSteps(1) do
+    cbsum = weightedsum(Q)
+    max_mass_loss = max(max_mass_loss, sum0 - cbsum)
+    max_mass_gain = max(max_mass_gain, cbsum - sum0)
+    nothing
+  end
+  solve!(Q, lsrk; timeend=timeend, callbacks=(cbmass,))
+
+  # Print some end of the simulation information
+  engf = norm(Q)
+  sumf = weightedsum(Q)
+  @info @sprintf """Finished
+  norm(Q)            = %.16e
+  norm(Q) / norm(Q₀) = %.16e
+  norm(Q) - norm(Q₀) = %.16e
+  max mass loss      = %.16e
+  max mass gain      = %.16e
+  initial mass       = %.16e
+  """ engf engf/eng0 engf-eng0 max_mass_loss max_mass_gain sum0
+  max(max_mass_loss, max_mass_gain) / sum0
+end
+
+using Test
+let
+  MPI.Initialized() || MPI.Init()
+  Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
+  mpicomm = MPI.COMM_WORLD
+  if MPI.Comm_rank(mpicomm) == 0
+    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+    loglevel = ll == "DEBUG" ? Logging.Debug :
+    ll == "WARN"  ? Logging.Warn  :
+    ll == "ERROR" ? Logging.Error : Logging.Info
+    global_logger(ConsoleLogger(stderr, loglevel))
+  else
+    global_logger(NullLogger())
+  end
+
+  dt = 1e-4
+  timeend = 1000*dt
+
+  polynomialorder = 4
+
+  mpicomm = MPI.COMM_WORLD
+  Nhorz = 4
+  Rrange = 1.0:0.25:2.0
+
+  for DFloat in (Float64,) #Float32)
+    Random.seed!(0)
+    delta_mass = run(mpicomm, polynomialorder, Nhorz, Rrange, timeend, DFloat, dt)
+    @test abs(delta_mass) < 1e-15
+  end
+end
+
+isinteractive() || MPI.Finalize()
+
+nothing

--- a/src/DGmethods/test/runtests.jl
+++ b/src/DGmethods/test/runtests.jl
@@ -24,6 +24,8 @@ using MPI, Test
                  (3, "Euler/isentropic_vortex_standalone_source.jl")
                  (1, "Euler/isentropic_vortex_standalone_bc.jl")
                  (3, "Euler/isentropic_vortex_standalone_bc.jl")
+                 (1, "conservation/sphere.jl")
+                 (3, "conservation/sphere.jl")
                 ]
     cmd =  `mpiexec -n $n $(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) --code-coverage=$coverage_opt $(joinpath(testdir, f))`
     @info "Running MPI test..." n f cmd

--- a/src/DGmethods/test/util/grad_test.jl
+++ b/src/DGmethods/test/util/grad_test.jl
@@ -41,8 +41,8 @@ function run(dim, Ne, N, DFloat)
 
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = 0,
-                           inviscid_flux! = (x...) -> (),
-                           inviscid_numerical_flux! = (x...) -> (),
+                           flux! = (x...) -> (),
+                           numerical_flux! = (x...) -> (),
                            auxiliary_state_length = 7,
                            auxiliary_state_initialization! = (x...) ->
                            auxiliary_state_initialization!(x..., dim))

--- a/src/Mesh/Topologies.jl
+++ b/src/Mesh/Topologies.jl
@@ -617,7 +617,7 @@ function CubedShellTopology(mpicomm, Neside, T; connectivity=:face,
   CubedShellTopology{T}(
     BoxElementTopology{2, T}(
       mpicomm, topology.elems, topology.realelems,
-      topology.ghostelems, topology.sendelems, elemtocoord,
+      topology.ghostelems, topology.sendelems, topology.elemtocoord,
       topology.elemtoelem, topology.elemtoface, topology.elemtoordr,
       topology.elemtobndy, topology.nabrtorank, topology.nabrtorecv,
       topology.nabrtosend, false))


### PR DESCRIPTION
Main purpose of this is to test conservation of the code. To do this we do advection on a sphere with a random velocity field and initial conditions.

Also added a `weightedsum` routine for the `MPIStateArray`. For accuracy I used a `BigFloat` to accumulate, but this should be revisited. It is really a map-reduce operation over several iterators, so maybe something can be done there when we think about the GPU.

Also contains a  bug fix for the `CubedShellTopology` when multiple MPI ranks are used (connected `elementocoord` was not being used, but only the local version).

#204 should be sorted out / merged before this PR

cc @lcw