### PR TITLE
Names cleanup

### DIFF
--- a/docs/src/Atmos/Microphysics.md
+++ b/docs/src/Atmos/Microphysics.md
@@ -270,7 +270,7 @@ using Plots
 # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
 function rain_evap_empirical(q_rai::DT, q::PhasePartition, T::DT, p::DT, ρ::DT) where {DT<:Real}
 
-    q_sat  = saturation_shum(T, ρ, q)
+    q_sat  = q_vap_saturation(T, ρ, q)
     q_vap  = q.tot - q.liq
     rr     = q_rai / (DT(1) - q.tot)
     rv_sat = q_sat / (DT(1) - q.tot)

--- a/docs/src/Utilities/MoistThermodynamics.md
+++ b/docs/src/Utilities/MoistThermodynamics.md
@@ -109,8 +109,8 @@ liquid_ice_pottemp_sat
 moist_gas_constants
 saturation_adjustment
 saturation_excess
-saturation_shum
-saturation_shum_generic
+q_vap_saturation
+q_vap_saturation_generic
 saturation_vapor_pressure
 soundspeed_air
 specific_volume

--- a/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
@@ -144,7 +144,7 @@ Smolarkiewicz and Grabowski 1996.
 function conv_q_rai_to_q_vap(qr::DT, q::PhasePartition{DT},
                              T::DT, p::DT, ρ::DT) where {DT<:Real}
 
-  qv_sat = saturation_shum(T, ρ, q)
+  qv_sat = q_vap_saturation(T, ρ, q)
   q_v = q.tot - q.liq - q.ice
   S = q_v/qv_sat - 1
 

--- a/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
@@ -37,7 +37,7 @@ individual water drop and the square root of its radius * g.
 function terminal_velocity_single_drop_coeff(ρ::DT) where {DT<:Real}
 
     # terminal_vel_of_individual_drop = v_drop_coeff * (g * drop_radius)^(1/2)
-    return sqrt(DT(8/3) / C_drag * (dens_liquid / ρ - DT(1)))
+    return sqrt(DT(8/3) / C_drag * (ρ_water / ρ - DT(1)))
 end
 
 """
@@ -57,7 +57,7 @@ function terminal_velocity(q_rai::DT, ρ::DT) where {DT<:Real}
     # gamma(9/2)
     gamma_9_2 = DT(11.631728396567448)
 
-    lambda::DT = (DT(8) * π * dens_liquid * MP_n_0 / ρ / q_rai)^DT(1/4)
+    lambda::DT = (DT(8) * π * ρ_water * MP_n_0 / ρ / q_rai)^DT(1/4)
 
     return gamma_9_2 * v_c / DT(6) * sqrt(grav / lambda)
 end
@@ -122,7 +122,7 @@ function conv_q_liq_to_q_rai_accr(q_liq::DT, q_rai::DT, ρ::DT) where {DT<:Real}
   gamma_7_2 = DT(3.3233509704478426)
 
   accr_coeff::DT = gamma_7_2 * DT(8)^DT(-7/8) * π^DT(1/8) * v_c * E_col *
-                   (ρ / dens_liquid)^DT(7/8)
+                   (ρ / ρ_water)^DT(7/8)
 
   return accr_coeff * DT(MP_n_0)^DT(1/8) * sqrt(DT(grav)) *
          q_liq * q_rai^DT(7/8)
@@ -159,9 +159,9 @@ function conv_q_rai_to_q_vap(qr::DT, q::PhasePartition{DT},
   N_Sc::DT = ν_air / D_vapor
   v_c = terminal_velocity_single_drop_coeff(ρ)
 
-  av::DT = sqrt(2 * π) * a_vent * sqrt(ρ / dens_liquid)
+  av::DT = sqrt(2 * π) * a_vent * sqrt(ρ / ρ_water)
   bv::DT = DT(2)^DT(7/16) * gamma_11_4 * π^DT(5/16) * b_vent * (N_Sc)^DT(1/3) *
-       sqrt(v_c) * (ρ / dens_liquid)^DT(11/16)
+       sqrt(v_c) * (ρ / ρ_water)^DT(11/16)
 
   F::DT = av * sqrt(qr) +
           bv * grav^DT(1/4) / (MP_n_0)^DT(3/16) / sqrt(ν_air) * qr^DT(11/16)

--- a/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
@@ -37,7 +37,7 @@ individual water drop and the square root of its radius * g.
 function terminal_velocity_single_drop_coeff(ρ::DT) where {DT<:Real}
 
     # terminal_vel_of_individual_drop = v_drop_coeff * (g * drop_radius)^(1/2)
-    return sqrt(DT(8/3) / C_drag * (ρ_water / ρ - DT(1)))
+    return sqrt(DT(8/3) / C_drag * (ρ_liquid / ρ - DT(1)))
 end
 
 """
