### PR TITLE
AtmosModel: move total specific enthalpy to top level

### DIFF
--- a/examples/DGmethods/ex_001_dycoms.jl
+++ b/examples/DGmethods/ex_001_dycoms.jl
@@ -236,7 +236,7 @@ let
     @info (ArrayType, DT, dim)
     result = run(mpicomm, ArrayType, dim, topl, 
                  polynomialorder, timeend, DT, dt, C_smag, LHF, SHF, C_drag, zmax, zsponge)
-    @test result ≈ DT(0.9999737128867487)
+    @test result ≈ DT(0.9999712407365311)
   end
 end
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -44,11 +44,6 @@ struct AtmosModel{O,RS,T,M,R,S,BC,IS} <: BalanceLaw
   init_state::IS
 end
 
-# defined here so that the main variables and flux definitions
-# can be found in this file since some of these are specialized for NoViscosity
-abstract type TurbulenceClosure end
-struct NoViscosity <: TurbulenceClosure end
-
 function vars_state(m::AtmosModel, T)
   @vars begin
     ρ::T
@@ -59,28 +54,23 @@ function vars_state(m::AtmosModel, T)
     radiation::vars_state(m.radiation,T)
   end
 end
-
-vars_gradient(m::AtmosModel, T) = vars_gradient(m, T, m.turbulence)
-function vars_gradient(m::AtmosModel, T, ::TurbulenceClosure)
+function vars_gradient(m::AtmosModel, T)
   @vars begin
     u::SVector{3,T}
+    h_tot::T
     turbulence::vars_gradient(m.turbulence,T)
     moisture::vars_gradient(m.moisture,T)
-    radiation::vars_gradient(m.radiation,T)
   end
 end
-vars_gradient(m::AtmosModel, T, ::NoViscosity) = @vars()
-
-vars_diffusive(m::AtmosModel, T) = vars_diffusive(m, T, m.turbulence)
-function vars_diffusive(m::AtmosModel, T, ::TurbulenceClosure)
+function vars_diffusive(m::AtmosModel, T)
   @vars begin
     ρτ::SHermitianCompact{3,T,6}
+    ρd_h_tot::SVector{3,T}
     turbulence::vars_diffusive(m.turbulence,T)
     moisture::vars_diffusive(m.moisture,T)
-    radiation::vars_diffusive(m.radiation,T)
   end
 end
-vars_diffusive(m::AtmosModel, T, ::NoViscosity) = @vars()
+
 
 function vars_aux(m::AtmosModel, T)
   @vars begin
