### PR TITLE
Change `bc` to `boundary` in sphere topology

### DIFF
--- a/test/DGmethods/soundings/create_sounding.m
+++ b/test/DGmethods/soundings/create_sounding.m
@@ -101,7 +101,7 @@ figure(1)
 plot(thetal, dataz, '*r', theta, dataz, '--g')
 xlabel('theta')
 ylabel('z [m]')
-title(" Thetal (red), theta (blue) [K]")
+title(' Thetal (red), theta (blue) [K]')
 ylim([100 1200])
 
 figure(2)


### PR DESCRIPTION
Brick mesh uses `boundary` as its keyword argument for boundary
conditions so unifying StackedCubedSphereTopology to do the same