### PR TITLE
Remove the param structure of the ODE solver

### DIFF
--- a/examples/DGmethods/ex_001_dycoms.jl
+++ b/examples/DGmethods/ex_001_dycoms.jl
@@ -159,7 +159,7 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, DT, dt, C_smag, LHF, SHF
                            MPI.Comm_rank(mpicomm), step[1])
     @debug "doing VTK output" outprefix
     writevtk(outprefix, Q, dg, flattenednames(vars_state(model,DT)), 
-             param[1], flattenednames(vars_aux(model,DT)))
+             dg.auxstate, flattenednames(vars_aux(model,DT)))
         
     step[1] += 1
     nothing

--- a/examples/DGmethods/ex_001_dycoms.jl
+++ b/examples/DGmethods/ex_001_dycoms.jl
@@ -124,9 +124,7 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, DT, dt, C_smag, LHF, SHF
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-
-  Q = init_ode_state(dg, param, DT(0))
+  Q = init_ode_state(dg, DT(0))
 
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 
@@ -169,7 +167,7 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, DT, dt, C_smag, LHF, SHF
 
   # Print some end of the simulation information
   engf = norm(Q)
-  Qe = init_ode_state(dg, param, DT(timeend))
+  Qe = init_ode_state(dg, DT(timeend))
 
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)

--- a/examples/DGmethods/ex_001_dycoms.jl
+++ b/examples/DGmethods/ex_001_dycoms.jl
@@ -165,7 +165,7 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, DT, dt, C_smag, LHF, SHF
     nothing
   end
 
-  solve!(Q, lsrk, param; timeend=timeend, callbacks=(cbinfo, cbvtk))
+  solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo, cbvtk))
 
   # Print some end of the simulation information
   engf = norm(Q)

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -183,7 +183,7 @@ function diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::V
 end
 
 function update_aux!(dg::DGModel, m::AtmosModel, Q::MPIStateArray,
-                     auxstate::MPIStateArray, t::Real, _)
+                     auxstate::MPIStateArray, t::Real)
   DFloat = eltype(Q)
   if num_integrals(m, DFloat) > 0
     indefinite_stack_integral!(dg, m, Q, auxstate, t)

--- a/src/DGmethods/DGmethods.jl
+++ b/src/DGmethods/DGmethods.jl
@@ -10,7 +10,7 @@ using ..VariableTemplates
 using DocStringExtensions
 using GPUifyLoops
 
-export BalanceLaw, DGModel, init_ode_param, init_ode_state, node_apply_aux!
+export BalanceLaw, DGModel, init_ode_state, node_apply_aux!
 
 include("balancelaw.jl")
 include("DGmodel.jl")

--- a/src/DGmethods/DGmethods.jl
+++ b/src/DGmethods/DGmethods.jl
@@ -10,7 +10,7 @@ using ..VariableTemplates
 using DocStringExtensions
 using GPUifyLoops
 
-export BalanceLaw, DGModel, init_ode_state, node_apply_aux!
+export BalanceLaw, DGModel, init_ode_state
 
 include("balancelaw.jl")
 include("DGmodel.jl")

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -14,7 +14,7 @@ function DGModel(balancelaw, grid, numfluxnondiff, numfluxdiff, gradnumflux;
           diffstate)
 end
 
-function (dg::DGModel)(dQdt, Q, param, t; increment=false)
+function (dg::DGModel)(dQdt, Q, t; increment=false)
   bl = dg.balancelaw
   device = typeof(Q.Q) <: Array ? CPU() : CUDA()
 
@@ -106,10 +106,6 @@ function (dg::DGModel)(dQdt, Q, param, t; increment=false)
   MPIStateArrays.finish_ghost_send!(Qvisc)
   MPIStateArrays.finish_ghost_send!(Q)
 end