@@ -57,7 +57,7 @@ function terminal_velocity(q_rai::DT, ρ::DT) where {DT<:Real}
     # gamma(9/2)
     gamma_9_2 = DT(11.631728396567448)
 
-    lambda::DT = (DT(8) * π * ρ_water * MP_n_0 / ρ / q_rai)^DT(1/4)
+    lambda::DT = (DT(8) * π * ρ_liquid * MP_n_0 / ρ / q_rai)^DT(1/4)
 
     return gamma_9_2 * v_c / DT(6) * sqrt(grav / lambda)
 end
@@ -122,7 +122,7 @@ function conv_q_liq_to_q_rai_accr(q_liq::DT, q_rai::DT, ρ::DT) where {DT<:Real}
   gamma_7_2 = DT(3.3233509704478426)
 
   accr_coeff::DT = gamma_7_2 * DT(8)^DT(-7/8) * π^DT(1/8) * v_c * E_col *
-                   (ρ / ρ_water)^DT(7/8)
+                   (ρ / ρ_liquid)^DT(7/8)
 
   return accr_coeff * DT(MP_n_0)^DT(1/8) * sqrt(DT(grav)) *
          q_liq * q_rai^DT(7/8)
@@ -159,9 +159,9 @@ function conv_q_rai_to_q_vap(qr::DT, q::PhasePartition{DT},
   N_Sc::DT = ν_air / D_vapor
   v_c = terminal_velocity_single_drop_coeff(ρ)
 
-  av::DT = sqrt(2 * π) * a_vent * sqrt(ρ / ρ_water)
+  av::DT = sqrt(2 * π) * a_vent * sqrt(ρ / ρ_liquid)
   bv::DT = DT(2)^DT(7/16) * gamma_11_4 * π^DT(5/16) * b_vent * (N_Sc)^DT(1/3) *
-       sqrt(v_c) * (ρ / ρ_water)^DT(11/16)
+       sqrt(v_c) * (ρ / ρ_liquid)^DT(11/16)
 
   F::DT = av * sqrt(qr) +
           bv * grav^DT(1/4) / (MP_n_0)^DT(3/16) / sqrt(ν_air) * qr^DT(11/16)

--- a/src/Utilities/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Utilities/MoistThermodynamics/MoistThermodynamics.jl
@@ -105,7 +105,7 @@ air_density(T::DT, p::DT, q::PhasePartition=PhasePartition(zero(DT))) where {DT<
 The (moist-)air density from the equation of state
 (ideal gas law), given a thermodynamic state `ts`.
 """
-air_density(ts::ThermodynamicState) = ts.density
+air_density(ts::ThermodynamicState) = ts.ρ
 
 """
     specific_volume(T, p[, q::PhasePartition])

--- a/src/Utilities/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Utilities/MoistThermodynamics/MoistThermodynamics.jl
@@ -26,7 +26,7 @@ export latent_heat_vapor, latent_heat_sublim, latent_heat_fusion
 
 # Saturation vapor pressures and specific humidities over liquid and ice
 export Liquid, Ice
-export saturation_vapor_pressure, saturation_shum_generic, saturation_shum
+export saturation_vapor_pressure, q_vap_saturation_generic, q_vap_saturation
 export saturation_excess
 
 # Functions used in thermodynamic equilibrium among phases (liquid and ice
@@ -401,7 +401,7 @@ latent_heat_generic(T::Real, LH_0::Real, Δcp::Real) =
 
 A phase condensate, to dispatch over
 [`saturation_vapor_pressure`](@ref) and
-[`saturation_shum_generic`](@ref).
+[`q_vap_saturation_generic`](@ref).
 """
 abstract type Phase end
 
@@ -410,7 +410,7 @@ abstract type Phase end
 
 A liquid phase, to dispatch over
 [`saturation_vapor_pressure`](@ref) and
-[`saturation_shum_generic`](@ref).
+[`q_vap_saturation_generic`](@ref).
 """
 struct Liquid <: Phase end
 
@@ -419,7 +419,7 @@ struct Liquid <: Phase end
 
 An ice phase, to dispatch over
 [`saturation_vapor_pressure`](@ref) and
-[`saturation_shum_generic`](@ref).
+[`q_vap_saturation_generic`](@ref).
 """
 struct Ice <: Phase end
 
@@ -472,7 +472,7 @@ function saturation_vapor_pressure(T::DT, LH_0::DT, Δcp::DT) where DT
 end
 
 """
-    saturation_shum_generic(T, ρ[; phase=Liquid()])
+    q_vap_saturation_generic(T, ρ[; phase=Liquid()])
 
 Compute the saturation specific humidity over a plane surface of condensate, given
 
@@ -482,13 +482,13 @@ and, optionally,
  - `Liquid()` indicating condensate is liquid
  - `Ice()` indicating condensate is ice
 """
-function saturation_shum_generic(T::DT, ρ::DT; phase::Phase=Liquid()) where DT
+function q_vap_saturation_generic(T::DT, ρ::DT; phase::Phase=Liquid()) where DT
     p_v_sat = saturation_vapor_pressure(T, phase)
-    return saturation_shum_from_pressure(T, ρ, p_v_sat)
+    return q_vap_saturation_from_pressure(T, ρ, p_v_sat)
 end
 
 """
-    saturation_shum(T, ρ[, q::PhasePartition])
+    q_vap_saturation(T, ρ[, q::PhasePartition])
 
 Compute the saturation specific humidity, given
 
@@ -510,7 +510,7 @@ zero, the saturation specific humidity is that over a mixture of liquid and ice,
 with the fraction of liquid given by temperature dependent `liquid_fraction_equil(T)`
 and the fraction of ice by the complement `1 - liquid_fraction_equil(T)`.
 """
-function saturation_shum(T::DT, ρ::DT, q::PhasePartition=PhasePartition(zero(DT))) where DT
+function q_vap_saturation(T::DT, ρ::DT, q::PhasePartition=PhasePartition(zero(DT))) where DT
 
     # get phase partitioning
     _liquid_frac = liquid_fraction_equil(T, q)
@@ -524,20 +524,20 @@ function saturation_shum(T::DT, ρ::DT, q::PhasePartition=PhasePartition(zero(DT
     # saturation vapor pressure over possible mixture of liquid and ice
     p_v_sat = saturation_vapor_pressure(T, DT(LH_0), Δcp)
 
-    return saturation_shum_from_pressure(T, ρ, p_v_sat)
+    return q_vap_saturation_from_pressure(T, ρ, p_v_sat)
 
 end
 
 """
-    saturation_shum(ts::ThermodynamicState)
+    q_vap_saturation(ts::ThermodynamicState)
 
 Compute the saturation specific humidity, given a thermodynamic state `ts`.
 """
-saturation_shum(ts::ThermodynamicState) =
-  saturation_shum(air_temperature(ts), air_density(ts), PhasePartition(ts))
+q_vap_saturation(ts::ThermodynamicState) =
+  q_vap_saturation(air_temperature(ts), air_density(ts), PhasePartition(ts))
 
 """
-    saturation_shum_from_pressure(T, ρ, p_v_sat)
+    q_vap_saturation_from_pressure(T, ρ, p_v_sat)
 
 Compute the saturation specific humidity, given
 
@@ -545,7 +545,7 @@ Compute the saturation specific humidity, given
  - `ρ` density
  - `p_v_sat` saturation vapor pressure
 """
-saturation_shum_from_pressure(T::DT, ρ::DT, p_v_sat::DT) where {DT<:Real} =
+q_vap_saturation_from_pressure(T::DT, ρ::DT, p_v_sat::DT) where {DT<:Real} =
   min(1, p_v_sat / (ρ * DT(R_v) * T))
 
 """
@@ -562,7 +562,7 @@ and the saturation specific humidity in equilibrium, and it is defined to be
 nonzero only if this difference is positive.
 """
 saturation_excess(T::DT, ρ::DT, q::PhasePartition) where {DT} =
-  max(0, q.tot - saturation_shum(T, ρ, q))
+  max(0, q.tot - q_vap_saturation(T, ρ, q))
 
 """
     saturation_excess(ts::ThermodynamicState)
@@ -672,7 +672,7 @@ See also [`saturation_adjustment_q_t_θ_l`](@ref).
 """
 function saturation_adjustment(e_int::DT, ρ::DT, q_tot::DT) where DT
   T_1 = max(DT(T_min), air_temperature(e_int, PhasePartition(q_tot))) # Assume all vapor
-  q_v_sat = saturation_shum(T_1, ρ)
+  q_v_sat = q_vap_saturation(T_1, ρ)
   if q_tot <= q_v_sat # If not saturated return T_1
     return T_1
   else # If saturated, iterate
@@ -703,7 +703,7 @@ See also [`saturation_adjustment`](@ref).
 """
 function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::DT, q_tot::DT, ρ::DT, p::DT) where DT
   T_1 = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p) # Assume all vapor
