### PR TITLE
Fix: moisture model + turbulence export

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -1,8 +1,8 @@
 module Atmos
 
 export AtmosModel,
-  ConstantViscosityWithDivergence,
-  DryModel, MoistEquil,
+  ConstantViscosityWithDivergence, SmagorinskyLilly,
+  DryModel, EquilMoist,
   NoRadiation,
   NoFluxBC, InitStateBC
 


### PR DESCRIPTION
Related to moisture.jl, turbulence.jl 
1) Fix MoistEquil -> EquilMoist
2) Export SmagorinskyLilly
https://github.com/climate-machine/CLIMA/blob/2f215bf9b6dd20fadee0c5f79d6a08bfa4446eb5/src/Atmos/Model/moisture.jl#L53