-
-
-
-
 
 """
     init_ode_param(dg::DGModel)

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -14,7 +14,7 @@ function DGModel(balancelaw, grid, numfluxnondiff, numfluxdiff, gradnumflux;
           diffstate)
 end
 
-function (dg::DGModel)(dQdt, Q, t; increment=false)
+function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment=false)
   bl = dg.balancelaw
   device = typeof(Q.Q) <: Array ? CPU() : CUDA()
 

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -46,9 +46,8 @@ function (dg::DGModel)(dQdt, Q, param, t; increment=false)
   Np = dofs_per_element(grid)
 
   if hasmethod(update_aux!, Tuple{typeof(dg), typeof(bl), typeof(Q),
-                                  typeof(auxstate), typeof(t),
-                                  typeof(param.blparam)})
-    update_aux!(dg, bl, Q, auxstate, t, param.blparam)
+                                  typeof(auxstate), typeof(t)})
+    update_aux!(dg, bl, Q, auxstate, t)
   end
 
   ########################
@@ -122,7 +121,7 @@ function init_ode_param(dg::DGModel)
   grid = dg.grid
   auxstate = create_auxstate(bl, grid)
   diffstate = create_diffstate(bl, grid)
-  return (aux=auxstate, diff=diffstate, blparam=nothing)
+  return (aux=auxstate, diff=diffstate)
 end
 function create_auxstate(bl, grid)
   topology = grid.topology

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -36,7 +36,6 @@ function vars_aux end
 function vars_gradient end
 function vars_diffusive end
 vars_integrals(::BalanceLaw, T) = @vars()
-# init_ode_param(::DGModel, ::BalanceLaw) = nothing # Defined in DGmodel.jl
 
 num_aux(m::BalanceLaw, T) = varsize(vars_aux(m,T)) 
 num_state(m::BalanceLaw, T) = varsize(vars_state(m,T)) # nstate

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -55,6 +55,29 @@ function boundary_state! end
 function init_aux! end
 function init_state! end
 
+function create_state(bl::BalanceLaw, grid, commtag)
+  topology = grid.topology
+  # FIXME: Remove after updating CUDA
+  h_vgeo = Array(grid.vgeo)
+  DFloat = eltype(h_vgeo)
+  Np = dofs_per_element(grid)
+  DA = arraytype(grid)
+
+  weights = view(h_vgeo, :, grid.Mid, :)
+  weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
+
+  state = MPIStateArray{Tuple{Np, num_state(bl,DFloat)}, DFloat,
+                        DA}(topology.mpicomm, length(topology.elems),
+                            realelems=topology.realelems,
+                            ghostelems=topology.ghostelems,
+                            vmaprecv=grid.vmaprecv, vmapsend=grid.vmapsend,
+                            nabrtorank=topology.nabrtorank,
+                            nabrtovmaprecv=grid.nabrtovmaprecv,
+                            nabrtovmapsend=grid.nabrtovmapsend, weights=weights,
+                            commtag=commtag)
+  return state
+end
+
 function create_auxstate(bl, grid, commtag=222)
   topology = grid.topology
   Np = dofs_per_element(grid)

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -54,3 +54,68 @@ function wavespeed end
 function boundary_state! end
 function init_aux! end
 function init_state! end
+
+function create_auxstate(bl, grid, commtag=222)
+  topology = grid.topology
+  Np = dofs_per_element(grid)
+
+  h_vgeo = Array(grid.vgeo)
+  DFloat = eltype(h_vgeo)
+  DA = arraytype(grid)
+
+  weights = view(h_vgeo, :, grid.Mid, :)
+  weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
+
+  auxstate = MPIStateArray{Tuple{Np, num_aux(bl,DFloat)}, DFloat, DA}(
+    topology.mpicomm,
+    length(topology.elems),
+    realelems=topology.realelems,
+    ghostelems=topology.ghostelems,
+    vmaprecv=grid.vmaprecv,
+    vmapsend=grid.vmapsend,
+    nabrtorank=topology.nabrtorank,
+    nabrtovmaprecv=grid.nabrtovmaprecv,
+    nabrtovmapsend=grid.nabrtovmapsend,
+    weights=weights,
+    commtag=commtag)
+
+  dim = dimensionality(grid)
+  polyorder = polynomialorder(grid)
+  vgeo = grid.vgeo
+  device = typeof(auxstate.Q) <: Array ? CPU() : CUDA()
+  nrealelem = length(topology.realelems)
+  @launch(device, threads=(Np,), blocks=nrealelem,
+          initauxstate!(bl, Val(dim), Val(polyorder), auxstate.Q, vgeo, topology.realelems))
+  MPIStateArrays.start_ghost_exchange!(auxstate)
+  MPIStateArrays.finish_ghost_exchange!(auxstate)
+
+  return auxstate
+end
+
+function create_diffstate(bl, grid, commtag=111)
+  topology = grid.topology
+  Np = dofs_per_element(grid)
+
+  h_vgeo = Array(grid.vgeo)
+  DFloat = eltype(h_vgeo)
+  DA = arraytype(grid)
+
+  weights = view(h_vgeo, :, grid.Mid, :)
+  weights = reshape(weights, size(weights, 1), 1, size(weights, 2))
+
+  # TODO: Clean up this MPIStateArray interface...
+  diffstate = MPIStateArray{Tuple{Np, num_diffusive(bl,DFloat)},DFloat, DA}(
+    topology.mpicomm,
+    length(topology.elems),
+    realelems=topology.realelems,
+    ghostelems=topology.ghostelems,
+    vmaprecv=grid.vmaprecv,
+    vmapsend=grid.vmapsend,
+    nabrtorank=topology.nabrtorank,
+    nabrtovmaprecv=grid.nabrtovmaprecv,
+    nabrtovmapsend=grid.nabrtovmapsend,
+    weights=weights,
+    commtag=commtag)
+
+  return diffstate
+end

--- a/src/DGmethods_old/DGBalanceLawDiscretizations.jl
+++ b/src/DGmethods_old/DGBalanceLawDiscretizations.jl
@@ -551,7 +551,7 @@ and after the call `dQ += F(Q, t)` if `increment == true`
 or `dQ = F(Q, t)` if `increment == false`
 """
 function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
-                              Q::MPIStateArray, param, t; increment)
+                              Q::MPIStateArray, t; increment)
 
   device = typeof(Q.Q) <: Array ? CPU() : CUDA()
 