-  q_v_sat = saturation_shum(T_1, ρ)
+  q_v_sat = q_vap_saturation(T_1, ρ)
   if q_tot <= q_v_sat # If not saturated
     return T_1
   else  # If saturated, iterate
@@ -810,7 +810,7 @@ and, optionally,
 """
 function liquid_ice_pottemp_sat(T::DT, p::DT, q::PhasePartition=PhasePartition(zero(DT))) where {DT}
     ρ = air_density(T, p, q)
-    q_v_sat = saturation_shum(T, ρ, q)
+    q_v_sat = q_vap_saturation(T, ρ, q)
     return liquid_ice_pottemp(T, p, PhasePartition(q_v_sat))
 end
 

--- a/src/Utilities/MoistThermodynamics/states.jl
+++ b/src/Utilities/MoistThermodynamics/states.jl
@@ -64,7 +64,7 @@ struct PhaseEquil{DT} <: ThermodynamicState{DT}
   "total specific humidity"
   q_tot::DT
   "density of air (potentially moist)"
-  density::DT
+  ρ::DT
   "temperature: computed via [`saturation_adjustment`](@ref)"
   T::DT
 end
@@ -90,7 +90,7 @@ end
 
 
 """
-    PhaseNonEquil{DT} <: ThermodynamicState
+   	 PhaseNonEquil{DT} <: ThermodynamicState
 
 A thermodynamic state assuming thermodynamic non-equilibrium (therefore, temperature can
 be computed directly).