@@ -119,95 +109,78 @@ Where
 """
 @inline function flux_nondiffusive!(m::AtmosModel, flux::Grad, state::Vars,
                                     aux::Vars, t::Real)
-  flux_advective!(m, flux, state, aux, t)
-  flux_pressure!(m, flux, state, aux, t)
-  flux_radiation!(m, flux, state, aux, t)
-end
-
-@inline function flux_advective!(m::AtmosModel, flux::Grad, state::Vars,
-                                 aux::Vars, t::Real)
-  # preflux
   ρinv = 1/state.ρ
   ρu = state.ρu
   u = ρinv * ρu
+
   # advective terms
   flux.ρ   = ρu
   flux.ρu  = ρu .* u'
   flux.ρe  = u * state.ρe
-end
 
-@inline function flux_pressure!(m::AtmosModel, flux::Grad, state::Vars, aux::Vars, t::Real)
-  # preflux
-  ρinv = 1/state.ρ
-  ρu = state.ρu
-  u = ρinv * ρu
-  p = pressure(m.moisture, m.orientation, state, aux)
   # pressure terms
+  p = pressure(m.moisture, m.orientation, state, aux)
   flux.ρu += p*I
   flux.ρe += u*p
+  flux_radiation!(m.radiation, flux, state, aux, t)
 end
 
-@inline function flux_radiation!(m::AtmosModel, flux::Grad, state::Vars,
-                                 aux::Vars, t::Real)
-  flux_radiation!(m.radiation, flux, state, aux,t)
-end
-
-flux_diffusive!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) =
-  flux_diffusive!(m, flux, state, diffusive, aux, t, m.turbulence)
-@inline function flux_diffusive!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real,
-                                 ::TurbulenceClosure)
+@inline function flux_diffusive!(m::AtmosModel, flux::Grad, state::Vars,
+                                 diffusive::Vars, aux::Vars, t::Real)
   ρinv = 1/state.ρ
   u = ρinv * state.ρu
 
   # diffusive
   ρτ = diffusive.ρτ
+  ρd_h_tot = diffusive.ρd_h_tot
   flux.ρu += ρτ
   flux.ρe += ρτ*u
+  flux.ρe += ρd_h_tot
   flux_diffusive!(m.moisture, flux, state, diffusive, aux, t)
 end
-flux_diffusive!(m::AtmosModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real,
-                ::NoViscosity) = nothing
 
 @inline function wavespeed(m::AtmosModel, nM, state::Vars, aux::Vars, t::Real)
   ρinv = 1/state.ρ
-  ρu = state.ρu
-  u = ρinv * ρu
+  u = ρinv * state.ρu
   return abs(dot(nM, u)) + soundspeed(m.moisture, m.orientation, state, aux)
 end
 
-gradvariables!(m::AtmosModel, transform::Vars, state::Vars, aux::Vars, t::Real) =
-  gradvariables!(m::AtmosModel, transform::Vars, state::Vars, aux::Vars, t::Real, m.turbulence)
-function gradvariables!(m::AtmosModel, transform::Vars, state::Vars, aux::Vars, t::Real, ::TurbulenceClosure)
-  ρinv = 1 / state.ρ
+function gradvariables!(atmos::AtmosModel, transform::Vars, state::Vars, aux::Vars, t::Real)
+  ρinv = 1/state.ρ
   transform.u = ρinv * state.ρu
+  transform.h_tot = total_specific_enthalpy(atmos.moisture, atmos.orientation, state, aux)
 
-  gradvariables!(m.moisture, m, transform, state, aux, t)
-  gradvariables!(m.turbulence, transform, state, aux, t)
+  gradvariables!(atmos.moisture, transform, state, aux, t)
+  gradvariables!(atmos.turbulence, transform, state, aux, t)
 end
-gradvariables!(m::AtmosModel, transform::Vars, state::Vars, aux::Vars, t::Real, ::NoViscosity) = nothing
+
 
 function symmetrize(X::StaticArray{Tuple{3,3}})
   SHermitianCompact(SVector(X[1,1], (X[2,1] + X[1,2])/2, (X[3,1] + X[1,3])/2, X[2,2], (X[3,2] + X[2,3])/2, X[3,3]))
 end
 
-diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real) =
-  diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real, m.turbulence)
-function diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real,
-                    ::TurbulenceClosure)
+function diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real)
   ∇u = ∇transform.u
   # strain rate tensor
   S = symmetrize(∇u)
   # kinematic viscosity tensor
-  ρν = dynamic_viscosity_tensor(m.turbulence, S, state, diffusive, aux, t)
+  ρν = dynamic_viscosity_tensor(m.turbulence, S, state, diffusive, ∇transform, aux, t)
   # momentum flux tensor
   diffusive.ρτ = scaled_momentum_flux_tensor(m.turbulence, ρν, S)
+
+  ∇h_tot = ∇transform.h_tot
+  # turbulent Prandtl number
+  diag_ρν = ρν isa Real ? ρν : diag(ρν) # either a scalar or matrix
+  # Diffusivity ρD_t = ρν/Prandtl_turb
+  ρD_t = diag_ρν * inv_Pr_turb
+  # diffusive flux of total energy
+  diffusive.ρd_h_tot = -ρD_t .* ∇transform.h_tot
+
   # diffusivity of moisture components
-  diffusive!(m.moisture, diffusive, ∇transform, state, aux, t, ρν, inv_Pr_turb)
+  diffusive!(m.moisture, diffusive, ∇transform, state, aux, t, ρD_t)
   # diffusion terms required for SGS turbulence computations
-  diffusive!(m.turbulence, diffusive, ∇transform, state, aux, t, ρν)
+  diffusive!(m.turbulence, diffusive, ∇transform, state, aux, t, ρD_t)
 end
-diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real,
-           ::NoViscosity) = nothing
 
 function update_aux!(dg::DGModel, m::AtmosModel, Q::MPIStateArray,
                      auxstate::MPIStateArray, t::Real, _)

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -4,8 +4,6 @@ export NoRadiation, StevensRadiation
 abstract type RadiationModel end
 
 vars_state(::RadiationModel, DT) = @vars()
-vars_gradient(::RadiationModel, DT) = @vars()
-vars_diffusive(::RadiationModel, DT) = @vars()
 vars_aux(::RadiationModel, DT) = @vars()
 vars_integrals(::RadiationModel, DT) = @vars()
 

--- a/src/Atmos/Model/turbulence.jl
+++ b/src/Atmos/Model/turbulence.jl
@@ -1,4 +1,6 @@
 #### Turbulence closures
+abstract type TurbulenceClosure end
+
 using CLIMA.PlanetParameters
 using CLIMA.SubgridScaleParameters
 export ConstantViscosityWithDivergence, SmagorinskyLilly
@@ -12,14 +14,11 @@ function atmos_init_aux!(::TurbulenceClosure, ::AtmosModel, aux::Vars, geom::Loc
 end
 function atmos_nodal_update_aux!(::TurbulenceClosure, ::AtmosModel, state::Vars, aux::Vars, t::Real)
 end
-function diffusive!(::TurbulenceClosure, diffusive, ∇transform, state, aux, t, ν)
-end
-function flux_diffusive!(::TurbulenceClosure, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
-end
-function flux_nondiffusive!(::TurbulenceClosure, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)
-end
 function gradvariables!(::TurbulenceClosure, transform::Vars, state::Vars, aux::Vars, t::Real)
 end
+function diffusive!(::TurbulenceClosure, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real, _...)
+end
+
 
 """
     ConstantViscosityWithDivergence <: TurbulenceClosure
