### PR TITLE
Select GPU devices for MPI runs

### DIFF
--- a/examples/DGmethods/ex_001_periodic_advection.jl
+++ b/examples/DGmethods/ex_001_periodic_advection.jl
@@ -307,6 +307,13 @@ let
   # called in a logging block deadlock will occur since `NullLogger` code is
   # not executed.
 
+  # Select the GPU device
+  @static if haspkg("CuArrays")
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
+  end
+
   # Dimensionality to run
   dim = 2
 
@@ -403,6 +410,11 @@ let
   # code is the same as above until the `solve!` call
   mpicomm = MPI.COMM_WORLD
   mpi_logger = ConsoleLogger(MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull)
+  @static if haspkg("CuArrays")
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
+  end
   dim = 2
   Ne = 20
   polynomialorder = 4

--- a/examples/DGmethods/ex_002_solid_body_rotation.jl
+++ b/examples/DGmethods/ex_002_solid_body_rotation.jl
@@ -251,6 +251,11 @@ end
 let
   mpicomm = MPI.COMM_WORLD
   mpi_logger = ConsoleLogger(MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull)
+  @static if haspkg("CuArrays")
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
+  end
   dim = 2
   Ne = 20
   polynomialorder = 4
@@ -318,6 +323,12 @@ end
 let
   mpicomm = MPI.COMM_WORLD
   mpi_logger = ConsoleLogger(MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull)
+
+  @static if haspkg("CuArrays")
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
+  end
 
   dim = 2
   polynomialorder = 4

--- a/examples/DGmethods/ex_003_acoustic_wave.jl
+++ b/examples/DGmethods/ex_003_acoustic_wave.jl
@@ -408,6 +408,13 @@ let
   mpicomm = MPI.COMM_WORLD
   mpi_logger = ConsoleLogger(MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull)
 
+  ## Select the GPU device
+  @static if haspkg("CuArrays")
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
+  end
+
   ## parameters for defining the cubed sphere.
   Ne_vertical   = 4  # number of vertical elements (small for CI/docs reasons)
   ## Ne_vertical   = 30 # Resolution required for stable long time result

--- a/examples/Microphysics/ex_1_saturation_adjustment.jl
+++ b/examples/Microphysics/ex_1_saturation_adjustment.jl
@@ -309,6 +309,12 @@ function run(dim, Ne, N, timeend, DFloat)
 
   mpicomm = MPI.COMM_WORLD
 
+  @static if haspkg("CuArrays")
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
+  end
+
   brickrange = ntuple(j->range(DFloat(0); length=Ne[j]+1, stop=Z_max), 2)
 
   topl = BrickTopology(mpicomm, brickrange, periodicity=(true, false))

--- a/examples/Microphysics/ex_2_Kessler.jl
+++ b/examples/Microphysics/ex_2_Kessler.jl
@@ -399,6 +399,12 @@ function run(dim, Ne, N, timeend, DFloat)
 
   mpicomm = MPI.COMM_WORLD
 
+  @static if haspkg("CuArrays")
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
+  end
+
   brickrange = ntuple(j->range(DFloat(0); length=Ne[j]+1, stop=Z_max), 2)
 
   topl = BrickTopology(mpicomm, brickrange, periodicity=(true, false))

--- a/test/DGmethods/Euler/isentropic_vortex_standalone.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone.jl
@@ -221,7 +221,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   timeend = 1

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_aux.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_aux.jl
@@ -237,7 +237,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   timeend = 1

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_bc.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_bc.jl
@@ -234,7 +234,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
   
   timeend = 1

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_integral.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_integral.jl
@@ -242,7 +242,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   timeend = 2halfperiod

--- a/test/DGmethods/Euler/isentropic_vortex_standalone_source.jl
+++ b/test/DGmethods/Euler/isentropic_vortex_standalone_source.jl
@@ -245,7 +245,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
   
   timeend = 1

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc.jl
@@ -314,7 +314,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   polynomialorder = 4

--- a/test/DGmethods/conservation/sphere.jl
+++ b/test/DGmethods/conservation/sphere.jl
@@ -161,7 +161,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   dt = 1e-4

--- a/test/DGmethods/sphere/advection_sphere_lsrk.jl
+++ b/test/DGmethods/sphere/advection_sphere_lsrk.jl
@@ -260,7 +260,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   # Perform Integration Testing for three different grid resolutions

--- a/test/DGmethods/sphere/advection_sphere_ssp33.jl
+++ b/test/DGmethods/sphere/advection_sphere_ssp33.jl
@@ -260,7 +260,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   # Perform Integration Testing for three different grid resolutions

--- a/test/DGmethods/sphere/advection_sphere_ssp34.jl
+++ b/test/DGmethods/sphere/advection_sphere_ssp34.jl
@@ -260,7 +260,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   # Perform Integration Testing for three different grid resolutions

--- a/test/DGmethods/util/filter_test.jl
+++ b/test/DGmethods/util/filter_test.jl
@@ -107,7 +107,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   numelem = (1, 1, 1)

--- a/test/DGmethods/util/grad_test.jl
+++ b/test/DGmethods/util/grad_test.jl
@@ -73,7 +73,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   numelem = (5, 5, 1)

--- a/test/DGmethods/util/grad_test_sphere.jl
+++ b/test/DGmethods/util/grad_test_sphere.jl
@@ -70,7 +70,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   numelem = (5, 5, 1)

--- a/test/DGmethods/util/integral_test.jl
+++ b/test/DGmethods/util/integral_test.jl
@@ -85,7 +85,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   numelem = (5, 5, 5)

--- a/test/DGmethods/util/integral_test_sphere.jl
+++ b/test/DGmethods/util/integral_test_sphere.jl
@@ -92,7 +92,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   polynomialorder = 4

--- a/test/LinearSolvers/poisson.jl
+++ b/test/LinearSolvers/poisson.jl
@@ -127,7 +127,9 @@ let
   logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
   global_logger(ConsoleLogger(logger_stream, loglevel))
   @static if haspkg("CUDAnative")
-    device!(MPI.Comm_rank(mpicomm) % length(devices()))
+    lcomm = MPI.Comm_split_type(mpicomm, MPI.MPI_COMM_TYPE_SHARED,
+                                MPI.Comm_rank(mpicomm))
+    CUDAnative.device!(MPI.Comm_rank(lcomm))
   end
 
   polynomialorder = 4


### PR DESCRIPTION
This pull request adds GPU device selection to the examples and removes an assumption of MPI rank ordering in the tests.