### PR TITLE
[BL] Remove preflux from flux computations

### DIFF
--- a/examples/Microphysics/ex_1_saturation_adjustment.jl
+++ b/examples/Microphysics/ex_1_saturation_adjustment.jl
@@ -56,7 +56,7 @@ const _c_z, _c_x, _c_p = 1:_nauxcstate
 
 
 # preflux computation for wavespeed function
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   @inbounds begin
     # unpack all the state variables
     ρ, ρu, ρw, ρe_tot, ρq_tot = Q[_ρ], Q[_ρu], Q[_ρw], Q[_ρe_tot], Q[_ρq_tot]
@@ -68,8 +68,7 @@ end
 
 
 # boundary condition
-@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t,
-                          u, w, ρ, q_tot, e_tot)
+@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t)
   @inbounds begin
     ρu_M, ρw_M, ρe_tot_M, ρq_tot_M = QM[_ρu], QM[_ρw], QM[_ρe_tot], QM[_ρq_tot]
 
@@ -81,16 +80,13 @@ end
     QP[_ρe_tot], QP[_ρq_tot] = ρe_tot_M, ρq_tot_M
 
     auxM .= auxP
-
-    # Required return from this function is either nothing
-    # or preflux with plus state as arguments
-    return preflux(QP)
   end
 end
 
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, u, w, ρ, q_tot, e_tot)
+@inline function wavespeed(n, Q, aux, t)
+  u, w, ρ, q_tot, e_tot = preflux(Q)
   @inbounds abs(n[1] * u + n[2] * w)
 end
 
@@ -124,8 +120,8 @@ end
 
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) = eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
-@inline function eulerflux!(F, Q, QV, aux, t, u, w, ρ, q_tot, e_tot)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  u, w, ρ, q_tot, e_tot = preflux(Q)
   @inbounds begin
     p = aux[_c_p]
 
@@ -192,14 +188,12 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                                          )
   numflux!(x...) = NumericalFluxes.rusanov!(x...,
                                             eulerflux!,
-                                            wavespeed,
-                                            preflux
+                                            wavespeed
                                            )
   numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x...,
                                                             eulerflux!,
                                                             bcstate!,
-                                                            wavespeed,
-                                                            preflux
+                                                            wavespeed
                                                            )
 
 

--- a/examples/Microphysics/ex_2_Kessler.jl
+++ b/examples/Microphysics/ex_2_Kessler.jl
@@ -56,7 +56,7 @@ const _c_z, _c_x, _c_p = 1:_nauxcstate
 
 
 # preflux computation
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   DFloat = eltype(Q)
   @inbounds begin
     # unpack all the state variables
@@ -81,8 +81,7 @@ end
 
 
 # boundary condition
-@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t,
-                          u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot)
+@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t)
   @inbounds begin
 
     ρu_M, ρw_M, ρe_tot_M, ρq_tot_M, ρq_liq_M, ρq_rai_M =
@@ -95,21 +94,17 @@ end
 
     QP[_ρe_tot], QP[_ρq_tot], QP[_ρq_liq] = ρe_tot_M, ρq_tot_M, ρq_liq_M
 
-    DF = eltype(ρ)
+    DF = eltype(QP)
     QP[_ρq_rai] = DF(0)
 
     auxM .= auxP
-
-    # Required return from this function is either nothing
-    # or preflux with plus state as arguments
-    return preflux(QP)
   end
 end
 
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, u, w, rain_w,
-                           ρ, q_tot, q_liq, q_rai, e_tot)
+@inline function wavespeed(n, Q, aux, t)
+  u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
   @inbounds begin
     abs(n[1] * u + n[2] * max(w, rain_w, w-rain_w))
   end
@@ -145,9 +140,8 @@ end
 
 
 # time tendencies
-source!(S, Q, aux, t) = source!(S, Q, aux, t, preflux(Q)...)
-@inline function source!(S, Q, aux, t, u, w, rain_w, ρ,
-                         q_tot, q_liq, q_rai, e_tot)
+@inline function source!(S, Q, aux, t)
+  u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
   @inbounds begin
     DF = eltype(Q)
 
