### PR TITLE
[BL] Remove states_for_gradient_transform

### DIFF
--- a/src/DGmethods/DGBalanceLawDiscretizations.jl
+++ b/src/DGmethods/DGBalanceLawDiscretizations.jl
@@ -109,9 +109,6 @@ struct DGBalanceLaw <: AbstractDGMethod
   "number of out states for the viscous_transform!"
   number_viscous_states::Int
 
-  "tuple of states going into gradient_transform!"
-  states_for_gradient_transform::Tuple
-
   "transform from state to variables to take gradient of"
   gradient_transform!::Union{Nothing, Function}
 
@@ -140,7 +137,6 @@ end
                  flux!,
                  numerical_flux!,
                  numerical_boundary_flux! = nothing,
-                 states_for_gradient_transform = (),
                  number_gradient_states = 0,
                  number_viscous_states = 0,
                  gradient_transform! = nothing,
@@ -235,7 +231,6 @@ stored in the auxiliary state.
 
 When viscous terms are needed, the user must specify values for the following
 keyword arguments:
-- `states_for_gradient_transform` (`Tuple`)
 - `number_gradient_states` (`Int`)
 - `number_viscous_states` (`Int`)
 - `gradient_transform!` (`Function`)
@@ -245,17 +240,14 @@ keyword arguments:
   boundary
 
 The function `gradient_transform!` is the implementation of the function `G` in
-the module docs; see [`DGBalanceLawDiscretizations`](@ref). It transforms the
-elements of the components of state vector specified by
-`states_for_gradient_transform` into the values that should have their gradient
-taken. It is called on each DOF as:
+the module docs; see [`DGBalanceLawDiscretizations`](@ref).  It is called on
+each DOF as:
 ```
 gradient_transform!(G, Q, aux, t)
 ```
 where `G` is an `MVector` of length `number_gradient_states` to be filled, `Q`
-is an `MVector` containing only the states specified by
-`states_for_gradient_transform`, `aux` is the full auxiliary state at the DOF,
-and `t` is the simulation time.Q
+is an `MVector` containing the states, `aux` is the full auxiliary state at the
+DOF, and `t` is the simulation time.Q
 
 The function `viscous_transform!` is the implementation of the function `H` in
 the module docs; see [`DGBalanceLawDiscretizations`](@ref). It transforms the