--- a/src/DGmethods_old/DGBalanceLawDiscretizations.jl
+++ b/src/DGmethods_old/DGBalanceLawDiscretizations.jl
@@ -551,7 +551,7 @@ and after the call `dQ += F(Q, t)` if `increment == true`
 or `dQ = F(Q, t)` if `increment == false`
 """
 function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
-                              Q::MPIStateArray, t; increment)
+                              Q::MPIStateArray, ::Nothing, t; increment)
 
   device = typeof(Q.Q) <: Array ? CPU() : CUDA()
 

--- a/src/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -324,8 +324,7 @@ end
 
 ODEs.updatedt!(ark::AdditiveRungeKutta, dt) = ark.dt[1] = dt
 
-function ODEs.dostep!(Q, ark::AdditiveRungeKutta, (param, param_linear),
-                      timeend, adjustfinalstep)
+function ODEs.dostep!(Q, ark::AdditiveRungeKutta, timeend, adjustfinalstep)
 
   time, dt = ark.t[1], ark.dt[1]
   if adjustfinalstep && time + dt > timeend
@@ -353,7 +352,7 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, (param, param_linear),
   blocks = div(length(rv_Q) + threads - 1, threads)
 
   # calculate the rhs at first stage to initialize the stage loop
-  rhs!(Rstages[1], Qstages[1], param, time + RKC[1] * dt, increment = false)
+  rhs!(Rstages[1], Qstages[1], time + RKC[1] * dt, increment = false)
 
   # note that it is important that this loop does not modify Q!
   for istage = 2:nstages
@@ -367,7 +366,7 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, (param, param_linear),
     #solves Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_linear!(Q_tt)
     α = dt * RKA_implicit[istage, istage]
     linearoperator! = function(LQ, Q)
-      rhs_linear!(LQ, Q, param_linear, stagetime; increment = false)
+      rhs_linear!(LQ, Q, stagetime; increment = false)
       @. LQ = Q - α * LQ
     end
     linearsolve!(linearoperator!, Qtt, Qhat, linearsolver)
@@ -375,13 +374,13 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, (param, param_linear),
     #update Qstages
     Qstages[istage] .+= Qtt
     
-    rhs!(Rstages[istage], Qstages[istage], param, stagetime, increment = false)
+    rhs!(Rstages[istage], Qstages[istage], stagetime, increment = false)
   end
  
   if split_nonlinear_linear
     for istage = 1:nstages
       stagetime = time + RKC[istage] * dt
-      rhs_linear!(Rstages[istage], Qstages[istage], param_linear, stagetime, increment = true)
+      rhs_linear!(Rstages[istage], Qstages[istage], stagetime, increment = true)
     end
   end
 

--- a/src/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -324,7 +324,7 @@ end
 
 ODEs.updatedt!(ark::AdditiveRungeKutta, dt) = ark.dt[1] = dt
 
-function ODEs.dostep!(Q, ark::AdditiveRungeKutta, timeend, adjustfinalstep)
+function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, timeend, adjustfinalstep)
 
   time, dt = ark.t[1], ark.dt[1]
   if adjustfinalstep && time + dt > timeend
@@ -352,7 +352,7 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, timeend, adjustfinalstep)
   blocks = div(length(rv_Q) + threads - 1, threads)
 
   # calculate the rhs at first stage to initialize the stage loop
-  rhs!(Rstages[1], Qstages[1], time + RKC[1] * dt, increment = false)
+  rhs!(Rstages[1], Qstages[1], p, time + RKC[1] * dt, increment = false)
 
   # note that it is important that this loop does not modify Q!
   for istage = 2:nstages
@@ -366,7 +366,7 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, timeend, adjustfinalstep)
     #solves Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_linear!(Q_tt)
     α = dt * RKA_implicit[istage, istage]
     linearoperator! = function(LQ, Q)
-      rhs_linear!(LQ, Q, stagetime; increment = false)
+      rhs_linear!(LQ, Q, p, stagetime; increment = false)
       @. LQ = Q - α * LQ
     end
     linearsolve!(linearoperator!, Qtt, Qhat, linearsolver)
@@ -374,13 +374,13 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, timeend, adjustfinalstep)
     #update Qstages
     Qstages[istage] .+= Qtt
     
-    rhs!(Rstages[istage], Qstages[istage], stagetime, increment = false)
+    rhs!(Rstages[istage], Qstages[istage], p, stagetime, increment = false)
   end
  
   if split_nonlinear_linear
     for istage = 1:nstages
       stagetime = time + RKC[istage] * dt
-      rhs_linear!(Rstages[istage], Qstages[istage], stagetime, increment = true)
+      rhs_linear!(Rstages[istage], Qstages[istage], p, stagetime, increment = true)
     end
   end
 

--- a/src/ODESolvers/LowStorageRungeKuttaMethod.jl
+++ b/src/ODESolvers/LowStorageRungeKuttaMethod.jl
@@ -72,7 +72,8 @@ end
 
 ODEs.updatedt!(lsrk::LowStorageRungeKutta2N, dt) = lsrk.dt[1] = dt
 
-function ODEs.dostep!(Q, lsrk::LowStorageRungeKutta2N, timeend, adjustfinalstep)
+function ODEs.dostep!(Q, lsrk::LowStorageRungeKutta2N, p, timeend,
+                      adjustfinalstep)
   time, dt = lsrk.t[1], lsrk.dt[1]
   if adjustfinalstep && time + dt > timeend
     dt = timeend - time
@@ -88,7 +89,7 @@ function ODEs.dostep!(Q, lsrk::LowStorageRungeKutta2N, timeend, adjustfinalstep)
   blocks = div(length(rv_Q) + threads - 1, threads)
 
   for s = 1:length(RKA)
-    rhs!(dQ, Q, time + RKC[s] * dt, increment = true)
+    rhs!(dQ, Q, p, time + RKC[s] * dt, increment = true)
     # update solution and scale RHS
     @launch(device(Q), threads=threads, blocks=blocks,
             update!(rv_dQ, rv_Q, RKA[s%length(RKA)+1], RKB[s], dt))

--- a/src/ODESolvers/LowStorageRungeKuttaMethod.jl
+++ b/src/ODESolvers/LowStorageRungeKuttaMethod.jl
@@ -72,8 +72,7 @@ end
 
 ODEs.updatedt!(lsrk::LowStorageRungeKutta2N, dt) = lsrk.dt[1] = dt
 
-function ODEs.dostep!(Q, lsrk::LowStorageRungeKutta2N, param, timeend,
-                      adjustfinalstep)
+function ODEs.dostep!(Q, lsrk::LowStorageRungeKutta2N, timeend, adjustfinalstep)
   time, dt = lsrk.t[1], lsrk.dt[1]
   if adjustfinalstep && time + dt > timeend
     dt = timeend - time
@@ -89,7 +88,7 @@ function ODEs.dostep!(Q, lsrk::LowStorageRungeKutta2N, param, timeend,
   blocks = div(length(rv_Q) + threads - 1, threads)
 
   for s = 1:length(RKA)
-    rhs!(dQ, Q, param, time + RKC[s] * dt, increment = true)
+    rhs!(dQ, Q, time + RKC[s] * dt, increment = true)
     # update solution and scale RHS
     @launch(device(Q), threads=threads, blocks=blocks,
             update!(rv_dQ, rv_Q, RKA[s%length(RKA)+1], RKB[s], dt))

--- a/src/ODESolvers/ODESolvers.jl
+++ b/src/ODESolvers/ODESolvers.jl
@@ -30,7 +30,7 @@ updated inplace. The final time `timeend` or `numberofsteps` must be specified.
 A series of optional callback functions can be specified using the tuple
 `callbacks`; see [`GenericCallbacks`](@ref).
 """
