### PR TITLE
Remove allow_failure on nightly with gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,13 +33,11 @@ gpu:test:dev:
   extends: .gputest
   variables:
     CI_VERSION_TAG: 'dev'
-  allow_failure: true
 
 cpu:test:dev:
   extends: .cputest
   variables:
     CI_VERSION_TAG: 'dev'
-  allow_failure: true
 
 gpu:test:v1.1:
   extends: .gputest


### PR DESCRIPTION
Since we currently pass on the gitlab nightly CI, I recommend removing the allow_failures

cc: @lcw @simonbyrne @charleskawczynski @vchuravy 