@@ -266,10 +258,9 @@ viscous_transform!(V, gradG, Q, aux, t)
 ```
 where `V` is an `MVector` of length `number_viscous_states` to be filled,
 `gradG` is an `MMatrix` containing the DG-gradient of ``G``, `Q` is an `MVector`
-containing only the states specified by `states_for_gradient_transform`, `aux`
-is the full auxiliary state at the DOF, and `t` is the simulation time. Note
-that `V` is a vector not a matrix so that minimal storage can be used if
-symmetry can be exploited.
+containing the states, `aux` is the full auxiliary state at the DOF, and `t` is
+the simulation time. Note that `V` is a vector not a matrix so that minimal
+storage can be used if symmetry can be exploited.
 
 The function `viscous_penalty!` is the penalty terms to be used for the
 DG-gradient calculation. It is called with data from two neighbouring degrees of
@@ -284,8 +275,7 @@ where:
   (`MVector` of length `3`)
 - `GM` and `GP` are the minus and plus evaluation of `gradient_transform!` on
   either side of the face
-- `QM` and `QP` are the minus and plus side states (`MArray`); filled only with
-  `states_for_gradient_transform` states.
+- `QM` and `QP` are the minus and plus side states (`MArray`)
 - `auxM` and `auxP` are the auxiliary states (`MArray`)
 - `t` is the current simulation time
 The viscous penalty function should compute on the faces
@@ -336,7 +326,6 @@ function DGBalanceLaw(;grid::DiscontinuousSpectralElementGrid,
                       length_state_vector, flux!,
                       numerical_flux!,
                       numerical_boundary_flux! = nothing,
-                      states_for_gradient_transform=(),
                       number_gradient_states=0,
                       number_viscous_states=0,
                       gradient_transform! = nothing,
@@ -359,13 +348,11 @@ function DGBalanceLaw(;grid::DiscontinuousSpectralElementGrid,
    error("no `numerical_boundary_flux!` given when topology "*
          "has boundary"))
 
-  if number_viscous_states > 0 || number_gradient_states > 0 ||
-    length(states_for_gradient_transform) > 0
+  if number_viscous_states > 0 || number_gradient_states > 0
 
     # These should all be true in this case
     @assert number_viscous_states > 0
     @assert number_gradient_states > 0
-    @assert length(states_for_gradient_transform) > 0
     @assert gradient_transform! !== nothing
     @assert viscous_transform! !== nothing
     @assert viscous_penalty! !== nothing
@@ -420,8 +407,7 @@ function DGBalanceLaw(;grid::DiscontinuousSpectralElementGrid,
   DGBalanceLaw(grid, length_state_vector, flux!,
                numerical_flux!, numerical_boundary_flux!,
                Qvisc, number_gradient_states, number_viscous_states,
-               states_for_gradient_transform, gradient_transform!,
-               viscous_transform!, viscous_penalty!,
+               gradient_transform!, viscous_transform!, viscous_penalty!,
                viscous_boundary_penalty!, auxstate, source!, preodefun!)
 end
 
@@ -578,7 +564,6 @@ function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
   nviscstate = disc.number_viscous_states
   ngradstate = disc.number_gradient_states
   nauxstate = size(auxstate, 2)
-  states_grad = disc.states_for_gradient_transform
 
   lgl_weights_vec = grid.ω
   Dmat = grid.D
@@ -601,8 +586,8 @@ function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
   if nviscstate > 0
 
     @launch(device, threads=(Nq, Nq, Nqk), blocks=nrealelem,
-            volumeviscterms!(Val(dim), Val(N), Val(nstate), Val(states_grad),
-                             Val(ngradstate), Val(nviscstate), Val(nauxstate),
+            volumeviscterms!(Val(dim), Val(N), Val(nstate), Val(ngradstate),
+                             Val(nviscstate), Val(nauxstate),
                              disc.viscous_transform!, disc.gradient_transform!,
                              Q.Q, Qvisc.Q, auxstate.Q, vgeo, t, Dmat,
                              topology.realelems))
@@ -610,8 +595,8 @@ function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
     MPIStateArrays.finish_ghost_recv!(Q)
 
     @launch(device, threads=Nfp, blocks=nrealelem,
-            faceviscterms!(Val(dim), Val(N), Val(nstate), Val(states_grad),
-                           Val(ngradstate), Val(nviscstate), Val(nauxstate),
+            faceviscterms!(Val(dim), Val(N), Val(nstate), Val(ngradstate),
+                           Val(nviscstate), Val(nauxstate),
                            disc.viscous_penalty!,
                            disc.viscous_boundary_penalty!,
                            disc.gradient_transform!, Q.Q, Qvisc.Q, auxstate.Q,

--- a/src/DGmethods/DGBalanceLawDiscretizations_kernels.jl
+++ b/src/DGmethods/DGBalanceLawDiscretizations_kernels.jl
@@ -317,11 +317,10 @@ function facerhs!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{nviscstate},
 end
 
 function volumeviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate},
-                          ::Val{states_grad}, ::Val{ngradstate},
-                          ::Val{nviscstate}, ::Val{nauxstate},
-                          viscous_transform!, gradient_transform!, Q,
-                          Qvisc, auxstate, vgeo, t, D,
-                          elems) where {dim, N, states_grad, ngradstate,
+                          ::Val{ngradstate}, ::Val{nviscstate},
+                          ::Val{nauxstate}, viscous_transform!,
+                          gradient_transform!, Q, Qvisc, auxstate, vgeo, t, D,
+                          elems) where {dim, N, ngradstate,
                                         nviscstate, nstate, nauxstate}
   DFloat = eltype(Q)
 
@@ -329,12 +328,11 @@ function volumeviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate},
 
   Nqk = dim == 2 ? 1 : Nq
 
-  ngradtransformstate = length(states_grad)
 
   s_G = @shmem DFloat (Nq, Nq, Nqk, ngradstate)
   s_D = @shmem DFloat (Nq, Nq)
 
-  l_Q = @scratch DFloat (ngradtransformstate, Nq, Nq, Nqk) 3
+  l_Q = @scratch DFloat (nstate, Nq, Nq, Nqk) 3
   l_aux = @scratch DFloat (nauxstate, Nq, Nq, Nqk) 3
   l_G = MArray{Tuple{ngradstate}, DFloat}(undef)
   l_Qvisc = MArray{Tuple{nviscstate}, DFloat}(undef)
@@ -353,8 +351,8 @@ function volumeviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate},
       @loop for j in (1:Nq; threadIdx().y)
         @loop for i in (1:Nq; threadIdx().x)
           ijk = i + Nq * ((j-1) + Nq * (k-1))
-          @unroll for s = 1:ngradtransformstate
-            l_Q[s, i, j, k] = Q[ijk, states_grad[s], e]
+          @unroll for s = 1:nstate
+            l_Q[s, i, j, k] = Q[ijk, s, e]
           end
 
           @unroll for s = 1:nauxstate
@@ -408,14 +406,13 @@ function volumeviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate},
   end
 end
 
-function faceviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{states_grad},
+function faceviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate},
                         ::Val{ngradstate}, ::Val{nviscstate},
                         ::Val{nauxstate}, viscous_penalty!,
                         viscous_boundary_penalty!, gradient_transform!,
                         Q, Qvisc, auxstate, vgeo, sgeo, t, vmapM, vmapP,
-                        elemtobndy, elems) where {dim, N, states_grad,
-                                                  ngradstate, nviscstate,
-                                                  nstate, nauxstate}
+                        elemtobndy, elems) where {dim, N, ngradstate,
+                                                  nviscstate, nstate, nauxstate}
   DFloat = eltype(Q)
 
   if dim == 1
@@ -432,13 +429,11 @@ function faceviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{states_grad},
     nface = 6
   end
 
-  ngradtransformstate = length(states_grad)
-
-  l_QM = MArray{Tuple{ngradtransformstate}, DFloat}(undef)
+  l_QM = MArray{Tuple{nstate}, DFloat}(undef)
   l_auxM = MArray{Tuple{nauxstate}, DFloat}(undef)
   l_GM = MArray{Tuple{ngradstate}, DFloat}(undef)
 
-  l_QP = MArray{Tuple{ngradtransformstate}, DFloat}(undef)
+  l_QP = MArray{Tuple{nstate}, DFloat}(undef)
   l_auxP = MArray{Tuple{nauxstate}, DFloat}(undef)
   l_GP = MArray{Tuple{ngradstate}, DFloat}(undef)
 
@@ -455,8 +450,8 @@ function faceviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{states_grad},
         vidM, vidP = ((idM - 1) % Np) + 1,  ((idP - 1) % Np) + 1
 
         # Load minus side data
-        @unroll for s = 1:ngradtransformstate
-          l_QM[s] = Q[vidM, states_grad[s], eM]
+        @unroll for s = 1:nstate
+          l_QM[s] = Q[vidM, s, eM]
         end
 
         @unroll for s = 1:nauxstate
@@ -466,8 +461,8 @@ function faceviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{states_grad},
         gradient_transform!(l_GM, l_QM, l_auxM, t)
 
         # Load plus side data
-        @unroll for s = 1:ngradtransformstate
-          l_QP[s] = Q[vidP, states_grad[s], eP]
+        @unroll for s = 1:nstate
+          l_QP[s] = Q[vidP, s, eP]
         end
 
         @unroll for s = 1:nauxstate

--- a/test/DGmethods/compressible_Navier_Stokes/dycoms.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/dycoms.jl
@@ -63,7 +63,6 @@ const _nviscstates = 6
 const _τ11, _τ22, _τ33, _τ12, _τ13, _τ23 = 1:_nviscstates
 
 const _ngradstates = 3
-const _states_for_gradient_transform = (_ρ, _U, _V, _W)
 #md nothing # hide
 
 if !@isdefined integration_testing
@@ -200,7 +199,6 @@ end
 # Compute the velocity from the state
 @inline function velocities!(vel, Q, _...)
     @inbounds begin
-        # ordering should match states_for_gradient_transform
         ρ, U, V, W = Q[_ρ], Q[_U], Q[_V], Q[_W]
         ρinv = 1 / ρ
         vel[1], vel[2], vel[3] = ρinv * U, ρinv * V, ρinv * W
@@ -513,8 +511,6 @@ function run(mpicomm, dim, Ne, N, timeend, DFloat, dt)
                              numerical_flux! = numflux!,
                              numerical_boundary_flux! = numbcflux!, 
                              number_gradient_states = _ngradstates,
-                             states_for_gradient_transform =
-                             _states_for_gradient_transform,
                              number_viscous_states = _nviscstates,
                              gradient_transform! = velocities!,
                              viscous_transform! = compute_stresses!,

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc.jl
@@ -32,7 +32,6 @@ const _nviscstates = 6
 const _τ11, _τ22, _τ33, _τ12, _τ13, _τ23 = 1:_nviscstates
 
 const _ngradstates = 3
-const _states_for_gradient_transform = (_ρ, _U, _V, _W)
 
 if !@isdefined integration_testing
   const integration_testing =
@@ -89,8 +88,7 @@ end
 # Compute the velocity from the state
 @inline function velocities!(vel, Q, _...)
   @inbounds begin
-    # ordering should match states_for_gradient_transform
-    ρ, U, V, W = Q[1], Q[2], Q[3], Q[4]
+    ρ, U, V, W = Q[_ρ], Q[_U], Q[_V], Q[_W]
     ρinv = 1 / ρ
     vel[1], vel[2], vel[3] = ρinv * U, ρinv * V, ρinv * W
   end
@@ -216,8 +214,6 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
                            numerical_flux! = numflux!,
                            numerical_boundary_flux! = numbcflux!,
                            number_gradient_states = _ngradstates,
-                           states_for_gradient_transform =
-                             _states_for_gradient_transform,
                            number_viscous_states = _nviscstates,
                            gradient_transform! = velocities!,
                            viscous_transform! = compute_stresses!,

--- a/test/DGmethods/compressible_Navier_Stokes/rtb_visc.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/rtb_visc.jl
@@ -34,7 +34,6 @@ const _nviscstates = 6
 const _τ11, _τ22, _τ33, _τ12, _τ13, _τ23 = 1:_nviscstates
 
 const _ngradstates = 3
-const _states_for_gradient_transform = (_ρ, _U, _V, _W)
 
 if !@isdefined integration_testing
   const integration_testing =
@@ -135,7 +134,6 @@ end
 # Compute the velocity from the state
 @inline function velocities!(vel, Q, _...)
   @inbounds begin
-    # ordering should match states_for_gradient_transform
     ρ, U, V, W = Q[_ρ], Q[_U], Q[_V], Q[_W]
     ρinv = 1 / ρ
     vel[1], vel[2], vel[3] = ρinv * U, ρinv * V, ρinv * W
@@ -382,8 +380,6 @@ function run(mpicomm, dim, Ne, N, timeend, DFloat, dt)
                            numerical_flux! = numflux!,
                            numerical_boundary_flux! = numbcflux!, 
                            number_gradient_states = _ngradstates,
-                           states_for_gradient_transform =
-                            _states_for_gradient_transform,
                            number_viscous_states = _nviscstates,
                            gradient_transform! = velocities!,
                            viscous_transform! = compute_stresses!,

--- a/test/LinearSolvers/poisson.jl
+++ b/test/LinearSolvers/poisson.jl
@@ -89,7 +89,6 @@ function run(mpicomm, ArrayType, DFloat, dim, polynomialorder, brickrange, perio
                            flux! = physical_flux!,
                            numerical_flux! = numerical_flux!,
                            number_gradient_states = 1,
-                           states_for_gradient_transform = (1,),
                            number_viscous_states = 3,
                            gradient_transform! = gradient_transform!,
                            viscous_transform! = viscous_transform!,

--- a/test/profiling/DGmethods/CNS.jl
+++ b/test/profiling/DGmethods/CNS.jl
@@ -18,7 +18,6 @@ const _nviscstates = 6
 const _τ11, _τ22, _τ33, _τ12, _τ13, _τ23 = 1:_nviscstates
 
 const _ngradstates = 3
-const _states_for_gradient_transform = (_ρ, _U, _V, _W)
 
 const _nauxstate = 3
 const _a_x, _a_y, _a_z = 1:_nauxstate
@@ -73,8 +72,7 @@ end
 # Compute the velocity from the state
 @inline function velocities!(vel, Q, _...)
   @inbounds begin
-    # ordering should match states_for_gradient_transform
-    ρ, U, V, W = Q[1], Q[2], Q[3], Q[4]
+    ρ, U, V, W = Q[_ρ], Q[_U], Q[_V], Q[_W]
     ρinv = 1 / ρ
     vel[1], vel[2], vel[3] = ρinv * U, ρinv * V, ρinv * W
   end
@@ -127,7 +125,6 @@ let
                       numerical_flux!;
                       stateoffset = ((_E, 20), (_ρ, 1)),
                       ngradstate = _ngradstates,
-                      states_grad = _states_for_gradient_transform,
                       nviscstate = _nviscstates,
                       gradient_transform! = velocities!,
                       viscous_transform! = compute_stresses!,
@@ -138,7 +135,6 @@ let
                       numerical_flux!;
                       stateoffset = ((_E, 20), (_ρ, 1)),
                       ngradstate = _ngradstates,
-                      states_grad = _states_for_gradient_transform,
                       nviscstate = _nviscstates,
                       gradient_transform! = velocities!,
                       viscous_transform! = compute_stresses!,


### PR DESCRIPTION
Based on how I have seen things being used, I think that removing the `states_for_gradient_transform` from the balance law solver will simplify things (and unify the interface).

cc: @lcw @asraero @simonbyrne @smarras79 