-function solve!(Q, solver::AbstractODESolver, param=nothing; timeend::Real=Inf,
+function solve!(Q, solver::AbstractODESolver; timeend::Real=Inf,
                 adjustfinalstep=true, numberofsteps::Integer=0, callbacks=())
 
   @assert isfinite(timeend) || numberofsteps > 0

--- a/src/ODESolvers/ODESolvers.jl
+++ b/src/ODESolvers/ODESolvers.jl
@@ -30,7 +30,7 @@ updated inplace. The final time `timeend` or `numberofsteps` must be specified.
 A series of optional callback functions can be specified using the tuple
 `callbacks`; see [`GenericCallbacks`](@ref).
 """
-function solve!(Q, solver::AbstractODESolver; timeend::Real=Inf,
+function solve!(Q, solver::AbstractODESolver, p=nothing; timeend::Real=Inf,
                 adjustfinalstep=true, numberofsteps::Integer=0, callbacks=())
 
   @assert isfinite(timeend) || numberofsteps > 0
@@ -50,7 +50,7 @@ function solve!(Q, solver::AbstractODESolver; timeend::Real=Inf,
   while time < timeend
     step += 1
 
-    time = dostep!(Q, solver, timeend, adjustfinalstep)
+    time = dostep!(Q, solver, p, timeend, adjustfinalstep)
 
     # FIXME: Determine better way to handle postcallback behavior
     # Current behavior:

--- a/src/ODESolvers/ODESolvers.jl
+++ b/src/ODESolvers/ODESolvers.jl
@@ -50,7 +50,7 @@ function solve!(Q, solver::AbstractODESolver, param=nothing; timeend::Real=Inf,
   while time < timeend
     step += 1
 
-    time = dostep!(Q, solver, param, timeend, adjustfinalstep)
+    time = dostep!(Q, solver, timeend, adjustfinalstep)
 
     # FIXME: Determine better way to handle postcallback behavior
     # Current behavior:

--- a/src/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
+++ b/src/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
@@ -69,7 +69,7 @@ end
 
 ODEs.updatedt!(ssp::StrongStabilityPreservingRungeKutta, dt) = ssp.dt[1] = dt
 
-function ODEs.dostep!(Q, ssp::StrongStabilityPreservingRungeKutta, timeend,
+function ODEs.dostep!(Q, ssp::StrongStabilityPreservingRungeKutta, p, timeend,
                       adjustfinalstep)
   time, dt = ssp.t[1], ssp.dt[1]
   if adjustfinalstep && time + dt > timeend
@@ -89,7 +89,7 @@ function ODEs.dostep!(Q, ssp::StrongStabilityPreservingRungeKutta, timeend,
   
   rv_Qstage .= rv_Q
   for s = 1:length(RKB)
-    rhs!(Rstage, Qstage, time + RKC[s] * dt, increment = false)
+    rhs!(Rstage, Qstage, p, time + RKC[s] * dt, increment = false)
   
     @launch(device(Q), threads = threads, blocks = blocks,
             update!(rv_Rstage, rv_Q, rv_Qstage, RKA[s,1], RKA[s,2], RKB[s], dt))

--- a/src/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
+++ b/src/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
@@ -69,7 +69,8 @@ end
 
 ODEs.updatedt!(ssp::StrongStabilityPreservingRungeKutta, dt) = ssp.dt[1] = dt
 
-function ODEs.dostep!(Q, ssp::StrongStabilityPreservingRungeKutta, param, timeend, adjustfinalstep)
+function ODEs.dostep!(Q, ssp::StrongStabilityPreservingRungeKutta, timeend,
+                      adjustfinalstep)
   time, dt = ssp.t[1], ssp.dt[1]
   if adjustfinalstep && time + dt > timeend
     dt = timeend - time
@@ -88,7 +89,7 @@ function ODEs.dostep!(Q, ssp::StrongStabilityPreservingRungeKutta, param, timeen
   
   rv_Qstage .= rv_Q
   for s = 1:length(RKB)
-    rhs!(Rstage, Qstage, param, time + RKC[s] * dt, increment = false)
+    rhs!(Rstage, Qstage, time + RKC[s] * dt, increment = false)
   
     @launch(device(Q), threads = threads, blocks = blocks,
             update!(rv_Rstage, rv_Q, rv_Qstage, RKA[s,1], RKA[s,2], RKB[s], dt))

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -1,7 +1,7 @@
 using CLIMA: haspkg
 using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
-using CLIMA.DGmethods: DGModel, init_ode_param, init_ode_state
+using CLIMA.DGmethods: DGModel, init_ode_state
 using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
                                        CentralNumericalFluxDiffusive,
                                        CentralNumericalFluxNonDiffusive
@@ -160,7 +160,6 @@ function run(mpicomm, polynomialorder, numelems,
 
   dg = DGModel(model, grid, NumericalFlux(),
                CentralNumericalFluxDiffusive(), CentralGradPenalty())
-  param = init_ode_param(dg)
 
   timeend = DFloat(2 * setup.domain_halflength / 10 / setup.translation_speed)
 
@@ -170,7 +169,7 @@ function run(mpicomm, polynomialorder, numelems,
   nsteps = ceil(Int, timeend / dt)
   dt = timeend / nsteps
 
-  Q = init_ode_state(dg, param, DFloat(0))
+  Q = init_ode_state(dg, DFloat(0))
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 
   eng0 = norm(Q)
@@ -212,7 +211,7 @@ function run(mpicomm, polynomialorder, numelems,
     outputtime = timeend
     cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
       vtkstep += 1
-      Qe = init_ode_state(dg, param, gettime(lsrk))
+      Qe = init_ode_state(dg, gettime(lsrk))
       do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model)
     end
     callbacks = (callbacks..., cbvtk)
@@ -221,7 +220,7 @@ function run(mpicomm, polynomialorder, numelems,
   solve!(Q, lsrk; timeend=timeend, callbacks=callbacks)
 
   # final statistics
-  Qe = init_ode_state(dg, param, timeend)
+  Qe = init_ode_state(dg, timeend)
   engf = norm(Q)
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -218,7 +218,7 @@ function run(mpicomm, polynomialorder, numelems,
     callbacks = (callbacks..., cbvtk)
   end
 
-  solve!(Q, lsrk, param; timeend=timeend, callbacks=callbacks)
+  solve!(Q, lsrk; timeend=timeend, callbacks=callbacks)
 
   # final statistics
   Qe = init_ode_state(dg, param, timeend)

--- a/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
@@ -127,9 +127,7 @@ function run(mpicomm, ArrayType,
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-
-  Q = init_ode_state(dg, param, DF(0))
+  Q = init_ode_state(dg, DF(0))
 
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 
@@ -172,7 +170,7 @@ function run(mpicomm, ArrayType,
   solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo,cbvtk))
   # End of the simulation information
   engf = norm(Q)
-  Qe = init_ode_state(dg, param, DF(timeend))
+  Qe = init_ode_state(dg, DF(timeend))
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)
   @info @sprintf """Finished

--- a/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
@@ -169,7 +169,7 @@ function run(mpicomm, ArrayType,
   end
 
 
-  solve!(Q, lsrk, param; timeend=timeend, callbacks=(cbinfo,cbvtk))
+  solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo,cbvtk))
   # End of the simulation information
   engf = norm(Q)
   Qe = init_ode_state(dg, param, DF(timeend))

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -134,9 +134,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-
-  Q = init_ode_state(dg, param, DFloat(0))
+  Q = init_ode_state(dg, DFloat(0))
 
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 
@@ -168,7 +166,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
 
   # Print some end of the simulation information
   engf = norm(Q)