@@ -110,5 +110,5 @@ struct PhaseNonEquil{DT} <: ThermodynamicState{DT}
   "phase partition"
   q::PhasePartition{DT}
   "density of air (potentially moist)"
-  density::DT
+  ρ::DT
 end

--- a/src/Utilities/PlanetParameters/PlanetParameters.jl
+++ b/src/Utilities/PlanetParameters/PlanetParameters.jl
@@ -24,7 +24,7 @@ using ..ParametersType
 @exportparameter cv_d              cp_d - R_d    "Isochoric specific heat dry air"
 
 # Properties of water
-@exportparameter ρ_water           1e3           "Density of liquid water (kg/m^3)"
+@exportparameter ρ_liquid          1e3           "Density of liquid water (kg/m^3)"
 @exportparameter molmass_water     18.01528e-3   "Molecular weight (kg/mol)"
 @exportparameter molmass_ratio     molmass_dryair/
                                    molmass_water "Molar mass ratio dry air/water"

--- a/src/Utilities/PlanetParameters/PlanetParameters.jl
+++ b/src/Utilities/PlanetParameters/PlanetParameters.jl
@@ -24,7 +24,7 @@ using ..ParametersType
 @exportparameter cv_d              cp_d - R_d    "Isochoric specific heat dry air"
 
 # Properties of water