@@ -187,9 +181,8 @@ source!(S, Q, aux, t) = source!(S, Q, aux, t, preflux(Q)...)
 end
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) = eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
-@inline function eulerflux!(F, Q, QV, aux, t, u, w, rain_w, ρ,
-                            q_tot, q_liq, q_rai, e_tot)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
   @inbounds begin
     p = aux[_c_p]
 
@@ -269,14 +262,12 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                                          )
   numflux!(x...) = NumericalFluxes.rusanov!(x...,
                                             eulerflux!,
-                                            wavespeed,
-                                            preflux
+                                            wavespeed
                                            )
   numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x...,
                                                             eulerflux!,
                                                             bcstate!,
-                                                            wavespeed,
-                                                            preflux
+                                                            wavespeed
                                                            )
 
   # spacedisc = data needed for evaluating the right-hand side function

--- a/src/DGmethods/NumericalFluxes.jl
+++ b/src/DGmethods/NumericalFluxes.jl
@@ -3,48 +3,37 @@ using StaticArrays
 
 """
     rusanov!(F::MArray, nM, QM, QVM, auxM, QP, QVP, auxP, t, flux!, wavespeed,
-             [preflux = (_...) -> (), computeQjump!])
+             [computeQjump!])
 
 Calculate the Rusanov (aka local Lax-Friedrichs) numerical flux given the plus
 and minus side states/viscous states `QP`/`QVP` and `QM`/`QVM` using the physical
 flux function `flux!` and `wavespeed` calculation.
 
 The `flux!` has almost the same calling convention as `flux!` from
-[`DGBalanceLaw`](@ref) except that `preflux(Q, aux, t)` is splatted at the end
-of the call.
+[`DGBalanceLaw`](@ref).
 
 The function `wavespeed` should return the maximum wavespeed for a state and is
-called as `wavespeed(nM, QM, auxM, t, preflux(QM, auxM, t)...)` and
-`wavespeed(nM, QP, auxP, t, preflux(QP, auxP, t)...)` where `nM` is the outward
-unit normal for the minus side.
+called as `wavespeed(nM, QM, auxM, t)` and `wavespeed(nM, QP, auxP, t)` where
+`nM` is the outward unit normal for the minus side.
 
 When present `computeQjump!(ΔQ, QM, auxM, QP, auxP)` will be called after so
 that the user specify the value to use for `QM - QP`; this is useful for
 correcting `Q` to include discontinuous reference states.
-
-!!! note
-
-    The undocumented arguments `PM` and `PP` for the function should not be used
-    by external callers and are used only internally by the function
-    `rusanov_boundary_flux!`
 
 """
 function rusanov!(F::MArray{Tuple{nstate}}, nM,
                   QM, QVM, auxM,
                   QP, QVP, auxP,
                   t, flux!, wavespeed,
-                  preflux = (_...) -> (),
-                  computeQjump! = nothing,
-                  PM = preflux(QM, QVM, auxM, t),
-                  PP = preflux(QP, QVP, auxP, t)
+                  computeQjump! = nothing
                  ) where {nstate}
-  λM = wavespeed(nM, QM, auxM, t, PM...)
+  λM = wavespeed(nM, QM, auxM, t)
   FM = similar(F, Size(3, nstate))
-  flux!(FM, QM, QVM, auxM, t, PM...)
+  flux!(FM, QM, QVM, auxM, t)
 
-  λP = wavespeed(nM, QP, auxP, t, PP...)
+  λP = wavespeed(nM, QP, auxP, t)
   FP = similar(F, Size(3, nstate))
-  flux!(FP, QP, QVP, auxP, t, PP...)
+  flux!(FP, QP, QVP, auxP, t)
 
   λ  =  max(λM, λP)
 