-  Qe = init_ode_state(dg, param, DFloat(timeend))
+  Qe = init_ode_state(dg, DFloat(timeend))
 
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -162,8 +162,8 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
     end
   end
 
-  solve!(Q, lsrk, param; timeend=timeend, callbacks=(cbinfo, ))
-  # solve!(Q, lsrk, param; timeend=timeend, callbacks=(cbinfo, cbvtk))
+  solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo, ))
+  # solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo, cbvtk))
 
 
   # Print some end of the simulation information

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
@@ -77,8 +77,8 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
     end
   end
 
-  solve!(Q, lsrk, param; timeend=timeend, callbacks=(cbinfo, ))
-  # solve!(Q, lsrk, param; timeend=timeend, callbacks=(cbinfo, cbvtk))
+  solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo, ))
+  # solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo, cbvtk))
 
 
   # Print some end of the simulation information

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
@@ -48,9 +48,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-
-  Q = init_ode_state(dg, param, DFloat(0))
+  Q = init_ode_state(dg, DFloat(0))
 
 
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
@@ -83,7 +81,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, DFloat, dt)
 
   # Print some end of the simulation information
   engf = norm(Q)
-  Qe = init_ode_state(dg, param, DFloat(timeend))
+  Qe = init_ode_state(dg, DFloat(timeend))
 
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)

--- a/test/DGmethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_model.jl
@@ -4,7 +4,7 @@ import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
                         vars_diffusive, flux_nondiffusive!, flux_diffusive!,
                         source!, wavespeed, boundary_state!,
                         gradvariables!,
-                        diffusive!, init_aux!, init_state!, init_ode_param,
+                        diffusive!, init_aux!, init_state!,
                         init_ode_state, LocalGeometry
 
 

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -34,7 +34,7 @@ end
 
 using CLIMA.Atmos
 using CLIMA.Atmos: internal_energy, thermo_state
-import CLIMA.Atmos: MoistureModel, temperature, pressure, soundspeed, update_aux!
+import CLIMA.Atmos: MoistureModel, temperature, pressure, soundspeed
 
 init_state!(state, aux, coords, t) = nothing
 

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -66,9 +66,7 @@ function run1(mpicomm, ArrayType, dim, topl, N, timeend, DFloat, dt)
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-
-  Q = init_ode_state(dg, param, DFloat(0))
+  Q = init_ode_state(dg, DFloat(0))
 
   mkpath("vtk")
   outprefix = @sprintf("vtk/refstate")
@@ -101,9 +99,7 @@ function run2(mpicomm, ArrayType, dim, topl, N, timeend, DFloat, dt)
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-
-  Q = init_ode_state(dg, param, DFloat(0))
+  Q = init_ode_state(dg, DFloat(0))
 
   mkpath("vtk")
   outprefix = @sprintf("vtk/refstate")

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -72,7 +72,7 @@ function run1(mpicomm, ArrayType, dim, topl, N, timeend, DFloat, dt)
 
   mkpath("vtk")
   outprefix = @sprintf("vtk/refstate")