-@exportparameter dens_liquid       1e3           "Density of liquid water (kg/m^3)"
+@exportparameter ρ_water           1e3           "Density of liquid water (kg/m^3)"
 @exportparameter molmass_water     18.01528e-3   "Molecular weight (kg/mol)"
 @exportparameter molmass_ratio     molmass_dryair/
                                    molmass_water "Molar mass ratio dry air/water"
@@ -51,7 +51,7 @@ using ..ParametersType
 @exportparameter press_triple      611.657       "Triple point vapor pressure (Pa)"
 
 # Properties of sea water
-@exportparameter dens_ocean        1.035e3       "Reference density sea water (kg/m^3)"
+@exportparameter ρ_ocean           1.035e3       "Reference density sea water (kg/m^3)"
 @exportparameter cp_ocean          3989.25       "Specific heat sea water (J/kg/K)"
 
 # Planetary parameters

--- a/test/Atmos/Parameterizations/Microphysics/runtests.jl
+++ b/test/Atmos/Parameterizations/Microphysics/runtests.jl
@@ -102,7 +102,7 @@ end
   function rain_evap_empir(q_rai::DT, q::PhasePartition,
                            T::DT, p::DT, ρ::DT) where {DT<:Real}
 
-      q_sat  = saturation_shum(T, ρ, q)
+      q_sat  = q_vap_saturation(T, ρ, q)
       q_vap  = q.tot - q.liq
       rr     = q_rai / (1 - q.tot)
       rv_sat = q_sat / (1 - q.tot)

--- a/test/Utilities/MoistThermodynamics/runtests.jl
+++ b/test/Utilities/MoistThermodynamics/runtests.jl
@@ -46,13 +46,13 @@ using LinearAlgebra
   @test saturation_vapor_pressure(DT(T_triple), Liquid()) ≈ press_triple
   @test saturation_vapor_pressure(DT(T_triple), Ice()) ≈ press_triple
 
-  @test saturation_shum(DT(T_triple), ρ, PhasePartition(DT(0))) == ρ_v_triple / ρ
-  @test saturation_shum(DT(T_triple), ρ, PhasePartition(q_tot,q_tot)) == ρ_v_triple / ρ
+  @test q_vap_saturation(DT(T_triple), ρ, PhasePartition(DT(0))) == ρ_v_triple / ρ
+  @test q_vap_saturation(DT(T_triple), ρ, PhasePartition(q_tot,q_tot)) == ρ_v_triple / ρ
 
-  @test saturation_shum_generic(DT(T_triple), ρ; phase=Liquid()) == ρ_v_triple / ρ
-  @test saturation_shum_generic(DT(T_triple), ρ; phase=Ice()) == ρ_v_triple / ρ
-  @test saturation_shum_generic.(DT(T_triple-20), ρ; phase=Liquid()) >=
-        saturation_shum_generic.(DT(T_triple-20), ρ; phase=Ice())
+  @test q_vap_saturation_generic(DT(T_triple), ρ; phase=Liquid()) == ρ_v_triple / ρ
+  @test q_vap_saturation_generic(DT(T_triple), ρ; phase=Ice()) == ρ_v_triple / ρ
+  @test q_vap_saturation_generic.(DT(T_triple-20), ρ; phase=Liquid()) >=
+        q_vap_saturation_generic.(DT(T_triple-20), ρ; phase=Ice())
 
   @test saturation_excess(DT(T_triple), ρ, PhasePartition(q_tot)) ==  q_tot - ρ_v_triple/ρ
   @test saturation_excess(DT(T_triple), ρ, PhasePartition(q_tot/1000)) == 0.0
