### PR TITLE
use devnull and not NullLogger for non-root MPI logging

### DIFF
--- a/src/Atmos/Dycore/test/rising_thermal_bubble.jl
+++ b/src/Atmos/Dycore/test/rising_thermal_bubble.jl
@@ -162,15 +162,12 @@ let
 
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-               ll == "WARN"  ? Logging.Warn  :
-               ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   nmoist = 1
   ntrace = 0

--- a/src/Atmos/Dycore/test/tracers_test.jl
+++ b/src/Atmos/Dycore/test/tracers_test.jl
@@ -179,16 +179,12 @@ let
 
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-               ll == "WARN"  ? Logging.Warn  :
-               ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   nmoist = 1
   ntrace = 2

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
@@ -261,8 +261,6 @@ let
 
     polynomialorder = 4
 
-    mpicomm = MPI.COMM_WORLD
-
     check_engf_eng0 = Dict{Tuple{Int64, Int64, DataType}, AbstractFloat}()
     check_engf_eng0[2, 1, Float64] = 9.9999795068862996e-01
     check_engf_eng0[3, 1, Float64] = 9.9999641494886327e-01

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone.jl
@@ -211,15 +211,12 @@ let
   MPI.Initialized() || MPI.Init()
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-    ll == "WARN"  ? Logging.Warn  :
-    ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   if integration_testing
     timeend = 1

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
@@ -281,8 +281,6 @@ let
 
     polynomialorder = 4
 
-    mpicomm = MPI.COMM_WORLD
-
     check_engf_eng0 = Dict{Tuple{Int64, Int64, DataType}, AbstractFloat}()
     check_engf_eng0[2, 1, Float64] = 9.9999784637552236e-01
     check_engf_eng0[3, 1, Float64] = 9.9999657640450179e-01

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_aux.jl
@@ -231,15 +231,12 @@ let
   MPI.Initialized() || MPI.Init()
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-    ll == "WARN"  ? Logging.Warn  :
-    ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   if integration_testing
     timeend = 1

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
@@ -280,8 +280,6 @@ let
 
     polynomialorder = 4
 
-    mpicomm = MPI.COMM_WORLD
-
     check_engf_eng0 = Dict{Tuple{Int64, Int64, DataType}, AbstractFloat}()
     check_engf_eng0[2, 1, Float64] = 9.9999647263376656e-01
     check_engf_eng0[3, 1, Float64] = 9.9999538532437882e-01

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_bc.jl
@@ -230,15 +230,12 @@ let
   MPI.Initialized() || MPI.Init()
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-    ll == "WARN"  ? Logging.Warn  :
-    ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   if integration_testing
     timeend = 1

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
@@ -241,15 +241,12 @@ let
   MPI.Initialized() || MPI.Init()
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-    ll == "WARN"  ? Logging.Warn  :
-    ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   if integration_testing
     timeend = 1

--- a/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
+++ b/src/DGmethods/test/Euler/isentropic_vortex_standalone_source.jl
@@ -291,8 +291,6 @@ let
 
     polynomialorder = 4
 
-    mpicomm = MPI.COMM_WORLD
-
     check_engf_eng0 = Dict{Tuple{Int64, Int64, DataType}, AbstractFloat}()
     check_engf_eng0[2, 1, Float64] = 9.9999808508887378e-01
     check_engf_eng0[3, 1, Float64] = 9.9999644038110480e-01

--- a/src/DGmethods/test/Sphere/advection_sphere.jl
+++ b/src/DGmethods/test/Sphere/advection_sphere.jl
@@ -225,15 +225,12 @@ let
     Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
     mpicomm=MPI.COMM_WORLD
 
-    if MPI.Comm_rank(mpicomm) == 0
-        ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-        loglevel = ll == "DEBUG" ? Logging.Debug :
-        ll == "WARN"  ? Logging.Warn  :
-        ll == "ERROR" ? Logging.Error : Logging.Info
-        global_logger(ConsoleLogger(stderr, loglevel))
-    else
-        global_logger(NullLogger())
-    end
+    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+    loglevel = ll == "DEBUG" ? Logging.Debug :
+    ll == "WARN"  ? Logging.Warn  :
+    ll == "ERROR" ? Logging.Error : Logging.Info
+    logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+    global_logger(ConsoleLogger(logger_stream, loglevel))
 
     #Perform Integration Testing for three different grid resolutions
     if integration_testing

--- a/src/DGmethods/test/compressible_Navier_Stokes/mms_bc.jl
+++ b/src/DGmethods/test/compressible_Navier_Stokes/mms_bc.jl
@@ -298,15 +298,12 @@ let
   MPI.Initialized() || MPI.Init()
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-    ll == "WARN"  ? Logging.Warn  :
-    ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   polynomialorder = 4
   base_num_elem = 4

--- a/src/DGmethods/test/conservation/sphere.jl
+++ b/src/DGmethods/test/conservation/sphere.jl
@@ -157,7 +157,6 @@ let
 
   polynomialorder = 4
 
-  mpicomm = MPI.COMM_WORLD
   Nhorz = 4
   Rrange = 1.0:0.25:2.0
 

--- a/src/DGmethods/test/conservation/sphere.jl
+++ b/src/DGmethods/test/conservation/sphere.jl
@@ -145,15 +145,12 @@ let
   MPI.Initialized() || MPI.Init()
   Sys.iswindows() || (isinteractive() && MPI.finalize_atexit())
   mpicomm = MPI.COMM_WORLD
-  if MPI.Comm_rank(mpicomm) == 0
-    ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
-    loglevel = ll == "DEBUG" ? Logging.Debug :
-    ll == "WARN"  ? Logging.Warn  :
-    ll == "ERROR" ? Logging.Error : Logging.Info
-    global_logger(ConsoleLogger(stderr, loglevel))
-  else
-    global_logger(NullLogger())
-  end
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
 
   dt = 1e-4
   timeend = 100*dt


### PR DESCRIPTION
When `NullLogger` is used for non-root logging, MPI calls in log records are optimized away resulting in deadlock. Using `devnull` avoids this problem.

This should fix some of the recent test timeouts