-  writevtk(outprefix, param[1], dg, flattenednames(vars_aux(model, DFloat)))
+  writevtk(outprefix, dg.auxstate, dg, flattenednames(vars_aux(model, DFloat)))
   return DFloat(0)
 end
 
@@ -107,7 +107,7 @@ function run2(mpicomm, ArrayType, dim, topl, N, timeend, DFloat, dt)
 
   mkpath("vtk")
   outprefix = @sprintf("vtk/refstate")
-  writevtk(outprefix, param[1], dg, flattenednames(vars_aux(model, DFloat)))
+  writevtk(outprefix, dg.auxstate, dg, flattenednames(vars_aux(model, DFloat)))
   return DFloat(0)
 end
 

--- a/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl
@@ -121,9 +121,7 @@ function run(mpicomm, ArrayType,
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-
-  Q = init_ode_state(dg, param, DF(0))
+  Q = init_ode_state(dg, DF(0))
 
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 
@@ -165,7 +163,7 @@ function run(mpicomm, ArrayType,
   solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo,cbvtk))
   # End of the simulation information
   engf = norm(Q)
-  Qe = init_ode_state(dg, param, DF(timeend))
+  Qe = init_ode_state(dg, DF(timeend))
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)
   @info @sprintf """Finished

--- a/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl
@@ -162,7 +162,7 @@ function run(mpicomm, ArrayType,
       nothing
   end
 
-  solve!(Q, lsrk, param; timeend=timeend, callbacks=(cbinfo,cbvtk))
+  solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo,cbvtk))
   # End of the simulation information
   engf = norm(Q)
   Qe = init_ode_state(dg, param, DF(timeend))

--- a/test/DGmethods/integral_test.jl
+++ b/test/DGmethods/integral_test.jl
@@ -62,7 +62,7 @@ function init_aux!(::IntegralTestModel{dim}, aux::Vars,
 end
 
 function update_aux!(dg::DGModel, m::IntegralTestModel, Q::MPIStateArray,
-                     auxstate::MPIStateArray, t::Real, _)
+                     auxstate::MPIStateArray, t::Real)
   indefinite_stack_integral!(dg, m, Q, auxstate, t)
   reverse_indefinite_stack_integral!(dg, m, auxstate, t)
 end

--- a/test/DGmethods/integral_test.jl
+++ b/test/DGmethods/integral_test.jl
@@ -101,8 +101,8 @@ function run(mpicomm, dim, ArrayType, Ne, N, DFloat)
   dg(dQdt, Q, param, 0.0)
 
   # Wrapping in Array ensure both GPU and CPU code use same approx
-  @test Array(param.aux.Q[:, 1, :]) ≈ Array(param.aux.Q[:, 8, :])
-  @test Array(param.aux.Q[:, 2, :]) ≈ Array(param.aux.Q[:, 9, :])
+  @test Array(dg.auxstate.Q[:, 1, :]) ≈ Array(dg.auxstate.Q[:, 8, :])
+  @test Array(dg.auxstate.Q[:, 2, :]) ≈ Array(dg.auxstate.Q[:, 9, :])
 end
 
 let

--- a/test/DGmethods/integral_test.jl
+++ b/test/DGmethods/integral_test.jl
@@ -97,7 +97,7 @@ function run(mpicomm, dim, ArrayType, Ne, N, DFloat)
   Q = init_ode_state(dg, DFloat(0))
   dQdt = similar(Q)
 
-  dg(dQdt, Q, 0.0)
+  dg(dQdt, Q, nothing, 0.0)
 
   # Wrapping in Array ensure both GPU and CPU code use same approx
   @test Array(dg.auxstate.Q[:, 1, :]) ≈ Array(dg.auxstate.Q[:, 8, :])

--- a/test/DGmethods/integral_test.jl
+++ b/test/DGmethods/integral_test.jl
@@ -27,7 +27,7 @@ import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
                         flux_nondiffusive!, flux_diffusive!, source!, wavespeed,
                         update_aux!, indefinite_stack_integral!,
                         reverse_indefinite_stack_integral!,  boundary_state!,
-                        init_aux!, init_state!, init_ode_param, init_ode_state,
+                        init_aux!, init_state!, init_ode_state,
                         LocalGeometry
 
 
@@ -94,11 +94,10 @@ function run(mpicomm, dim, ArrayType, Ne, N, DFloat)
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-  Q = init_ode_state(dg, param, DFloat(0))
+  Q = init_ode_state(dg, DFloat(0))
   dQdt = similar(Q)
 
-  dg(dQdt, Q, param, 0.0)
+  dg(dQdt, Q, 0.0)
 
   # Wrapping in Array ensure both GPU and CPU code use same approx
   @test Array(dg.auxstate.Q[:, 1, :]) ≈ Array(dg.auxstate.Q[:, 8, :])

--- a/test/DGmethods/integral_test_sphere.jl
+++ b/test/DGmethods/integral_test_sphere.jl
@@ -27,7 +27,7 @@ import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
                         flux_nondiffusive!, flux_diffusive!, source!, wavespeed,
                         update_aux!, indefinite_stack_integral!,
                         reverse_indefinite_stack_integral!,  boundary_state!,
-                        gradvariables!, init_aux!, init_state!, init_ode_param,
+                        gradvariables!, init_aux!, init_state!,
                         init_ode_state, LocalGeometry
 
 
@@ -94,13 +94,12 @@ function run(mpicomm, topl, ArrayType, N, DFloat, Rinner, Router)
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-  Q = init_ode_state(dg, param, DFloat(0))
+  Q = init_ode_state(dg, DFloat(0))
   dQdt = similar(Q)
 
   exact_aux = copy(dg.auxstate)
 
-  dg(dQdt, Q, param, 0.0)
+  dg(dQdt, Q, 0.0)
   
   euclidean_distance(exact_aux, dg.auxstate)
 end

--- a/test/DGmethods/integral_test_sphere.jl
+++ b/test/DGmethods/integral_test_sphere.jl
@@ -99,7 +99,7 @@ function run(mpicomm, topl, ArrayType, N, DFloat, Rinner, Router)
 
   exact_aux = copy(dg.auxstate)
 
-  dg(dQdt, Q, 0.0)
+  dg(dQdt, Q, nothing, 0.0)
   
   euclidean_distance(exact_aux, dg.auxstate)
 end

--- a/test/DGmethods/integral_test_sphere.jl
+++ b/test/DGmethods/integral_test_sphere.jl
@@ -98,11 +98,11 @@ function run(mpicomm, topl, ArrayType, N, DFloat, Rinner, Router)
   Q = init_ode_state(dg, param, DFloat(0))
   dQdt = similar(Q)
 
-  exact_aux = copy(param.aux)
+  exact_aux = copy(dg.auxstate)
 
   dg(dQdt, Q, param, 0.0)
   
-  euclidean_distance(exact_aux, param.aux)
+  euclidean_distance(exact_aux, dg.auxstate)
 end
 
 let

--- a/test/DGmethods/integral_test_sphere.jl
+++ b/test/DGmethods/integral_test_sphere.jl
@@ -37,7 +37,7 @@ struct IntegralTestSphereModel{T} <: BalanceLaw
 end
 
 function update_aux!(dg::DGModel, m::IntegralTestSphereModel, Q::MPIStateArray,
-                     auxstate::MPIStateArray, t::Real, _)
+                     auxstate::MPIStateArray, t::Real)
   indefinite_stack_integral!(dg, m, Q, auxstate, t)
   reverse_indefinite_stack_integral!(dg, m, auxstate, t)
 end

--- a/test/DGmethods_old/Euler/RTB_IMEX.jl
+++ b/test/DGmethods_old/Euler/RTB_IMEX.jl
@@ -371,8 +371,7 @@ function run(mpicomm, dim, brickrange, periodicity, N, timeend, DFloat, dt, outp
     nothing
   end
 
-  param = (nothing, nothing)
-  solve!(Q, timestepper, param; timeend=timeend, callbacks=(cbinfo, cbvtk))
+  solve!(Q, timestepper; timeend=timeend, callbacks=(cbinfo, cbvtk))
 
   # Print some end of the simulation information
   engf = norm(Q)

--- a/test/DGmethods_old/Euler/isentropic_vortex_standalone_IMEX.jl
+++ b/test/DGmethods_old/Euler/isentropic_vortex_standalone_IMEX.jl
@@ -318,8 +318,7 @@ function main(mpicomm, DFloat, topl::AbstractTopology{dim}, N, timeend,
     nothing
   end
 
-  param = (nothing, nothing)
-  solve!(Q, ark, param; timeend=timeend, callbacks=(cbinfo, cbvtk))
+  solve!(Q, ark; timeend=timeend, callbacks=(cbinfo, cbvtk))
 
   # Print some end of the simulation information
   engf = norm(Q)

--- a/test/LinearSolvers/poisson.jl
+++ b/test/LinearSolvers/poisson.jl
@@ -100,7 +100,8 @@ function run(mpicomm, ArrayType, DFloat, dim, polynomialorder, brickrange, perio
   Qrhs = MPIStateArray(spacedisc, (args...) -> rhs!(dim, args...))
   Qexact = MPIStateArray(spacedisc, (args...) -> exactsolution!(dim, args...))
 
-  linearoperator!(y, x) = SpaceMethods.odefun!(spacedisc, y, x, 0, increment = false)
+  linearoperator!(y, x) = SpaceMethods.odefun!(spacedisc, y, x, nothing, 0;
+                                               increment = false)
 
   linearsolver = linmethod(Q)
 

--- a/test/LinearSolvers/poisson.jl
+++ b/test/LinearSolvers/poisson.jl
@@ -100,7 +100,7 @@ function run(mpicomm, ArrayType, DFloat, dim, polynomialorder, brickrange, perio
   Qrhs = MPIStateArray(spacedisc, (args...) -> rhs!(dim, args...))
   Qexact = MPIStateArray(spacedisc, (args...) -> exactsolution!(dim, args...))
 
-  linearoperator!(y, x) = SpaceMethods.odefun!(spacedisc, y, x, nothing, 0, increment = false)
+  linearoperator!(y, x) = SpaceMethods.odefun!(spacedisc, y, x, 0, increment = false)
 
   linearsolver = linmethod(Q)
 

--- a/test/ODESolvers/runtests.jl
+++ b/test/ODESolvers/runtests.jl
@@ -164,8 +164,7 @@ let
           solver = method(rhs!, rhs_linear!, DivideLinearSolver(),
                           Q; dt = dt, t0 = 0.0,
                           split_nonlinear_linear = split_nonlinear_linear)
-          param = (nothing, nothing)
-          solve!(Q, solver, param; timeend = finaltime)
+          solve!(Q, solver; timeend = finaltime)
           errors[n] = abs(Q[1] - exactsolution(q0, finaltime))
         end
 
@@ -195,8 +194,7 @@ let
             solver = method(rhs!, rhs_linear!, DivideLinearSolver(),
                             Q; dt = dt, t0 = 0.0,
                             split_nonlinear_linear = split_nonlinear_linear)
-            param = (nothing, nothing)
-            solve!(Q, solver, param; timeend = finaltime)
+            solve!(Q, solver; timeend = finaltime)
             Q = Array(Q)
             errors[n] = maximum(abs.(Q - exactsolution.(q0s, finaltime)))
           end

--- a/test/ODESolvers/runtests.jl
+++ b/test/ODESolvers/runtests.jl
@@ -17,7 +17,7 @@ const imex_methods = [(ARK2GiraldoKellyConstantinescu, 2),
                      ]
 
 let 
-  function rhs!(dQ, Q, param, time; increment)
+  function rhs!(dQ, Q, time; increment)
     if increment
       dQ .+= Q * cos(time)
     else
@@ -115,7 +115,7 @@ end
 
 let 
   c = 100.0
-  function rhs_full!(dQ, Q, param, time; increment)
+  function rhs_full!(dQ, Q, time; increment)
     if increment
       dQ .+= im * c * Q .+ exp(im * time)
     else
@@ -123,7 +123,7 @@ let
     end
   end
   
-  function rhs_nonlinear!(dQ, Q, param, time; increment)
+  function rhs_nonlinear!(dQ, Q, time; increment)
     if increment
       dQ .+= exp(im * time)
     else
@@ -131,7 +131,7 @@ let
     end
   end
  
-  function rhs_linear!(dQ, Q, param, time; increment)
+  function rhs_linear!(dQ, Q, time; increment)
     if increment
       dQ .+= im * c * Q
     else

--- a/test/ODESolvers/runtests.jl
+++ b/test/ODESolvers/runtests.jl
@@ -17,7 +17,7 @@ const imex_methods = [(ARK2GiraldoKellyConstantinescu, 2),
                      ]
 
 let 
-  function rhs!(dQ, Q, time; increment)
+  function rhs!(dQ, Q, ::Nothing, time; increment)
     if increment
       dQ .+= Q * cos(time)
     else
@@ -115,7 +115,7 @@ end
 
 let 
   c = 100.0
-  function rhs_full!(dQ, Q, time; increment)
+  function rhs_full!(dQ, Q, ::Nothing, time; increment)
     if increment
       dQ .+= im * c * Q .+ exp(im * time)
     else
@@ -123,7 +123,7 @@ let
     end
   end
   
-  function rhs_nonlinear!(dQ, Q, time; increment)
+  function rhs_nonlinear!(dQ, Q, ::Nothing, time; increment)
     if increment
       dQ .+= exp(im * time)
     else
@@ -131,7 +131,7 @@ let
     end
   end
  
-  function rhs_linear!(dQ, Q, time; increment)
+  function rhs_linear!(dQ, Q, ::Nothing, time; increment)
     if increment
       dQ .+= im * c * Q
     else

--- a/test/Ocean/shallow_water/GyreDriver.jl
+++ b/test/Ocean/shallow_water/GyreDriver.jl
@@ -136,7 +136,7 @@ function run(mpicomm, topl, ArrayType, N, dt, DFloat, model, test)
     cb = (cb..., cbvtk)
   end
 
-  solve!(Q, lsrk, param; timeend=timeend, callbacks=cb)
+  solve!(Q, lsrk; timeend=timeend, callbacks=cb)
 
   error = euclidean_distance(Q, Qe) / norm(Qe)
   @info @sprintf("""Finished

