### PR TITLE
Remove kwargs from find_zero

### DIFF
--- a/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
+++ b/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
@@ -128,8 +128,8 @@ function compute_friction_velocity(u_ave, flux, z_0, z_1, β_m, γ_m, tol_abs, i
       ustar_1 = compute_ustar(ustar_0)
       ustar, converged = RootSolvers.find_zero(
         u -> u_ave - u*compute_u_ave_over_ustar(u),
-        ustar_0, ustar_1, SecantMethod();
-        xatol=tol_abs, maxiters=iter_max)
+        ustar_0, ustar_1, SecantMethod(),
+        tol_abs, iter_max)
     end
 
   end
@@ -264,8 +264,8 @@ function compute_friction_velocity(u_ave, θ, flux, Δz, z_0, a, Ψ_m_tol, tol_a
     ustar_1 = compute_ustar(ustar_0)
     ustar, converged = RootSolvers.find_zero(
       u -> u_ave - u*compute_u_ave_over_ustar(u),
-      ustar_0, ustar_1, SecantMethod();
-      xatol=tol_abs, maxiters=iter_max)
+      ustar_0, ustar_1, SecantMethod(),
+      tol_abs, iter_max)
   end
   return ustar
 end

--- a/src/Utilities/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Utilities/MoistThermodynamics/MoistThermodynamics.jl
@@ -680,7 +680,7 @@ function saturation_adjustment(e_int::DT, ρ::DT, q_tot::DT) where DT
     T_2 = air_temperature(e_int, PhasePartition(q_tot, DT(0), q_tot)) # Assume all ice
     T, converged = find_zero(
       T -> internal_energy_sat(T, ρ, q_tot) - e_int,
-      T_1, T_2, SecantMethod(); xatol=DT(1e-3), maxiters=10)
+      T_1, T_2, SecantMethod(), DT(1e-3), 10)
       if !converged
         error("saturation adjustment did not converge")
       end
@@ -710,7 +710,7 @@ function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::DT, q_tot::DT, ρ::D
     T_2 = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p, PhasePartition(q_tot, DT(0), q_tot)) # Assume all ice
     T, converged = find_zero(
       T -> θ_liq_ice - liquid_ice_pottemp_sat(T, p, PhasePartition_equil(T, ρ, q_tot)),
-      T_1, T_2, SecantMethod(); xatol=DT(1e-3), maxiters=10)
+      T_1, T_2, SecantMethod(), DT(1e-3), 10)
     return T
   end
 end

--- a/src/Utilities/RootSolvers/RootSolvers.jl
+++ b/src/Utilities/RootSolvers/RootSolvers.jl
@@ -31,9 +31,9 @@ struct NewtonsMethod <: RootSolvingMethod end
 # we use simple checks for now, will switch to relative checks later.
 
 """
-    x, converged = find_zero(f, x0[, x1], method;
-                             xatol=0, xrtol=sqrt(eps(eltype(x0))),
-                             yatol=sqrt(eps(eltype(x0))), maxiters=10_000)
+    x, converged = find_zero(f, x0[, x1], method,
+                             xatol=1e-3,
+                             maxiters=10_000)
 
 Finds the nearest root of `f` to `x0` and `x1`. Returns a the value of the root `x` such
 that `f(x) ≈ 0`, and a Boolean value `converged` indicating convergence.
@@ -50,7 +50,7 @@ The keyword arguments:
 """
 function find_zero end
 
-function find_zero(f::F, x0::T, x1::T, ::SecantMethod;
+function find_zero(f::F, x0::T, x1::T, ::SecantMethod,
                    xatol=T(1e-3),
                    maxiters=10_000) where {F, T<:AbstractFloat}
   y0 = f(x0)
@@ -68,7 +68,7 @@ function find_zero(f::F, x0::T, x1::T, ::SecantMethod;
   return x1, false
 end
 
-function find_zero(f::F, x0::T, x1::T, ::RegulaFalsiMethod;
+function find_zero(f::F, x0::T, x1::T, ::RegulaFalsiMethod,
                    xatol=T(1e-3),
                    maxiters=10_000) where {F, T<:AbstractFloat}
   y0 = f(x0)
@@ -114,7 +114,7 @@ function value_deriv(f, x::T) where {T}
     ForwardDiff.value(tag, y), ForwardDiff.partials(tag, y, 1)
 end
 
-function find_zero(f::F, x0::T, ::NewtonsMethod;
+function find_zero(f::F, x0::T, ::NewtonsMethod,
                    xatol=1e-3,
                    maxiters=10_000) where {F, T<:AbstractFloat}
   for i in 1:maxiters


### PR DESCRIPTION
Key word arguments can prevent functions from being inlined when run in a
GPU kernel.  For this reason, we remove the keyword arguments from
`find_zero`.