@@ -29,9 +28,13 @@ Turbulence with constant dynamic viscosity (`ρν`). Divergence terms are includ
 struct ConstantViscosityWithDivergence{T} <: TurbulenceClosure
   ρν::T
 end
-dynamic_viscosity_tensor(m::ConstantViscosityWithDivergence, S, state::Vars, diffusive::Vars, aux::Vars, t::Real) = m.ρν
+
+function dynamic_viscosity_tensor(m::ConstantViscosityWithDivergence, S, 
+  state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real)
+  return m.ρν
+end
 function scaled_momentum_flux_tensor(m::ConstantViscosityWithDivergence, ρν, S)
-  @inbounds trS = tr(S)
+  trS = tr(S)
   return (-2*ρν) * S + (2*ρν/3)*trS * I
 end
 
@@ -58,16 +61,13 @@ struct SmagorinskyLilly{T} <: TurbulenceClosure
   C_smag::T
 end
 vars_aux(::SmagorinskyLilly,T) = @vars(Δ::T)
-vars_gradient(::SmagorinskyLilly,T) = @vars(θ_v::T)
-vars_diffusive(::SmagorinskyLilly,T) = @vars(∂θ∂Φ::T)
 function atmos_init_aux!(::SmagorinskyLilly, ::AtmosModel, aux::Vars, geom::LocalGeometry)
   aux.turbulence.Δ = lengthscale(geom)
 end
+
+vars_gradient(::SmagorinskyLilly,T) = @vars(θ_v::T)
 function gradvariables!(m::SmagorinskyLilly, transform::Vars, state::Vars, aux::Vars, t::Real)
   transform.turbulence.θ_v = aux.moisture.θ_v
-end
-function diffusive!(m::SmagorinskyLilly, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real, ρν::Union{Real,AbstractMatrix})
-  diffusive.turbulence.∂θ∂Φ = dot(∇transform.turbulence.θ_v, aux.orientation.∇Φ)
 end
 
 """
@@ -104,24 +104,24 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1111/j.2153-3490.1962.tb001
 year = {1962}
 }
 """
