### PR TITLE
Splitting AtmosModel into nonlinear and linear parts

### DIFF
--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -1,0 +1,66 @@
+export Linear
+
+struct Linear <: ModelPart end
+
+@inline function flux_advective!(m::AtmosModel{Linear},
+                                 flux::Grad, state::Vars, aux::Vars, t::Real)
+  ρu = state.ρu
+  ρ_ref = aux.ref_state.ρ
+  ρu_ref = aux.ref_state.ρu
+  ρe_ref = aux.ref_state.ρe
+
+  ρ_ref_inv = 1 / ρ_ref
+  u_ref = ρ_ref_inv * ρu_ref
+  e_ref = ρe_ref * ρ_ref_inv 
+
+  flux.ρ   = ρu
+  flux.ρu  = ρu * u_ref'
+  flux.ρe  = ρu * e_ref
+end
+
+@inline function flux_pressure!(m::AtmosModel{Linear},
+                                flux::Grad, state::Vars, aux::Vars, t::Real)
+  DFloat = eltype(state)
+  ρ = state.ρ
+  ρu = state.ρu
+  ρe = state.ρe
+
+  ρ_inv = 1 / ρ
+  u = ρ_inv * ρu
+
+  ρ_ref = aux.ref_state.ρ
+  ρ_ref_inv = 1 / ρ_ref
+  p_ref = pressure(m.moisture, m.orientation, aux.ref_state, aux)
+  
+  e_pot = gravitational_potential(m.orientation, aux)
+  # FIXME: use linearized_air_pressure, currently it doesn't work here
+  # because it doesn't handle ρ == 0 well
+  p_L = ρ * DFloat(R_d) * DFloat(T_0) + DFloat(R_d) / DFloat(cv_d) * (ρe - ρ * e_pot)
+
+  #ts = thermo_state(m.moisture, m.orientation, state, aux)
+  #e_kin = u' * u / 2
+  #p_L = linearized_air_pressure(e_kin, e_pot, ts)
+
+  flux.ρu += p_L * I
+  flux.ρe += ρu * p_ref * ρ_ref_inv
+end
+
+@inline function wavespeed(m::AtmosModel{Linear}, nM, state::Vars, aux::Vars, t::Real)
+  ρ_ref = aux.ref_state.ρ
+  ρu_ref = aux.ref_state.ρu
+  ρ_ref_inv = 1 / ρ_ref
+  u_ref = ρ_ref_inv * ρu_ref
+
+  soundspeed_linear = soundspeed(m.moisture, m.orientation, aux.ref_state, aux) 
+  return abs(dot(nM, u_ref)) + soundspeed_linear
+end
+
+# prevents errors thrown when calculating virtual potential temperature for
+# nonphysical states
+atmos_nodal_update_aux!(moist::DryModel, atmos::AtmosModel{Linear},
+                        state::Vars, aux::Vars, t::Real) = nothing
+
+# needs to be defined for ambiguity resolution :(
+flux_diffusive!(m::AtmosModel{Linear},
+                flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real,
+                ::NoViscosity) = nothing

--- a/src/Atmos/Model/nonlinear.jl
+++ b/src/Atmos/Model/nonlinear.jl
@@ -2,6 +2,7 @@ export NonLinear
 
 struct NonLinear <: ModelPart end
 