@@ -66,14 +55,12 @@ end
 """
     rusanov_boundary_flux!(F::MArray{Tuple{nstate}}, nM, QM, QVM, auxM, QP, QVP,
                            auxP, bctype, t, flux!, bcstate!, wavespeed,
-                           preflux = (_...) -> (), computeQjump! = nothing
-                           ) where {nstate}
+                           computeQjump! = nothing) where {nstate}
 
 The function `bcstate!` is used to calculate the plus side state for the
 boundary condition `bctype`. The calling convention is:
 ```
-PP = bcstate!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t,
-              preflux(QM, auxM, t)...)
+bcstate!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t)
 ```
 where `QP`, `QVP`, and `auxP` are the plus side state, viscous state, and
 auxiliary state to be filled from the given data; other arguments should not be
@@ -85,14 +72,11 @@ function rusanov_boundary_flux!(F::MArray{Tuple{nstate}}, nM,
                                 bctype, t,
                                 flux!, bcstate!,
                                 wavespeed,
-                                preflux = (_...) -> (),
                                 computeQjump! = nothing
                                ) where {nstate}
-  PM = preflux(QM, QVM, auxM, t)
-  bcstate!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t, PM...)
-  PP = preflux(QP, QVP, auxP, t)
-  rusanov!(F, nM, QM, QVM, auxM, QP, QVP, auxP, t, flux!, wavespeed, preflux,
-           computeQjump!, PM, PP)
+  bcstate!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t)
+  rusanov!(F, nM, QM, QVM, auxM, QP, QVP, auxP, t, flux!, wavespeed,
+           computeQjump!)
 end
 
 end

--- a/test/DGmethods/Euler/isentropic_vortex_standalone.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone.jl
@@ -53,7 +53,7 @@ const statenames = ("ρ", "U", "V", "W", "E")
 const γ_exact = 7 // 5
 
 # preflux computation
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   ρinv = 1 / ρ
@@ -62,16 +62,15 @@ const γ_exact = 7 // 5
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) =
-eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
-
-@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -135,8 +134,7 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                            flux! = eulerflux!,
                            numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
-                                                    wavespeed,
-                                                    preflux))
+                                                    wavespeed))
 
   # This is a actual state/function that lives on the grid
   initialcondition(Q, x...) = isentropicvortex!(Q, 0, x...)

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_aux.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_aux.jl
@@ -52,7 +52,7 @@ if !@isdefined integration_testing
 end
 
 # preflux computation
-@inline function preflux(Q, QV, aux, t)
+@inline function preflux(Q, aux)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, Uδ, Vδ, Wδ, E= Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   @inbounds U, V, W = Uδ-aux[1], Vδ-aux[2], Wδ-aux[3]
@@ -77,16 +77,15 @@ end
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q, aux)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) =
-eulerflux!(F, Q, QV, aux, t, preflux(Q, QV, aux, t)...)
-
-@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  P, u, v, w, ρinv = preflux(Q, aux)
   @inbounds begin
     ρ, Uδ, Vδ, Wδ, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
     U, V, W = Uδ-aux[1], Vδ-aux[2], Wδ-aux[3]
@@ -152,7 +151,6 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                            numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
                                                     wavespeed,
-                                                    preflux,
                                                     computeQjump!),
                            auxiliary_state_length = 3,
                            auxiliary_state_initialization! =

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_bc.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_bc.jl
@@ -52,7 +52,7 @@ if !@isdefined integration_testing
 end
 
 # preflux computation
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   ρinv = 1 / ρ
@@ -61,16 +61,15 @@ end
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) =
-eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
-
-@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -86,7 +85,7 @@ end
   @inbounds aux[1], aux[2], aux[3] = x, y, z
 end
 
-@inline function bcstate!(QP, _, _, _, QM, _, auxM, bctype, t, _...)
+@inline function bcstate!(QP, _, _, _, QM, _, auxM, bctype, t)
   @inbounds begin
     x, y, z = auxM[1], auxM[2], auxM[3]
     isentropicvortex!(QP, t, x, y, z)
@@ -141,11 +140,9 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                                          )
 
   # spacedisc = data needed for evaluating the right-hand side function
-  numflux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed,
-                                            preflux)
+  numflux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed)
   numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x..., eulerflux!,
-                                                           bcstate!, wavespeed,
-                                                           preflux)
+                                                            bcstate!, wavespeed)
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
                            flux! = eulerflux!,

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_integral.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_integral.jl
@@ -52,7 +52,7 @@ if !@isdefined integration_testing
 end
 
 # preflux computation
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   ρinv = 1 / ρ
@@ -61,16 +61,15 @@ end
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) =
-eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
-
-@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -147,8 +146,7 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                                          )
 
   # spacedisc = data needed for evaluating the right-hand side function
-  numflux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed,
-                                            preflux)
+  numflux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed)
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
                            flux! = eulerflux!,

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_source.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_source.jl
@@ -52,7 +52,7 @@ if !@isdefined integration_testing
 end
 
 # preflux computation
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   ρinv = 1 / ρ
@@ -61,7 +61,8 @@ end
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
@@ -91,10 +92,8 @@ end
 end
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) =
-eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
-
-@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -158,8 +157,7 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
                            flux! = eulerflux!,
                            numerical_flux! = (x...) ->
                            NumericalFluxes.rusanov!(x..., eulerflux!,
-                                                    wavespeed,
-                                                    preflux),
+                                                    wavespeed),
                            auxiliary_state_length = _nauxstate,
                            auxiliary_state_initialization! =
                            auxiliary_state_initialization!,

--- a/test/DGmethods/compressible_Navier_Stokes/dycoms.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/dycoms.jl
@@ -101,7 +101,7 @@ const yc   = (ymax + ymin) / 2
 # Modules: NumericalFluxes.jl 
 # functions: wavespeed, cns_flux!, bcstate!
 # -------------------------------------------------------------------------
-@inline function preflux(Q,VF, aux, _...)
+@inline function preflux(Q, aux)
     γ::eltype(Q) = γ_exact
     gravity::eltype(Q) = grav
     R_gas::eltype(Q) = R_d
@@ -125,7 +125,8 @@ end
 
 # -------------------------------------------------------------------------
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+    P, u, v, w, ρinv = preflux(Q, aux)
     γ::eltype(Q) = γ_exact
     @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
@@ -164,8 +165,8 @@ end
 #md # Note that the preflux calculation is splatted at the end of the function call
 #md # to cns_flux!
 # -------------------------------------------------------------------------
-cns_flux!(F, Q, VF, aux, t) = cns_flux!(F, Q, VF, aux, t, preflux(Q,VF, aux)...)
-@inline function cns_flux!(F, Q, VF, aux, t, P, u, v, w, ρinv)
+@inline function cns_flux!(F, Q, VF, aux, t)
+    P, u, v, w, ρinv = preflux(Q, aux)
     @inbounds begin
         ρ, U, V, W, E, QT = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E], Q[_QT]
         # Inviscid contributions 
@@ -267,7 +268,8 @@ end
 
 # -------------------------------------------------------------------------
 # generic bc for 2d , 3d
-@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t, PM, uM, vM, wM, ρinvM)
+@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t)
+  PM, uM, vM, wM, ρinvM = preflux(QM, auxM)
     @inbounds begin
         x, y, z = auxM[_a_x], auxM[_a_y], auxM[_a_z]
         ρM, UM, VM, WM, EM, QTM = QM[_ρ], QM[_U], QM[_V], QM[_W], QM[_E], QM[_QT]
@@ -281,8 +283,6 @@ end
         VFP .= VFM
         # To calculate PP, uP, vP, wP, ρinvP we use the preflux function 
         nothing
-        #preflux(QP, auxP, t)
-        # Required return from this function is either nothing or preflux with plus state as arguments
     end
 end
 # -------------------------------------------------------------------------
@@ -503,8 +503,8 @@ function run(mpicomm, dim, Ne, N, timeend, DFloat, dt)
                                             DeviceArray = ArrayType,
                                             polynomialorder = N)
     
-    numflux!(x...)   = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed, preflux)
-    numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x..., cns_flux!, bcstate!, wavespeed, preflux)
+    numflux!(x...)   = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed)
+    numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x..., cns_flux!, bcstate!, wavespeed)
 
     # spacedisc = data needed for evaluating the right-hand side function
     spacedisc = DGBalanceLaw(grid = grid,

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc.jl
@@ -42,7 +42,7 @@ end
 include("mms_solution_generated.jl")
 
 # preflux computation
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   ρinv = 1 / ρ
@@ -51,15 +51,16 @@ include("mms_solution_generated.jl")
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
 
 # flux function
-cns_flux!(F, Q, VF, aux, t) = cns_flux!(F, Q, VF, aux, t, preflux(Q)...)
 
-@inline function cns_flux!(F, Q, VF, aux, t, P, u, v, w, ρinv)
+@inline function cns_flux!(F, Q, VF, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -178,7 +179,7 @@ end
   end
 end
 
-@inline function bcstate2D!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t, _...)
+@inline function bcstate2D!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t)
   @inbounds begin
     x, y, z = auxM[_a_x], auxM[_a_y], auxM[_a_z]
     initialcondition!(Val(2), QP, t, x, y, z)
@@ -186,7 +187,7 @@ end
   nothing
 end
 
-@inline function bcstate3D!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t, _...)
+@inline function bcstate3D!(QP, QVP, auxP, nM, QM, QVM, auxM, bctype, t)
   @inbounds begin
     x, y, z = auxM[_a_x], auxM[_a_y], auxM[_a_z]
     initialcondition!(Val(3), QP, t, x, y, z)
@@ -204,12 +205,11 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
                                          )
 
   # spacedisc = data needed for evaluating the right-hand side function
-  numflux!(x...) = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed,
-                                            preflux)
+  numflux!(x...) = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed)
   bcstate! = dim == 2 ?  bcstate2D! : bcstate3D!
   numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x..., cns_flux!,
                                                             bcstate!,
-                                                            wavespeed, preflux)
+                                                            wavespeed)
   spacedisc = DGBalanceLaw(grid = grid,
                            length_state_vector = _nstate,
                            flux! = cns_flux!,

--- a/test/DGmethods/compressible_Navier_Stokes/rtb_visc.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/rtb_visc.jl
@@ -64,7 +64,7 @@ const zc   = zmax / 2
 # Modules: NumericalFluxes.jl 
 # functions: wavespeed, cns_flux!, bcstate!
 # -------------------------------------------------------------------------
-@inline function preflux(Q,VF, aux, _...)
+@inline function preflux(Q, aux)
   γ::eltype(Q) = γ_exact
   gravity::eltype(Q) = grav
   R_gas::eltype(Q) = R_d
@@ -84,7 +84,8 @@ end
 
 # -------------------------------------------------------------------------
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q, aux)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
@@ -99,8 +100,8 @@ end
 #md # Note that the preflux calculation is splatted at the end of the function call
 #md # to cns_flux!
 # -------------------------------------------------------------------------
-cns_flux!(F, Q, VF, aux, t) = cns_flux!(F, Q, VF, aux, t, preflux(Q,VF, aux)...)
-@inline function cns_flux!(F, Q, VF, aux, t, P, u, v, w, ρinv)
+@inline function cns_flux!(F, Q, VF, aux, t)
+  P, u, v, w, ρinv = preflux(Q, aux)
   @inbounds begin
     ρ, U, V, W, E, QT = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E], Q[_QT]
     # Inviscid contributions 
@@ -202,7 +203,8 @@ end
 
 # -------------------------------------------------------------------------
 # generic bc for 2d , 3d
-@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t, PM, uM, vM, wM, ρinvM)
+@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t)
+  PM, uM, vM, wM, ρinvM = preflux(QM, auxM)
   @inbounds begin
     x, y, z = auxM[_a_x], auxM[_a_y], auxM[_a_z]
     ρM, UM, VM, WM, EM, QTM = QM[_ρ], QM[_U], QM[_V], QM[_W], QM[_E], QM[_QT]
@@ -214,10 +216,7 @@ end
     QP[_E] = EM
     QP[_QT] = QTM
     VFP .= VFM
-    # To calculate PP, uP, vP, wP, ρinvP we use the preflux function 
     nothing
-    #preflux(QP, auxP, t)
-    # Required return from this function is either nothing or preflux with plus state as arguments
   end
 end
 # -------------------------------------------------------------------------
@@ -372,8 +371,8 @@ function run(mpicomm, dim, Ne, N, timeend, DFloat, dt)
                                           DeviceArray = ArrayType,
                                           polynomialorder = N)
   
-  numflux!(x...) = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed, preflux)
-  numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x..., cns_flux!, bcstate!, wavespeed, preflux)
+  numflux!(x...) = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed)
+  numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(x..., cns_flux!, bcstate!, wavespeed)
 
   # spacedisc = data needed for evaluating the right-hand side function
   spacedisc = DGBalanceLaw(grid = grid,

--- a/test/DGmethods/sphere/advection_sphere_lsrk.jl
+++ b/test/DGmethods/sphere/advection_sphere_lsrk.jl
@@ -64,8 +64,7 @@ if !@isdefined integration_testing
   parse(Bool, lowercase(get(ENV,"JULIA_CLIMA_INTEGRATION_TESTING","false")))
 end
 
-# preflux computation: NOT needed for this test
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ = Q[1]
   ρinv = 1 / ρ
@@ -74,9 +73,8 @@ end
 end
 
 #{{{ advectionflux
-advectionflux!(F, Q, QV, aux, t) = advectionflux!(F, Q, QV, aux, t,
-                                                  preflux(Q)...)
-@inline function advectionflux!(F,Q,QV,aux,t,P,u,v,w,ρinv)
+@inline function advectionflux!(F,Q,QV,aux,t)
+  P,u,v,w,ρinv = preflux(Q)
   @inbounds begin
     u,v,w = aux[uid], aux[vid], aux[wid]
     ρ=Q[1]
@@ -148,7 +146,7 @@ function main(mpicomm, DFloat, topl, N, timeend, ArrayType, dt, ti_method)
 
   #{{{ numerical fluxex
   numflux!(x...) = NumericalFluxes.rusanov!(x..., advectionflux!,
-                                            wavespeed, preflux)
+                                            wavespeed)
 
   # zero flux at the boundaries: not entirely accurate but good enough
   function numbcflux!(F, _...)

--- a/test/DGmethods/sphere/advection_sphere_ssp33.jl
+++ b/test/DGmethods/sphere/advection_sphere_ssp33.jl
@@ -64,8 +64,7 @@ if !@isdefined integration_testing
   parse(Bool, lowercase(get(ENV,"JULIA_CLIMA_INTEGRATION_TESTING","false")))
 end
 
-# preflux computation: NOT needed for this test
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ = Q[1]
   ρinv = 1 / ρ
@@ -74,9 +73,8 @@ end
 end
 
 #{{{ advectionflux
-advectionflux!(F, Q, QV, aux, t) = advectionflux!(F, Q, QV, aux, t,
-                                                  preflux(Q)...)
-@inline function advectionflux!(F,Q,QV,aux,t,P,u,v,w,ρinv)
+@inline function advectionflux!(F,Q,QV,aux,t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     u,v,w = aux[uid], aux[vid], aux[wid]
     ρ=Q[1]
@@ -148,7 +146,7 @@ function main(mpicomm, DFloat, topl, N, timeend, ArrayType, dt, ti_method)
 
   #{{{ numerical fluxex
   numflux!(x...) = NumericalFluxes.rusanov!(x..., advectionflux!,
-                                            wavespeed, preflux)
+                                            wavespeed)
 
   # zero flux at the boundaries: not entirely accurate but good enough
   function numbcflux!(F, _...)

--- a/test/DGmethods/sphere/advection_sphere_ssp34.jl
+++ b/test/DGmethods/sphere/advection_sphere_ssp34.jl
@@ -64,8 +64,7 @@ if !@isdefined integration_testing
   parse(Bool, lowercase(get(ENV,"JULIA_CLIMA_INTEGRATION_TESTING","false")))
 end
 
-# preflux computation: NOT needed for this test
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ = Q[1]
   ρinv = 1 / ρ
@@ -74,9 +73,8 @@ end
 end
 
 #{{{ advectionflux
-advectionflux!(F, Q, QV, aux, t) = advectionflux!(F, Q, QV, aux, t,
-                                                  preflux(Q)...)
-@inline function advectionflux!(F,Q,QV,aux,t,P,u,v,w,ρinv)
+@inline function advectionflux!(F,Q,QV,aux,t)
+  P,u,v,w,ρinv = preflux(Q)
   @inbounds begin
     u,v,w = aux[uid], aux[vid], aux[wid]
     ρ=Q[1]
@@ -148,7 +146,7 @@ function main(mpicomm, DFloat, topl, N, timeend, ArrayType, dt, ti_method)
 
   #{{{ numerical fluxex
   numflux!(x...) = NumericalFluxes.rusanov!(x..., advectionflux!,
-                                            wavespeed, preflux)
+                                            wavespeed)
 
   # zero flux at the boundaries: not entirely accurate but good enough
   function numbcflux!(F, _...)

--- a/test/profiling/DGmethods/CNS.jl
+++ b/test/profiling/DGmethods/CNS.jl
@@ -26,7 +26,7 @@ const _a_x, _a_y, _a_z = 1:_nauxstate
 const γ_exact = 7//5
 const μ_exact = 1//100
 
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   ρinv = 1 / ρ
@@ -35,15 +35,15 @@ const μ_exact = 1//100
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
 
 # flux function
-cns_flux!(F, Q, VF, aux, t) = cns_flux!(F, Q, VF, aux, t, preflux(Q)...)
-
-@inline function cns_flux!(F, Q, VF, aux, t, P, u, v, w, ρinv)
+@inline function cns_flux!(F, Q, VF, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -116,8 +116,7 @@ end
   end
 end
 
-numerical_flux!(x...) = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed,
-                                                 preflux)
+numerical_flux!(x...) = NumericalFluxes.rusanov!(x..., cns_flux!, wavespeed)
 let
   DFloat = Float64
   dim = 2

--- a/test/profiling/DGmethods/Euler.jl
+++ b/test/profiling/DGmethods/Euler.jl
@@ -16,7 +16,7 @@ const statenames = ("ρ", "U", "V", "W", "E")
 const γ_exact = 7 // 5
 
 # preflux computation
-@inline function preflux(Q, _...)
+@inline function preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
   ρinv = 1 / ρ
@@ -25,16 +25,15 @@ const γ_exact = 7 // 5
 end
 
 # max eigenvalue
-@inline function wavespeed(n, Q, aux, t, P, u, v, w, ρinv)
+@inline function wavespeed(n, Q, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   γ::eltype(Q) = γ_exact
   @inbounds abs(n[1] * u + n[2] * v + n[3] * w) + sqrt(ρinv * γ * P)
 end
 
 # physical flux function
-eulerflux!(F, Q, QV, aux, t) =
-eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
-
-@inline function eulerflux!(F, Q, QV, aux, t, P, u, v, w, ρinv)
+@inline function eulerflux!(F, Q, QV, aux, t)
+  P, u, v, w, ρinv = preflux(Q)
   @inbounds begin
     ρ, U, V, W, E = Q[_ρ], Q[_U], Q[_V], Q[_W], Q[_E]
 
@@ -46,8 +45,7 @@ eulerflux!(F, Q, QV, aux, t, preflux(Q)...)
   end
 end
 
-numerical_flux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed,
-                                                 preflux)
+numerical_flux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed)
 
 let
   DFloat = Float64


### PR DESCRIPTION
Based on how I have seen things being used, I think that removing the `preflux` from the balance law solver will simplify things (and unify the interface).

cc: @lcw @asraero @simonbyrne @trontrytel @smarras79 