-function squared_buoyancy_correction(normS, diffusive::Vars, aux::Vars)
-  T = eltype(diffusive)
-  N² = inv(aux.moisture.θ_v) * diffusive.turbulence.∂θ∂Φ
+function squared_buoyancy_correction(normS, ∇transform::Grad, aux::Vars)
+  ∂θ∂Φ = dot(∇transform.turbulence.θ_v, aux.orientation.∇Φ)
+  N² = ∂θ∂Φ / aux.moisture.θ_v
   Richardson = N² / (normS^2 + eps(normS))
-  sqrt(clamp(T(1) - Richardson*inv_Pr_turb, T(0), T(1)))
+  sqrt(clamp(1 - Richardson*inv_Pr_turb, 0, 1))
 end
 
 function strain_rate_magnitude(S::SHermitianCompact{3,T,6}) where {T}
   sqrt(2*S[1,1]^2 + 4*S[2,1]^2 + 4*S[3,1]^2 + 2*S[2,2]^2 + 4*S[3,2]^2 + 2*S[3,3]^2)
 end
 
-function dynamic_viscosity_tensor(m::SmagorinskyLilly, S, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+function dynamic_viscosity_tensor(m::SmagorinskyLilly, S, state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real)
   # strain rate tensor norm
   # Notation: normS ≡ norm2S = √(2S:S)
   # ρν = (Cₛ * Δ * f_b)² * √(2S:S)
   T = eltype(state)
   @inbounds normS = strain_rate_magnitude(S)
-  f_b² = squared_buoyancy_correction(normS, diffusive, aux)
+  f_b² = squared_buoyancy_correction(normS, ∇transform, aux)
   # Return Buoyancy-adjusted Smagorinsky Coefficient (ρ scaled)
   return state.ρ * normS * f_b² * T(m.C_smag * aux.turbulence.Δ)^2
 end

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -14,7 +14,7 @@ using CLIMA.PlanetParameters: kappa_d
 using CLIMA.MoistThermodynamics: air_density, total_energy, soundspeed_air
 using CLIMA.Atmos: AtmosModel, NoOrientation, NoReferenceState,
                    DryModel, NoRadiation, PeriodicBC,
-                   NoViscosity, vars_state
+                   ConstantViscosityWithDivergence, vars_state
 using CLIMA.VariableTemplates: flattenednames
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
@@ -151,7 +151,7 @@ function run(mpicomm, polynomialorder, numelems,
   end
   model = AtmosModel(NoOrientation(),
                      NoReferenceState(),
-                     NoViscosity(),
+                     ConstantViscosityWithDivergence(0.0),
                      DryModel(),
                      NoRadiation(),
                      nothing,

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -35,8 +35,7 @@ end
 include("mms_solution_generated.jl")
 
 using CLIMA.Atmos
-using CLIMA.Atmos: internal_energy, thermo_state
-import CLIMA.Atmos: MoistureModel, temperature, pressure, soundspeed, update_aux!
+import CLIMA.Atmos: MoistureModel, temperature, pressure, soundspeed, total_specific_enthalpy
 
 """
     MMSDryModel
@@ -46,12 +45,14 @@ Assumes the moisture components is in the dry limit.
 struct MMSDryModel <: MoistureModel
 end
 
+function total_specific_enthalpy(moist::MoistureModel, orientation::Orientation, state::Vars, aux::Vars)
+  zero(eltype(state))
+end
 function pressure(m::MMSDryModel, orientation::Orientation, state::Vars, aux::Vars)
   T = eltype(state)
   γ = T(7)/T(5)
   ρinv = 1 / state.ρ
   return (γ-1)*(state.ρe - ρinv/2 * sum(abs2, state.ρu))
-
 end
 
 function soundspeed(m::MMSDryModel, orientation::Orientation, state::Vars, aux::Vars)


### PR DESCRIPTION
Reduces the assumptions on the moisture model, and also avoids the need for updating the mms test case for the time being.

Also changes the order of `diffusive!` calculations so that SmagorinskyLilly usese the most recent gradient. As a result, this affects the DYCOMS tolerance. cc @asraero @smarras79 

Supersedes #413.