### PR TITLE
Increase bors timeout to 1 day

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,5 +3,5 @@ status = [
   "ci/slurmci"
 ]
 delete_merged_branches = true
-timeout_sec = 14400
+timeout_sec = 86400
 block_labels = [ "do-not-merge-yet" ]


### PR DESCRIPTION
There has been a bit of a backlog on the cluster recently meaning jobs are timing out. This should hopefully let them finish.