### PR TITLE
Removing default zeroing of MPIStateArray

### DIFF
--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -63,10 +63,6 @@ struct MPIStateArray{S <: Tuple, T, DeviceArray, N,
     host_sendQ = zeros(T, S.parameters..., numsendelem)
     host_recvQ = zeros(T, S.parameters..., numrecvelem)
 
-    fill!(Q, 0)
-    fill!(device_sendQ, 0)
-    fill!(device_recvQ, 0)
-
     nnabr = length(nabrtorank)
     sendreq = fill(MPI.REQUEST_NULL, nnabr)
     recvreq = fill(MPI.REQUEST_NULL, nnabr)
@@ -80,9 +76,9 @@ struct MPIStateArray{S <: Tuple, T, DeviceArray, N,
                                            device_sendQ, device_recvQ, weights,
                                            commtag)
   end
-
-
 end
+
+Base.fill!(Q::MPIStateArray, x) = fill!(Q.Q, x)
 
 """
    MPIStateArray{S, T, DA}(mpicomm, numelem; realelems=1:numelem,

--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -55,28 +55,17 @@ struct MPIStateArray{S <: Tuple, T, DeviceArray, N,
     N = length(S.parameters)+1
     numsendelem = length(sendelems)
     numrecvelem = length(ghostelems)
-    (Q, device_sendQ, device_recvQ) = try
+    (Q, device_sendQ, device_recvQ) =
       (DA{T, N}(undef, S.parameters..., numelem),
        DA{T, N}(undef, S.parameters..., numsendelem),
        DA{T, N}(undef, S.parameters..., numrecvelem))
-    catch
-      try
-        # TODO: Remove me after CUDA upgrade...
-        (DA{T, N}(S.parameters..., numelem),
-         DA{T, N}(S.parameters..., numsendelem),
-         DA{T, N}(S.parameters..., numrecvelem))
-      catch
-        error("MPIStateArray:Cannot construct array")
-      end
-    end
 
     host_sendQ = zeros(T, S.parameters..., numsendelem)
     host_recvQ = zeros(T, S.parameters..., numrecvelem)
 
-    # Length check is to work around a CuArrays bug.
-    length(Q) > 0 && fill!(Q, 0)
-    length(device_sendQ) > 0 && fill!(device_sendQ, 0)
-    length(device_recvQ) > 0 && fill!(device_recvQ, 0)
+    fill!(Q, 0)
+    fill!(device_sendQ, 0)
+    fill!(device_recvQ, 0)
 
     nnabr = length(nabrtorank)
     sendreq = fill(MPI.REQUEST_NULL, nnabr)

--- a/src/ODESolvers/LowStorageRungeKuttaMethod.jl
+++ b/src/ODESolvers/LowStorageRungeKuttaMethod.jl
@@ -82,7 +82,9 @@ struct LowStorageRungeKutta{T, AT, Nstages} <: ODEs.AbstractODESolver
            T(2006345519317) / T(3224310063776),
            T(2802321613138) / T(2924317926251))
 
-    new{T, AT, length(RKA)}(dt, t0, rhs!, similar(Q), RKA, RKB, RKC)
+    dQ = similar(Q)
+    fill!(dQ, 0)
+    new{T, AT, length(RKA)}(dt, t0, rhs!, dQ, RKA, RKB, RKC)
   end
 end
 


### PR DESCRIPTION
As discussed in https://github.com/climate-machine/CLIMA/pull/237#issuecomment-495392923 we do not need to be filling MPIStateArrays with zeros by default.