### PR TITLE
Add normpervars to MPIStateArray

### DIFF
--- a/test/Arrays/reductions.jl
+++ b/test/Arrays/reductions.jl
@@ -18,6 +18,9 @@ globalA = vcat([A for _ in 1:mpisize]...)
 QA = MPIStateArray{Tuple{localsize[1:2]...}, Float32, Array}(mpicomm, localsize[3])
 QA .= A
 
+@test normpervar(QA) .≈ 
+@test normpervar(QA, 1) .≈ 
+
 @test isapprox(norm(QA, 1), norm(globalA, 1))
 @test isapprox(norm(QA), norm(globalA))
 @test isapprox(norm(QA, Inf), norm(globalA, Inf))
@@ -42,6 +45,9 @@ QB .= B
 
   QA = MPIStateArray{Tuple{localsize[1:2]...}, Float32, CuArray}(mpicomm, localsize[3])
   QA .= A
+
+  @test normpervar(QA) .≈ 
+  @test normpervar(QA, 1) .≈ 
 
   @test isapprox(norm(QA, 1), norm(globalA, 1))
   @test isapprox(norm(QA), norm(globalA))


### PR DESCRIPTION
This PR adds `npv = normpervars(Q::MPIStateArray, ...)`, which computes norms for each of the states. i.e., `length(npv) = numstates(Q)`.

This may help debugging since it's difficult to see how `ρq_tot~O(1)` varies while `ρe ~O(10^4)`.