### PR TITLE
Reduce GPU tests

### DIFF
--- a/.slurmci/gpu-test.sh
+++ b/.slurmci/gpu-test.sh
@@ -18,4 +18,4 @@ module load cmake/3.10.2 openmpi/3.1.2 cuda/9.1
 # to avoid race conditions we create a separate depot per job
 julia --color=no --project=env/gpu -e 'using Pkg; pkg"instantiate"; pkg"precompile"'
 
-julia --color=no --project=env/gpu test/runtests.jl
+julia --color=no --project=env/gpu test/runtests_gpu.jl

--- a/test/Utilities/RootSolvers/runtests.jl
+++ b/test/Utilities/RootSolvers/runtests.jl
@@ -1,7 +1,6 @@
 using Test
+using CLIMA
 using CLIMA.RootSolvers
-
-const HAVE_CUDA = Base.identify_package("CuArrays") !== nothing
 
 @testset "RootSolvers correctness" begin
   f(x) = x^2 - 100^2
@@ -23,7 +22,7 @@ const HAVE_CUDA = Base.identify_package("CuArrays") !== nothing
   end  
 end
 
-@static if HAVE_CUDA
+@static if haspkg("CuArrays")
   using CuArrays
   CuArrays.allowscalar(false)
   

--- a/test/runtests_gpu.jl
+++ b/test/runtests_gpu.jl
@@ -1,0 +1,19 @@
+using Test, Pkg
+
+ENV["JULIA_LOG_LEVEL"] = "WARN"
+
+for submodule in ["Utilities/ParametersType",
+                  "Utilities/PlanetParameters",
+                  "Utilities/RootSolvers",
+                  "Utilities/MoistThermodynamics",
+                  "Atmos/Parameterizations/SurfaceFluxes",
+                  "Atmos/Parameterizations/TurbulenceConvection",
+                  "Mesh",
+                  "DGmethods",
+                  "ODESolvers"
+                  ]
+
+  println("Starting tests for $submodule")
+  t = @elapsed include(joinpath(submodule,"runtests.jl"))
+  println("Completed tests for $submodule, $(round(Int, t)) seconds elapsed")
+end


### PR DESCRIPTION
Only test what is actually GPU-enabled. Should help avoid timeout issues.