+# FIXME: this doesn't seem to work ?
 const use_linearized_pressure = false
 
 @inline function flux_advective!(m::AtmosModel{NonLinear},
@@ -66,7 +67,13 @@ end
 
   soundspeed_full = soundspeed(m.moisture, m.orientation, state, aux)
   soundspeed_linear = soundspeed(m.moisture, m.orientation, aux.ref_state, aux)
-  return abs(dot(nM, u)) - abs(dot(nM, u_ref)) + soundspeed_full - soundspeed_linear
+
+  if use_linearized_pressure
+    soundspeed_contribution = -zero(eltype(state))
+  else
+    soundspeed_contribution = soundspeed_full - soundspeed_linear
+  end
+  return abs(dot(nM, u)) - abs(dot(nM, u_ref)) + soundspeed_contribution
 end
 
 # needs to be defined for ambiguity resolution :(

--- a/src/Atmos/Model/nonlinear.jl
+++ b/src/Atmos/Model/nonlinear.jl
@@ -1,0 +1,75 @@
+export NonLinear
+
+struct NonLinear <: ModelPart end
+
+const use_linearized_pressure = false
+
+@inline function flux_advective!(m::AtmosModel{NonLinear},
+                                 flux::Grad, state::Vars, aux::Vars, t::Real)
+  ρ = state.ρ
+  ρu = state.ρu
+  ρe = state.ρe
+  
+  ρ_ref = aux.ref_state.ρ
+  ρu_ref = aux.ref_state.ρu
+  ρe_ref = aux.ref_state.ρe
+  
+  ρ_inv = 1 / ρ
+  u = ρ_inv * ρu
+  e = ρ_inv * ρe
+
+  ρ_ref_inv = 1 / ρ_ref
+  u_ref = ρ_ref_inv * ρu_ref
+  e_ref = ρ_ref_inv * ρe_ref
+
+  flux.ρ   = -zero(eltype(state))
+  flux.ρu  = ρu * (u' - u_ref')
+  flux.ρe  = ρu * (e - e_ref)
+end
+
+@inline function flux_pressure!(m::AtmosModel{NonLinear},
+                                flux::Grad, state::Vars, aux::Vars, t::Real)
+  DFloat = eltype(state)
+  ρ = state.ρ
+  ρu = state.ρu
+  ρ_ref = aux.ref_state.ρ
+  
+  ρ_inv = 1 / ρ
+  u = ρ_inv * ρu
+  ρ_ref_inv = 1 / ρ_ref
+
+  ts = thermo_state(m.moisture, m.orientation, state, aux)
+  e_kin = u' * u / 2
+  e_pot = gravitational_potential(m.orientation, aux)
+  p_L = linearized_air_pressure(e_kin, e_pot, ts)
+
+  if use_linearized_pressure
+    p = p_L
+  else
+    p = pressure(m.moisture, m.orientation, state, aux)
+  end
+
+  p_ref = pressure(m.moisture, m.orientation, aux.ref_state, aux)
+
+  flux.ρu += (p - p_L) * I
+  flux.ρe += ρu * (ρ_inv * p - ρ_ref_inv * p_ref)
+end
+
+@inline function wavespeed(m::AtmosModel{NonLinear}, nM, state::Vars, aux::Vars, t::Real)
+  ρ = state.ρ
+  ρu = state.ρu
+  ρ_ref = aux.ref_state.ρ
+  ρu_ref = aux.ref_state.ρu
+  
+  u = ρu / ρ
+  u_ref = ρu_ref / ρ_ref
+
+  soundspeed_full = soundspeed(m.moisture, m.orientation, state, aux)
+  soundspeed_linear = soundspeed(m.moisture, m.orientation, aux.ref_state, aux)
+  return abs(dot(nM, u)) - abs(dot(nM, u_ref)) + soundspeed_full - soundspeed_linear
+end
+
+# needs to be defined for ambiguity resolution :(
+flux_diffusive!(m::AtmosModel{NonLinear},
+                flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real,
+                ::NoViscosity) = nothing

--- a/test/DGmethods/Euler/isentropicvortex_imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex_imex.jl
@@ -146,7 +146,7 @@ function run(mpicomm, polynomialorder, numelems, setup,
   param = init_ode_param(dg)
   param_linear = init_ode_param(dg_linear)
 
-  timeend = DFloat(2 * setup.domain_halflength / 10 / setup.translation_speed)
+  timeend = DFloat(2 * setup.domain_halflength / setup.translation_speed)
 
   # determine the time step
   elementsize = minimum(step.(brickrange))
@@ -189,19 +189,20 @@ function run(mpicomm, polynomialorder, numelems, setup,
   if output_vtk
     # create vtk dir
     vtkdir = "vtk_isentropicvortex" *
-      "_poly$(polynomialorder)_dims$(dims)_$(ArrayType)_$(DFloat)_level$(level)"
+      "_poly$(polynomialorder)_dims$(dims)_$(ArrayType)_$(DFloat)_level$(level)" *
+      "_$(split_nonlinear_linear)"
     mkpath(vtkdir)
     
     vtkstep = 0
     # output initial step
-    do_output(mpicomm, vtkdir, vtkstep, dg_full, Q, Q, model)
+    do_output(mpicomm, vtkdir, vtkstep, dg, Q, Q, model)
 
     # setup the output callback
     outputtime = timeend
     cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
       vtkstep += 1
       Qe = init_ode_state(dg, param, gettime(ode_solver))
-      do_output(mpicomm, vtkdir, vtkstep, dg_full, Q, Qe, model)
+      do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model)
     end
     callbacks = (callbacks..., cbvtk)
   end

--- a/test/DGmethods/Euler/isentropicvortex_imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex_imex.jl
@@ -1,0 +1,321 @@
+using CLIMA: haspkg
+using CLIMA.Mesh.Topologies: BrickTopology
+using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
+using CLIMA.DGmethods: DGModel, init_ode_param, init_ode_state, LocalGeometry
+using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+                                       CentralNumericalFluxDiffusive
+using CLIMA.ODESolvers: solve!, gettime
+using CLIMA.AdditiveRungeKuttaMethod
+using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
+using CLIMA.VTK: writevtk, writepvtu
+using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
+using CLIMA.MPIStateArrays: euclidean_distance
+using CLIMA.PlanetParameters: kappa_d
+using CLIMA.MoistThermodynamics: air_density, total_energy, soundspeed_air
+using CLIMA.Atmos: AtmosModel, Full, Linear, NonLinear,
+                   NoOrientation,
+                   NoReferenceState, ReferenceState,
+                   DryModel, NoRadiation, PeriodicBC,
+                   NoViscosity, vars_state
+using CLIMA.VariableTemplates: @vars, Vars, flattenednames
+import CLIMA.Atmos: atmos_init_aux!, vars_aux
+
+using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
+@static if haspkg("CuArrays")
+  using CUDAdrv
+  using CUDAnative
+  using CuArrays
+  CuArrays.allowscalar(false)
+  const ArrayTypes = (CuArray,)
+else
+  const ArrayTypes = (Array,)
+end
+
+const integration_testing = true
+if !@isdefined integration_testing
+  const integration_testing =
+    parse(Bool, lowercase(get(ENV,"JULIA_CLIMA_INTEGRATION_TESTING","false")))
+end
+
+const output_vtk = false
+
+function main()
+  MPI.Initialized() || MPI.Init()
+  mpicomm = MPI.COMM_WORLD
+
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = Dict("DEBUG" => Logging.Debug,
+                  "WARN"  => Logging.Warn,
+                  "ERROR" => Logging.Error,
+                  "INFO"  => Logging.Info)[ll]
+
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
+  polynomialorder = 4
+  numlevels = integration_testing ? 4 : 1
+
+  expected_error = Dict()
+
+  expected_error[Float64, true, 1] = 1.1995402648404040e+01
+  expected_error[Float64, true, 2] = 2.0809818401778615e+00
+  expected_error[Float64, true, 3] = 6.3709142077428532e-02
+  expected_error[Float64, true, 4] = 2.2556313480754410e-03
+  
+  expected_error[Float64, false, 1] = 1.1995402576828100e+01
+  expected_error[Float64, false, 2] = 2.0809818288550272e+00
+  expected_error[Float64, false, 3] = 6.3709173428486129e-02
+  expected_error[Float64, false, 4] = 2.2555262442164612e-03
+
+  @testset "$(@__FILE__)" begin
+    for ArrayType in ArrayTypes, DFloat in (Float64,), dims in 2
+      for split_nonlinear_linear in (true, false)
+        let
+          split = split_nonlinear_linear ? "(Nonlinear, Linear)" :
+                                           "(Full, Linear)"
+          @info @sprintf """Configuration
+                            ArrayType = %s
+                            DFloat    = %s
+                            dims      = %d
+                            splitting = %s
+                            """ "$ArrayType" "$DFloat" dims split
+        end
+
+        setup = IsentropicVortexSetup{DFloat}()
+        errors = Vector{DFloat}(undef, numlevels)
+
+        for level in 1:numlevels
+          numelems = ntuple(dim -> dim == 3 ? 1 : 2 ^ (level - 1) * 5, dims)
+          errors[level] =
+            run(mpicomm, polynomialorder, numelems, setup, split_nonlinear_linear,
+                ArrayType, DFloat, dims, level)
+
+          @test errors[level] ≈ expected_error[DFloat, split_nonlinear_linear, level]
+        end
+
+        rates = @. log2(first(errors[1:numlevels-1]) / first(errors[2:numlevels]))
+        numlevels > 1 && @info "Convergence rates\n" *
+          join(["rate for levels $l → $(l + 1) = $(rates[l])" for l in 1:numlevels-1], "\n")
+      end
+    end
+  end
+end
+
+function run(mpicomm, polynomialorder, numelems, setup,
+             split_nonlinear_linear, ArrayType, DFloat, dims, level)
+  brickrange = ntuple(dims) do dim
+    range(-setup.domain_halflength; length=numelems[dim] + 1, stop=setup.domain_halflength)
+  end
+
+  topology = BrickTopology(mpicomm,
+                           brickrange;
+                           periodicity=ntuple(_ -> true, dims))
+
+  grid = DiscontinuousSpectralElementGrid(topology,
+                                          FloatType = DFloat,
+                                          DeviceArray = ArrayType,
+                                          polynomialorder = polynomialorder)
+
+  initialcondition! = function(args...)
+    isentropicvortex_initialcondition!(setup, args...)
+  end
+  
+  refstate = IsentropicVortexReferenceState{DFloat}(setup)
+
+  part = split_nonlinear_linear ? NonLinear : Full
+  model = AtmosModel{part}(NoOrientation(),
+                          split_nonlinear_linear ? refstate : NoReferenceState(),
+                          NoViscosity(),
+                          DryModel(),
+                          NoRadiation(),
+                          nothing,
+                          PeriodicBC(),
+                          initialcondition!)
+
+  model_linear = AtmosModel{Linear}(NoOrientation(),
+                                    refstate, 
+                                    NoViscosity(),
+                                    DryModel(),
+                                    NoRadiation(),
+                                    nothing,
+                                    PeriodicBC(),
+                                    (_...) -> nothing)
+
+  dg = DGModel(model, grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty())
+  dg_linear = DGModel(model_linear, grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty())
+  
+  param = init_ode_param(dg)
+  param_linear = init_ode_param(dg_linear)
+
+  timeend = DFloat(2 * setup.domain_halflength / 10 / setup.translation_speed)
+
+  # determine the time step
+  elementsize = minimum(step.(brickrange))
+  dt = elementsize / soundspeed_air(setup.T∞) / polynomialorder ^ 2
+  nsteps = ceil(Int, timeend / dt)
+  dt = timeend / nsteps
+
+  Q = init_ode_state(dg, param, DFloat(0))
+  
+  linearsolver = GeneralizedMinimalResidual(10, Q, 1e-10)
+  ode_solver = ARK2GiraldoKellyConstantinescu(dg, dg_linear, linearsolver,
+                                              Q; dt = dt, t0 = 0,
+                                              split_nonlinear_linear = split_nonlinear_linear)
+
+  eng0 = norm(Q)
+  dims == 2 && (numelems = (numelems..., 0))
+  @info @sprintf """Starting refinement level %d
+                    numelems  = (%d, %d, %d)
+                    dt        = %.16e
+                    norm(Q₀)  = %.16e
+                    """ level numelems... dt eng0
+
+  # Set up the information callback
+  starttime = Ref(now())
+  cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s=false)
+    if s
+      starttime[] = now()
+    else
+      energy = norm(Q)
+      runtime = Dates.format(convert(DateTime, now() - starttime[]), dateformat"HH:MM:SS")
+      @info @sprintf """Update
+                        simtime = %.16e
+                        runtime = %s
+                        norm(Q) = %.16e
+                        """ gettime(ode_solver) runtime energy
+    end
+  end
+  callbacks = (cbinfo,)
+
+  if output_vtk
+    # create vtk dir
+    vtkdir = "vtk_isentropicvortex" *
+      "_poly$(polynomialorder)_dims$(dims)_$(ArrayType)_$(DFloat)_level$(level)"
+    mkpath(vtkdir)
+    
+    vtkstep = 0
+    # output initial step
+    do_output(mpicomm, vtkdir, vtkstep, dg_full, Q, Q, model)
+
+    # setup the output callback
+    outputtime = timeend
+    cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+      vtkstep += 1
+      Qe = init_ode_state(dg, param, gettime(ode_solver))
+      do_output(mpicomm, vtkdir, vtkstep, dg_full, Q, Qe, model)
+    end
+    callbacks = (callbacks..., cbvtk)
+  end
+
+  solve!(Q, ode_solver, (param, param_linear); timeend=timeend, callbacks=callbacks)
+
+  # final statistics
+  Qe = init_ode_state(dg, param, timeend)
+  engf = norm(Q)
+  engfe = norm(Qe)
+  errf = euclidean_distance(Q, Qe)
+  @info @sprintf """Finished refinement level %d
+  norm(Q)                 = %.16e
+  norm(Q) / norm(Q₀)      = %.16e
+  norm(Q) - norm(Q₀)      = %.16e
+  norm(Q - Qe)            = %.16e
+  norm(Q - Qe) / norm(Qe) = %.16e
+  """ level engf engf/eng0 engf-eng0 errf errf/engfe
+  errf
+end
+
+Base.@kwdef struct IsentropicVortexSetup{DFloat}
+  p∞::DFloat = 10 ^ 5
+  T∞::DFloat = 300
+  ρ∞::DFloat = air_density(DFloat(T∞), DFloat(p∞))
+  translation_speed::DFloat = 150
+  translation_angle::DFloat = pi / 4
+  vortex_speed::DFloat = 50
+  vortex_radius::DFloat = 1 // 200
+  domain_halflength::DFloat = 1 // 20
+end
+
+struct IsentropicVortexReferenceState{DFloat} <: ReferenceState
+  setup::IsentropicVortexSetup{DFloat}
+end
+vars_aux(::IsentropicVortexReferenceState, DT) = @vars(ρ::DT, ρu::SVector{3,DT}, ρe::DT)
+function atmos_init_aux!(m::IsentropicVortexReferenceState, atmos::AtmosModel, aux::Vars, geom::LocalGeometry)
+  DFloat = eltype(aux)
+  setup = m.setup
+  ρ∞ = setup.ρ∞
+  p∞ = setup.p∞
+  T∞ = setup.T∞
+  translation_speed = setup.translation_speed
+  α = setup.translation_angle
+
+  u∞ = SVector(translation_speed * cos(α), translation_speed * sin(α), 0)
+
+  aux.ref_state.ρ = ρ∞
+  aux.ref_state.ρu = ρ∞ * u∞
+  e_kin = u∞' * u∞ / 2
+  aux.ref_state.ρe = ρ∞ * total_energy(e_kin, DFloat(0), T∞)
+end
+
+function isentropicvortex_initialcondition!(setup, state, aux, coords, t)
+  DFloat = eltype(state)
+  x = MVector(coords)
+
+  ρ∞ = setup.ρ∞
+  p∞ = setup.p∞
+  T∞ = setup.T∞
+  translation_speed = setup.translation_speed
+  α = setup.translation_angle
+  vortex_speed = setup.vortex_speed
+  R = setup.vortex_radius
+  L = setup.domain_halflength
+
+  u∞ = SVector(translation_speed * cos(α), translation_speed * sin(α), 0)
+
+  x .-= u∞ * t
+  # make the function periodic
+  x .-= floor.((x + L) / 2L) * 2L
+
+  @inbounds begin
+    r = sqrt(x[1] ^ 2 + x[2] ^ 2)
+    δu_x = -vortex_speed * x[2] / R * exp(-(r / R) ^ 2 / 2)
+    δu_y =  vortex_speed * x[1] / R * exp(-(r / R) ^ 2 / 2)
+  end
+  u = u∞ .+ SVector(δu_x, δu_y, 0)
+
+  T = T∞ * (1 - kappa_d * vortex_speed ^ 2 / 2 * ρ∞ / p∞ * exp(-(r / R) ^ 2))
+  # adiabatic/isentropic relation
+  p = p∞ * (T / T∞) ^ (DFloat(1) / kappa_d)
+  ρ = air_density(T, p)
+
+  state.ρ = ρ
+  state.ρu = ρ * u
+  e_kin = u' * u / 2
+  state.ρe = ρ * total_energy(e_kin, DFloat(0), T)
+end
+
+function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname = "isentropicvortex_imex")
+  ## name of the file that this MPI rank will write
+  filename = @sprintf("%s/%s_mpirank%04d_step%04d",
+                      vtkdir, testname, MPI.Comm_rank(mpicomm), vtkstep)
+
+  statenames = flattenednames(vars_state(model, eltype(Q)))
+  exactnames = statenames .* "_exact"
+
+  writevtk(filename, Q, dg, statenames, Qe, exactnames)
+
+  ## Generate the pvtu file for these vtk files
+  if MPI.Comm_rank(mpicomm) == 0
+    ## name of the pvtu file
+    pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+    ## name of each of the ranks vtk files
+    prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+      @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+    end
+
+    writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+
+    @info "Done writing VTK: $pvtuprefix"
+  end
+end
+
+main()


### PR DESCRIPTION
This PR:
- enables using `AtmosModel` for IMEX or split-explicit time stepping in a
  very naive way by creating two separate `AmosModel`s for the nonlinear
  and linear parts
- adds a test that that verifies this splitting using IMEX

Marking this as a draft since I am not sure that this is the way to go and there is
a bunch other issues. However, it shows roughly what is needed.