@@ -64,20 +64,20 @@ using LinearAlgebra
 
   @test air_temperature(cv_m(PhasePartition(DT(0)))*(T-T_0), PhasePartition(DT(0))) === DT(T)
   @test air_temperature(cv_m(PhasePartition(DT(q_tot)))*(T-T_0) + q_tot*e_int_v0, PhasePartition(q_tot)) ≈ DT(T)
-  
+
   @test total_energy(DT(e_kin),DT(e_pot), DT(T_0)) === DT(e_kin) + DT(e_pot)
   @test total_energy(DT(e_kin),DT(e_pot), DT(T)) ≈ DT(e_kin) + DT(e_pot) + cv_d*(T-T_0)
   @test total_energy(DT(0),DT(0), DT(T_0), PhasePartition(q_tot)) ≈ q_tot*e_int_v0
 
   # phase partitioning in equilibrium
-  q_liq = DT(0.1);  
+  q_liq = DT(0.1);
   T = DT(T_icenuc-10); ρ = DT(1.0); q_tot = DT(0.21)
   @test liquid_fraction_equil(T) === DT(0)
   @test liquid_fraction_equil(T, PhasePartition(q_tot,q_liq,q_liq)) === DT(0.5)
   q = PhasePartition_equil(T, ρ, q_tot)
   @test q.liq ≈ DT(0)
   @test 0 < q.ice <= q_tot
-  
+
   T = DT(T_freeze+10); ρ = DT(0.1); q_tot = DT(0.60)
   @test liquid_fraction_equil(T) === DT(1)
   @test liquid_fraction_equil(T, PhasePartition(q_tot,q_liq,q_liq/2)) === DT(2/3)
@@ -93,12 +93,12 @@ using LinearAlgebra
   q_tot = DT(0.21); ρ = DT(0.1)
   @test saturation_adjustment(internal_energy_sat(200.0, ρ, q_tot), ρ, q_tot) ≈ 200.0
   q = PhasePartition_equil(T, ρ, q_tot)
-  @test q.tot - q.liq - q.ice ≈ saturation_shum(T, ρ)
+  @test q.tot - q.liq - q.ice ≈ q_vap_saturation(T, ρ)
 
   q_tot = DT(0.78); ρ = DT(1)
   @test saturation_adjustment(internal_energy_sat(300.0, ρ, q_tot), ρ, q_tot) ≈ 300.0
   q = PhasePartition_equil(T, ρ, q_tot)
-  @test q.tot - q.liq - q.ice ≈ saturation_shum(T, ρ)
+  @test q.tot - q.liq - q.ice ≈ q_vap_saturation(T, ρ)
 
   # potential temperatures
   T = DT(300)
@@ -139,7 +139,7 @@ using LinearAlgebra
     @test latent_heat_vapor(ts) isa typeof(e_int)
     @test latent_heat_sublim(ts) isa typeof(e_int)
     @test latent_heat_fusion(ts) isa typeof(e_int)
-    @test saturation_shum(ts) isa typeof(e_int)
+    @test q_vap_saturation(ts) isa typeof(e_int)
     @test saturation_excess(ts) isa typeof(e_int)
     @test liquid_fraction_equil(ts) isa typeof(e_int)
     @test liquid_fraction_nonequil(ts) isa typeof(e_int)


### PR DESCRIPTION
To make naming more consistent among different modules I suggest to:
-  use \rho_water and \rho_ocean for water density. (We already use \rho for air density.)
- use q_vap_saturation instead of saturation_shum for saturation specific humidity. (We use q_ to denote specific humidities of our tracers)  