--- a/test/Ocean/shallow_water/GyreDriver.jl
+++ b/test/Ocean/shallow_water/GyreDriver.jl
@@ -113,12 +113,12 @@ function run(mpicomm, topl, ArrayType, N, dt, DFloat, model, test)
     outprefix = @sprintf("ic_mpirank%04d_ic", MPI.Comm_rank(mpicomm))
     statenames = flattenednames(vars_state(model, eltype(Q)))
     auxnames = flattenednames(vars_aux(model, eltype(Q)))
-    writevtk(outprefix, Q, dg, statenames, param.aux, auxnames)
+    writevtk(outprefix, Q, dg, statenames, dg.auxstate, auxnames)
 
     outprefix = @sprintf("exact_mpirank%04d", MPI.Comm_rank(mpicomm))
     statenames = flattenednames(vars_state(model, eltype(Qe)))
     auxnames = flattenednames(vars_aux(model, eltype(Qe)))
-    writevtk(outprefix, Qe, dg, statenames, param.aux, auxnames)
+    writevtk(outprefix, Qe, dg, statenames, dg.auxstate, auxnames)
 
     step = [0]
     vtkpath = outname
@@ -129,7 +129,7 @@ function run(mpicomm, topl, ArrayType, N, dt, DFloat, model, test)
       @debug "doing VTK output" outprefix
       statenames = flattenednames(vars_state(model, eltype(Q)))
       auxnames = flattenednames(vars_aux(model, eltype(Q)))
-      writevtk(outprefix, Q, dg, statenames, param.aux, auxnames)
+      writevtk(outprefix, Q, dg, statenames, dg.auxstate, auxnames)
       step[1] += 1
       nothing
     end

--- a/test/Ocean/shallow_water/GyreDriver.jl
+++ b/test/Ocean/shallow_water/GyreDriver.jl
@@ -101,9 +101,8 @@ function run(mpicomm, topl, ArrayType, N, dt, DFloat, model, test)
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
 
-  param = init_ode_param(dg)
-  Q  = init_ode_state(dg, param, DFloat(0))
-  Qe = init_ode_state(dg, param, DFloat(timeend))
+  Q  = init_ode_state(dg, DFloat(0))
+  Qe = init_ode_state(dg, DFloat(timeend))
 
   lsrk = LSRK144NiegemannDiehlBusch(dg, Q; dt = dt, t0 = 0)
 


### PR DESCRIPTION
Removes the `params` from the ODE solver interface and merges previously stored data into the `DGmodel`.

The `params` was complicating the ODE interface when multiple balance laws are needed (e.g., IMEX and multirate). The interface I added should also simplify the sharing of `auxstate` and `diffstate` (which is really just scratch space) between different DGmodels