### PR TITLE
Add MoistThermo constructor consistency tests

### DIFF
--- a/docs/src/Common/MoistThermodynamics.md
+++ b/docs/src/Common/MoistThermodynamics.md
@@ -83,7 +83,10 @@ ThermodynamicState
 PhaseDry
 PhaseEquil
 PhaseNonEquil
+TemperatureSHumEquil
 LiquidIcePotTempSHumEquil
+LiquidIcePotTempSHumNonEquil
+LiquidIcePotTempSHumNonEquil_density
 ```
 
 ```@docs

--- a/docs/src/Common/MoistThermodynamics.md
+++ b/docs/src/Common/MoistThermodynamics.md
@@ -86,7 +86,7 @@ PhaseNonEquil
 TemperatureSHumEquil
 LiquidIcePotTempSHumEquil
 LiquidIcePotTempSHumNonEquil
-LiquidIcePotTempSHumNonEquil_density
+LiquidIcePotTempSHumNonEquil_given_pressure
 ```
 
 ```@docs

--- a/docs/src/Common/MoistThermodynamics.md
+++ b/docs/src/Common/MoistThermodynamics.md
@@ -84,7 +84,6 @@ PhaseDry
 PhaseEquil
 PhaseNonEquil
 LiquidIcePotTempSHumEquil
-LiquidIcePotTempSHumEquil_no_ρ
 ```
 
 ```@docs

--- a/examples/DGmethods/ex_001_dycoms.jl
+++ b/examples/DGmethods/ex_001_dycoms.jl
@@ -19,7 +19,7 @@ using CLIMA.VTK
 
 using CLIMA.Atmos: vars_state, vars_aux
 
-using Random 
+using Random
 const seed = MersenneTwister(0)
 
 @static if haspkg("CuArrays")
@@ -27,7 +27,7 @@ const seed = MersenneTwister(0)
   using CUDAnative
   using CuArrays
   CuArrays.allowscalar(false)
-  const ArrayTypes = (CuArray,) 
+  const ArrayTypes = (CuArray,)
 else
   const ArrayTypes = (Array,)
 end
@@ -40,11 +40,11 @@ end
 """
   Initial Condition for DYCOMS_RF01 LES
 @article{doi:10.1175/MWR2930.1,
-author = {Stevens, Bjorn and Moeng, Chin-Hoh and Ackerman, 
-          Andrew S. and Bretherton, Christopher S. and Chlond, 
-          Andreas and de Roode, Stephan and Edwards, James and Golaz, 
-          Jean-Christophe and Jiang, Hongli and Khairoutdinov, 
-          Marat and Kirkpatrick, Michael P. and Lewellen, David C. and Lock, Adrian and 
+author = {Stevens, Bjorn and Moeng, Chin-Hoh and Ackerman,
+          Andrew S. and Bretherton, Christopher S. and Chlond,
+          Andreas and de Roode, Stephan and Edwards, James and Golaz,
+          Jean-Christophe and Jiang, Hongli and Khairoutdinov,
+          Marat and Kirkpatrick, Michael P. and Lewellen, David C. and Lock, Adrian and
           Maeller, Frank and Stevens, David E. and Whelan, Eoin and Zhu, Ping},
 title = {Evaluation of Large-Eddy Simulations via Observations of Nocturnal Marine Stratocumulus},
 journal = {Monthly Weather Review},
@@ -60,7 +60,7 @@ eprint = {https://doi.org/10.1175/MWR2930.1}
 function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   DT         = eltype(state)
   xvert::DT  = z
-  
+
   epsdv::DT     = molmass_ratio
   q_tot_sfc::DT = 8.1e-3
   Rm_sfc::DT    = gas_constant_air(PhasePartition(q_tot_sfc))
@@ -68,15 +68,15 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   P_sfc::DT     = 1.0178e5
   T_BL::DT      = 285.0
   T_sfc::DT     = P_sfc/(ρ_sfc * Rm_sfc);
-  
+
   q_liq::DT      = 0
   q_ice::DT      = 0
-  zb::DT         = 600   
-  zi::DT         = 840 
+  zb::DT         = 600
+  zi::DT         = 840
   dz_cloud       = zi - zb
   q_liq_peak::DT = 4.5e-4
-  
-  if xvert > zb && xvert <= zi        
+
+  if xvert > zb && xvert <= zi
     q_liq = (xvert - zb)*q_liq_peak/dz_cloud
   end
   if ( xvert <= zi)
@@ -94,8 +94,8 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   H = Rm_sfc * T_BL / grav;
   P = P_sfc * exp(-xvert/H);
   #Exner
-  exner_dry = exner(P, PhasePartition(DT(0)))
-  #Temperature 
+  exner_dry = exner_given_pressure(P, PhasePartition(DT(0)))
+  #Temperature
   T             = exner_dry*θ_liq + LH_v0*q_liq/(cpm*exner_dry);
   #Density
   ρ             = P/(Rm*T);
@@ -110,10 +110,10 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   e_pot       = grav * xvert
   E           = ρ * total_energy(e_kin, e_pot, T, q_pt)
   state.ρ     = ρ
-  state.ρu    = SVector(U, V, W) 
+  state.ρu    = SVector(U, V, W)
   state.ρe    = E
   state.moisture.ρq_tot = ρ * q_tot
-end   
+end
 
 
 function run(mpicomm, ArrayType, dim, topl, N, timeend, DT, dt, C_smag, LHF, SHF, C_drag, zmax, zsponge)
@@ -128,10 +128,10 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, DT, dt, C_smag, LHF, SHF
                      SmagorinskyLilly{DT}(C_smag),
                      EquilMoist(),
                      StevensRadiation{DT}(85, 1, 840, 1.22, 3.75e-6, 70, 22),
-                     (Gravity(), 
-                      RayleighSponge{DT}(zmax, zsponge, 1), 
-                      Subsidence(), 
-                      GeostrophicForcing{DT}(7.62e-5, 7, -5.5)), 
+                     (Gravity(),
+                      RayleighSponge{DT}(zmax, zsponge, 1),
+                      Subsidence(),
+                      GeostrophicForcing{DT}(7.62e-5, 7, -5.5)),
                      DYCOMS_BC{DT}(C_drag, LHF, SHF),
                      Initialise_DYCOMS!)
 
@@ -173,9 +173,9 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, DT, dt, C_smag, LHF, SHF
     outprefix = @sprintf("./vtk-dycoms/dycoms_%dD_mpirank%04d_step%04d", dim,
                            MPI.Comm_rank(mpicomm), step[1])
     @debug "doing VTK output" outprefix
-    writevtk(outprefix, Q, dg, flattenednames(vars_state(model,DT)), 
+    writevtk(outprefix, Q, dg, flattenednames(vars_state(model,DT)),
              dg.auxstate, flattenednames(vars_aux(model,DT)))
-        
+
     step[1] += 1
     nothing
   end
@@ -214,7 +214,7 @@ let
   @testset "$(@__FILE__)" for ArrayType in ArrayTypes
     # Problem type
     DT = Float64
-    # DG polynomial order 
+    # DG polynomial order
     N = 4
     # SGS Filter constants
     C_smag = DT(0.15)
@@ -227,7 +227,7 @@ let
                   grid1d(0, 1500, elemsize=DT(20)*N))
     zmax = brickrange[3][end]
     zsponge = DT(0.75 * zmax)
-    
+
     topl = StackedBrickTopology(mpicomm, brickrange,
                                 periodicity = (true, true, false),
                                 boundary=((0,0),(0,0),(1,2)))
@@ -235,7 +235,7 @@ let
     timeend = 100dt
     dim = 3
     @info (ArrayType, DT, dim)
-    result = run(mpicomm, ArrayType, dim, topl, 
+    result = run(mpicomm, ArrayType, dim, topl,
                  N, timeend, DT, dt, C_smag, LHF, SHF, C_drag, zmax, zsponge)
     @test result ≈ DT(0.9999737848359238)
   end

--- a/examples/DGmethods/ex_002_IOstrings.jl
+++ b/examples/DGmethods/ex_002_IOstrings.jl
@@ -98,7 +98,7 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   H     = Rm_sfc * T_sfc / grav;
   p     = P_sfc * exp(-xvert/H);
   #Density, Temperature
-  TS    = LiquidIcePotTempSHumEquil_no_ρ(θ_liq, q_pt, p)
+  TS    = LiquidIcePotTempSHumEquil(θ_liq, q_pt, p)
   ρ     = air_density(TS)
   T     = air_temperature(TS)
   #Assign State Variables

--- a/examples/DGmethods/ex_002_IOstrings.jl
+++ b/examples/DGmethods/ex_002_IOstrings.jl
@@ -98,7 +98,7 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   H     = Rm_sfc * T_sfc / grav;
   p     = P_sfc * exp(-xvert/H);
   #Density, Temperature
-  TS    = LiquidIcePotTempSHumNonEquil(θ_liq, q_pt, p)
+  TS    = LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq, q_pt, p)
   ρ     = air_density(TS)
   T     = air_temperature(TS)
   #Assign State Variables

--- a/examples/DGmethods/ex_002_IOstrings.jl
+++ b/examples/DGmethods/ex_002_IOstrings.jl
@@ -29,7 +29,7 @@ using GPUifyLoops
   using CUDAnative
   using CuArrays
   CuArrays.allowscalar(false)
-  const ArrayTypes = (CuArray,) 
+  const ArrayTypes = (CuArray,)
 else
   const ArrayTypes = (Array,)
 end
@@ -46,11 +46,11 @@ const seed = MersenneTwister(0)
 """
   Initial Condition for DYCOMS_RF01 LES
 @article{doi:10.1175/MWR2930.1,
-author = {Stevens, Bjorn and Moeng, Chin-Hoh and Ackerman, 
-          Andrew S. and Bretherton, Christopher S. and Chlond, 
-          Andreas and de Roode, Stephan and Edwards, James and Golaz, 
-          Jean-Christophe and Jiang, Hongli and Khairoutdinov, 
-          Marat and Kirkpatrick, Michael P. and Lewellen, David C. and Lock, Adrian and 
+author = {Stevens, Bjorn and Moeng, Chin-Hoh and Ackerman,
+          Andrew S. and Bretherton, Christopher S. and Chlond,
+          Andreas and de Roode, Stephan and Edwards, James and Golaz,
+          Jean-Christophe and Jiang, Hongli and Khairoutdinov,
+          Marat and Kirkpatrick, Michael P. and Lewellen, David C. and Lock, Adrian and
           Maeller, Frank and Stevens, David E. and Whelan, Eoin and Zhu, Ping},
 title = {Evaluation of Large-Eddy Simulations via Observations of Nocturnal Marine Stratocumulus},
 journal = {Monthly Weather Review},
@@ -74,14 +74,14 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   T_sfc::FT     = 292.5
   P_sfc::FT     = MSLP
   ρ_sfc::FT     = P_sfc / Rm_sfc / T_sfc
-  # Specify moisture profiles 
+  # Specify moisture profiles
   q_liq::FT      = 0
   q_ice::FT      = 0
   zb::FT         = 600    # initial cloud bottom
   zi::FT         = 840    # initial cloud top
   dz_cloud       = zi - zb
-  q_liq_peak::FT = 0.00045 #cloud mixing ratio at z_i    
-  if xvert > zb && xvert <= zi        
+  q_liq_peak::FT = 0.00045 #cloud mixing ratio at z_i
+  if xvert > zb && xvert <= zi
     q_liq = (xvert - zb)*q_liq_peak/dz_cloud
   end
   if xvert <= zi
@@ -91,14 +91,14 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
     θ_liq = FT(297.5) + (xvert - zi)^(FT(1/3))
     q_tot = FT(1.5e-3)
   end
-    
+
   # Calculate PhasePartition object for vertical domain extent
-  q_pt  = PhasePartition(q_tot, q_liq, q_ice) 
+  q_pt  = PhasePartition(q_tot, q_liq, q_ice)
   #Pressure
   H     = Rm_sfc * T_sfc / grav;
   p     = P_sfc * exp(-xvert/H);
   #Density, Temperature
-  TS    = LiquidIcePotTempSHumEquil(θ_liq, q_pt, p)
+  TS    = LiquidIcePotTempSHumNonEquil(θ_liq, q_pt, p)
   ρ     = air_density(TS)
   T     = air_temperature(TS)
   #Assign State Variables
@@ -107,7 +107,7 @@ function Initialise_DYCOMS!(state::Vars, aux::Vars, (x,y,z), t)
   e_pot       = grav * xvert
   E           = ρ * total_energy(e_kin, e_pot, T, q_pt)
   state.ρ     = ρ
-  state.ρu    = SVector(ρ*u, ρ*v, ρ*w) 
+  state.ρu    = SVector(ρ*u, ρ*v, ρ*w)
   state.ρe    = E
   state.moisture.ρq_tot = ρ * q_tot
 end
@@ -123,8 +123,8 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt, C_smag, LHF, SHF
   # Problem constants
   # Radiation model
   κ             = FT(85)
-  α_z           = FT(1) 
-  z_i           = FT(840) 
+  α_z           = FT(1)
+  z_i           = FT(840)
   D_subsidence  = FT(3.75e-6)
   ρ_i           = FT(1.13)
   F_0           = FT(70)
@@ -133,17 +133,17 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt, C_smag, LHF, SHF
   f_coriolis    = FT(7.62e-5)
   u_geostrophic = FT(7)
   v_geostrophic = FT(-5.5)
-  
+
   # Model definition
   model = AtmosModel(FlatOrientation(),
                      NoReferenceState(),
                      SmagorinskyLilly{FT}(C_smag),
                      EquilMoist(),
                      StevensRadiation{FT}(κ, α_z, z_i, ρ_i, D_subsidence, F_0, F_1),
-                     (Gravity(), 
-                      RayleighSponge{FT}(zmax, zsponge, 1), 
-                      Subsidence(), 
-                      GeostrophicForcing{FT}(f_coriolis, u_geostrophic, v_geostrophic)), 
+                     (Gravity(),
+                      RayleighSponge{FT}(zmax, zsponge, 1),
+                      Subsidence(),
+                      GeostrophicForcing{FT}(f_coriolis, u_geostrophic, v_geostrophic)),
                      DYCOMS_BC{FT}(C_drag, LHF, SHF),
                      Initialise_DYCOMS!)
   # Balancelaw description
@@ -153,9 +153,9 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt, C_smag, LHF, SHF
                CentralNumericalFluxDiffusive(),
                CentralGradPenalty())
   Q = init_ode_state(dg, FT(0); device=CPU())
-    
+
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
-  # Calculating initial condition norm 
+  # Calculating initial condition norm
 #=  eng0 = norm(Q)
   @info @sprintf """Starting
   norm(Q₀) = %.16e""" eng0
@@ -176,7 +176,7 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt, C_smag, LHF, SHF
                                   Dates.dateformat"HH:MM:SS"))
     end
   end
-  
+
   # Setup VTK output callbacks
   step = [0]
     cbvtk = GenericCallbacks.EveryXSimulationSteps(1) do (init=false)
@@ -184,13 +184,13 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt, C_smag, LHF, SHF
     outprefix = @sprintf("%s/dycoms_%dD_mpirank%04d_step%04d", OUTPATH, dim,
                            MPI.Comm_rank(mpicomm), step[1])
     @debug "doing VTK output" outprefix
-    writevtk(outprefix, Q, dg, flattenednames(vars_state(model,FT)), 
+    writevtk(outprefix, Q, dg, flattenednames(vars_state(model,FT)),
              dg.auxstate, flattenednames(vars_aux(model,FT)))
-        
+
     step[1] += 1
     nothing
   end
-    
+
   solve!(Q, lsrk; timeend=timeend, callbacks=(cbinfo, cbvtk))
 
 end
@@ -212,7 +212,7 @@ let
   for ArrayType in ArrayTypes
     # Problem type
     FT = Float32
-    # DG polynomial order 
+    # DG polynomial order
     N = 4
     # SGS Filter constants
     C_smag = FT(0.15)
@@ -231,9 +231,9 @@ let
       brickrange = (grid1d(xmin, xmax, elemsize=FT(grid_resolution[1])*N),
                     grid1d(ymin, ymax, elemsize=FT(grid_resolution[2])*N),
                     grid1d(zmin, zmax, elemsize=FT(grid_resolution[end])*N))
-      
+
     zsponge = FT(0.75 * zmax)
-    
+
     topl = StackedBrickTopology(mpicomm, brickrange,
                                 periodicity = (true, true, false),
                                 boundary=((0,0),(0,0),(1,2)))
@@ -244,9 +244,9 @@ let
 
     #Create unique output path directory:
     OUTPATH = IOstrings_outpath_name(problem_name, grid_resolution)
-      
+
 #    @info (ArrayType, dt, FT, dim)
-#    result = run(mpicomm, ArrayType, dim, topl, 
+#    result = run(mpicomm, ArrayType, dim, topl,
 #                 N, timeend, FT, dt, C_smag, LHF, SHF, C_drag, grid_resolution, domain_size, zmax, zsponge, problem_name, OUTPATH)
 
   end

--- a/examples/Microphysics/ex_1_saturation_adjustment.jl
+++ b/examples/Microphysics/ex_1_saturation_adjustment.jl
@@ -158,7 +158,7 @@ const X_max = 1500. # m
     p = p_1000 * ((p_0 / p_1000)^(R_d / cp_d) -
                 R_d / cp_d * grav / θ_0 / R_m * (z - z_0)
                )^(cp_d / R_d)
-    T::FT = θ_0 * exner(p, PhasePartition(qt_0))
+    T::FT = θ_0 * exner_given_pressure(p, PhasePartition(qt_0))
     ρ::FT = p / R_m / T
 
     # TODO should this be more "grid aware"?

--- a/examples/Microphysics/ex_1_saturation_adjustment.jl
+++ b/examples/Microphysics/ex_1_saturation_adjustment.jl
@@ -105,7 +105,7 @@ end
     qt_0::FT   = 7.5 * 1e-3  # kg/kg
     z_0::FT    = 0           # m
 
-    R_m, cp_m, cv_m, γ = moist_gas_constants(PhasePartition(qt_0))
+    R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
 
     # Pressure profile assuming hydrostatic and constant θ and qt profiles.
     # It is done this way to be consistent with Arabas paper.
@@ -149,7 +149,7 @@ const X_max = 1500. # m
   qt_0::FT   = 7.5 * 1e-3  # kg/kg
   z_0::FT    = 0           # m
 
-  R_m, cp_m, cv_m, γ = moist_gas_constants(PhasePartition(qt_0))
+  R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
 
   @inbounds begin
     # Pressure profile assuming hydrostatic and constant θ and qt profiles.

--- a/examples/Microphysics/ex_2_Kessler.jl
+++ b/examples/Microphysics/ex_2_Kessler.jl
@@ -124,7 +124,7 @@ end
     qt_0::FT   = 7.5 * 1e-3  # kg/kg
     z_0::FT    = 0           # m
 
-    R_m, cp_m, cv_m, γ = moist_gas_constants(PhasePartition(qt_0))
+    R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
 
     # Pressure profile assuming hydrostatic and constant θ and qt profiles.
     # It is done this way to be consistent with Arabas paper.
@@ -220,7 +220,7 @@ function single_eddy!(Q, t, x, z, _...)
   qt_0::FT   = 7.5 * 1e-3  # kg/kg
   z_0::FT    = 0           # m
 
-  R_m, cp_m, cv_m, γ = moist_gas_constants(PhasePartition(qt_0))
+  R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
 
   @inbounds begin
     # Pressure profile assuming hydrostatic and constant θ and qt profiles.

--- a/examples/Microphysics/ex_2_Kessler.jl
+++ b/examples/Microphysics/ex_2_Kessler.jl
@@ -229,7 +229,7 @@ function single_eddy!(Q, t, x, z, _...)
     p = p_1000 * ((p_0 / p_1000)^(R_d / cp_d) -
                 R_d / cp_d * grav / θ_0 / R_m * (z - z_0)
                )^(cp_d / R_d)
-    T::FT = θ_0 * exner(p, PhasePartition(qt_0))
+    T::FT = θ_0 * exner_given_pressure(p, PhasePartition(qt_0))
     ρ::FT = p / R_m / T
 
     # TODO should this be more "grid aware"?

--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -20,7 +20,7 @@ export linearized_air_pressure
 export total_energy, internal_energy, internal_energy_sat
 
 # Specific heats of moist air
-export cp_m, cv_m, gas_constant_air, moist_gas_constants
+export cp_m, cv_m, gas_constant_air, gas_constants
 
 # Latent heats
 export latent_heat_vapor, latent_heat_sublim, latent_heat_fusion
@@ -35,7 +35,8 @@ export saturation_excess
 export liquid_fraction_equil, liquid_fraction_nonequil, saturation_adjustment, PhasePartition_equil
 
 # Auxiliary functions, e.g., for diagnostic purposes
-export air_temperature_from_liquid_ice_pottemp, dry_pottemp, dry_pottemp_given_pressure, virtual_pottemp, exner, exner_given_pressure
+export air_temperature_from_liquid_ice_pottemp, air_temperature_from_liquid_ice_pottemp_given_pressure
+export dry_pottemp, dry_pottemp_given_pressure, virtual_pottemp, exner, exner_given_pressure
 export liquid_ice_pottemp, liquid_ice_pottemp_given_pressure, liquid_ice_pottemp_sat, relative_humidity
 
 include("states.jl")
@@ -105,11 +106,8 @@ linearized_air_pressure(ρ::FT, e_tot::FT, e_pot::FT, q::PhasePartition{FT}=q_pt
 linearized_air_pressure(e_kin::FT, e_pot::FT, ts::ThermodynamicState{FT}) where {FT<:Real} =
   linearized_air_pressure(air_density(ts), total_energy(e_kin, e_pot, ts), e_pot, PhasePartition(ts))
 
-function linearized_air_pressure(e_kin::FT, e_pot::FT, ts::PhaseDry{FT}) where {FT<:Real}
-  ρ = air_density(ts)
-  e_tot = total_energy(e_kin, e_pot, ts)
-  return ρ*FT(R_d)*FT(T_0) + FT(R_d)/FT(cv_d)*(ρ*e_tot - ρ*e_pot)
-end
+linearized_air_pressure(e_kin::FT, e_pot::FT, ts::PhaseDry{FT}) where {FT<:Real} =
+  linearized_air_pressure(air_density(ts), total_energy(e_kin, e_pot, ts), e_pot, PhasePartition(ts))
 
 """
     air_density(T, p[, q::PhasePartition])
@@ -198,7 +196,7 @@ cv_m(ts::PhaseDry{FT}) where {FT<:Real} = FT(cv_d)
 
 
 """
-    (R_m, cp_m, cv_m, γ_m) = moist_gas_constants([q::PhasePartition])
+    (R_m, cp_m, cv_m, γ_m) = gas_constants([q::PhasePartition])
 
 Wrapper to compute all gas constants at once, where optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
@@ -212,7 +210,7 @@ The function returns a tuple of
 Without the specific humidity arguments, the results
 are that of dry air.
 """
-function moist_gas_constants(q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
+function gas_constants(q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
     R_gas  = gas_constant_air(q)
     cp = cp_m(q)
     cv = cv_m(q)
@@ -221,7 +219,7 @@ function moist_gas_constants(q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
 end
 
 """
-    (R_m, cp_m, cv_m, γ_m) = moist_gas_constants(ts::ThermodynamicState)
+    (R_m, cp_m, cv_m, γ_m) = gas_constants(ts::ThermodynamicState)
 
 Wrapper to compute all gas constants at once, given a thermodynamic state `ts`.
 
@@ -232,8 +230,8 @@ The function returns a tuple of
  - `γ_m = cp_m/cv_m`
 
 """
-moist_gas_constants(ts::ThermodynamicState) = moist_gas_constants(PhasePartition(ts))
-function moist_gas_constants(ts::PhaseDry)
+gas_constants(ts::ThermodynamicState) = gas_constants(PhasePartition(ts))
+function gas_constants(ts::PhaseDry)
     R_gas  = gas_constant_air(ts)
     cp = cp_m(ts)
     cv = cv_m(ts)
@@ -325,7 +323,7 @@ The internal energy per unit mass in
 thermodynamic equilibrium at saturation,
 given a thermodynamic state `ts`.
 """
-internal_energy_sat(ts::PhaseDry{FT}) where {FT<:Real} = cv_m(ts) * (air_temperature(ts) - FT(T_0))
+internal_energy_sat(ts::PhaseDry{FT}) where {FT<:Real} = cv_d * (air_temperature(ts) - FT(T_0))
 internal_energy_sat(ts::PhaseEquil) =
   internal_energy_sat(air_temperature(ts), air_density(ts), ts.q_tot)
 internal_energy_sat(ts::PhaseNonEquil) =
@@ -553,18 +551,18 @@ Compute the saturation specific humidity, given
 and, optionally,
  - `q` [`PhasePartition`](@ref)
 
-If the phase partition `q` is given, the saturation specific humidity is that over a
+If the `PhasePartition` `q` is given, the saturation specific humidity is that of a
 mixture of liquid and ice, computed in a thermodynamically consistent way from the
 weighted sum of the latent heats of the respective phase transitions (Pressel et al.,
-JAMES, 2015).  That is, the saturation vapor pressure and from it the saturation specific
+JAMES, 2015). That is, the saturation vapor pressure and from it the saturation specific
 humidity are computed from a weighted mean of the latent heats of vaporization and
-sublimation, with the weights given by the fractions of condensate `q.liq/(q.liq + q.ice)`
+sublimation, with the weights given by the fractions of condensates `q.liq/(q.liq + q.ice)`
 and `q.ice/(q.liq + q.ice)` that are liquid and ice, respectively.
 
-If the condensate specific humidities `q.liq` and `q.ice` are not given or are both
-zero, the saturation specific humidity is that over a mixture of liquid and ice,
-with the fraction of liquid given by temperature dependent `liquid_fraction_equil(T)`
-and the fraction of ice by the complement `1 - liquid_fraction_equil(T)`.
+If the `PhasePartition` `q` is not given, or has zero liquid and ice specific humidities,
+the saturation specific humidity is that over a mixture of liquid and ice, with the
+fraction of liquid given by temperature dependent `liquid_fraction_equil(T)` and the
+fraction of ice by the complement `1 - liquid_fraction_equil(T)`.
 """
 function q_vap_saturation(T::FT, ρ::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0),FT(0),FT(0))) where {FT<:Real}
 
@@ -615,7 +613,7 @@ end
 Compute the saturation specific humidity, given
 
  - `T` ambient air temperature,
- - `ρ` density
+ - `ρ` (moist-)air density
  - `p_v_sat` saturation vapor pressure
 """
 q_vap_saturation_from_pressure(T::FT, ρ::FT, p_v_sat::FT) where {FT<:Real} =
@@ -645,7 +643,7 @@ given a thermodynamic state `ts`.
 """
 saturation_excess(ts::ThermodynamicState) =
   saturation_excess(air_temperature(ts), air_density(ts), PhasePartition(ts))
-saturation_excess(ts::PhaseDry) = max(0, - q_vap_saturation(ts))
+saturation_excess(ts::PhaseDry{FT}) where FT = FT(0)
 
 """
     liquid_fraction_equil(T[, q::PhasePartition])
@@ -721,7 +719,8 @@ Partition the phases in equilibrium, returning a [`PhasePartition`](@ref) object
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
 
-The residual `q.tot - q.liq - q.ice` is the vapor specific humidity.
+The residual `q.tot - q.liq - q.ice` is the vapor specific humidity, where `q`
+is the resulting `PhasePartition`.
 """
 function PhasePartition_equil(T::FT, ρ::FT, q_tot::FT) where {FT<:Real}
     _liquid_frac = liquid_fraction_equil(T)   # fraction of condensate that is liquid
@@ -746,16 +745,17 @@ Compute the temperature that is consistent with
  - `ρ` (moist-)air density
  - `q_tot` total specific humidity
 
-See also [`saturation_adjustment_q_t_θ_l`](@ref).
+See also [`saturation_adjustment_q_tot_θ_liq_ice`](@ref).
 """
 function saturation_adjustment(e_int::FT, ρ::FT, q_tot::FT) where {FT<:Real}
   T_1 = max(FT(T_min), air_temperature(e_int, PhasePartition(q_tot))) # Assume all vapor
   q_v_sat = q_vap_saturation(T_1, ρ)
-  if q_tot <= q_v_sat # If not saturated return T_1
+  unsaturated = q_tot <= q_v_sat
+  if unsaturated
     return T_1
-  else # If saturated, iterate
+  else
     # FIXME here: need to revisit bounds for saturation adjustment to guarantee bracketing of zero.
-    T_2 = air_temperature(e_int, PhasePartition(q_tot, FT(0), q_tot)) # Assume all ice
+    T_2 = air_temperature(e_int, PhasePartition(q_tot, FT(0), q_tot-q_v_sat)) # Assume all ice
     T, converged = find_zero(
       T -> internal_energy_sat(T, ρ, q_tot) - e_int,
       T_1, T_2, SecantMethod(), FT(1e-3), 10)
@@ -773,7 +773,13 @@ Compute the temperature that is consistent with
 
  - `θ_liq_ice` liquid-ice potential temperature
  - `q_tot` total specific humidity
- - `ρ` density
+ - `ρ` (moist-)air density
+
+by solving the equation
+
+``
+  θ_{liq_ice} - liquid_ice_pottemp_sat(T, ρ, q_tot) = 0
+``
 
 See also [`saturation_adjustment`](@ref).
 """
@@ -785,13 +791,13 @@ function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, q_tot::FT, ρ::F
 
   # TODO/FIXME: The iteration process seems brittle, and needs to
   # be reviewed/improved
-  T_1 = air_temperature_initial_guess(θ_liq_ice, ρ, PhasePartition(q_tot)) # Assume all vapor
+  T_1 = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, PhasePartition(q_tot)) # Assume all vapor
   q_v_sat = q_vap_saturation(T_1, ρ)
-  saturated = q_tot <= q_v_sat
-  if saturated
+  unsaturated = q_tot <= q_v_sat
+  if unsaturated
     return T_1
   else
-    T_2 = air_temperature_initial_guess(θ_liq_ice, ρ, PhasePartition(q_tot, FT(0), q_tot)) # Assume all vapor
+    T_2 = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, PhasePartition(q_tot, FT(0), q_tot-q_v_sat)) # Assume all ice
     T, converged = find_zero(
       T -> liquid_ice_pottemp_sat(T, ρ, q_tot) - θ_liq_ice,
       T_1, T_2, SecantMethod(), FT(1e-5), 40)
@@ -800,23 +806,6 @@ function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, q_tot::FT, ρ::F
       end
     return T
   end
-end
-
-"""
-    air_temperature_initial_guess(θ_liq_ice, ρ, q::PhasePartition)
-
-Solves the non-linear equation
-``
-  T = θ_{liq_ice}*(ρ R_m T/MSLP)^(R_m/cp_m) + (LH_{v0} q_{liq} + LH_{s0} q_{ice}) / cp_m
-``
-for temperature `T`
-"""
-function air_temperature_initial_guess(θ_liq_ice::FT, ρ::FT,
-  q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
-  T, converged = find_zero(
-    T -> T - air_temperature_from_liquid_ice_pottemp(θ_liq_ice, air_pressure(T, ρ, q), q),
-    FT(T_min), FT(T_max), SecantMethod(), FT(1e-3), 10)
-  return T
 end
 
 """
@@ -849,7 +838,7 @@ end
 
 The liquid-ice potential temperature where
  - `T` temperature
- - `ρ` density
+ - `ρ` (moist-)air density
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
@@ -867,12 +856,12 @@ liquid_ice_pottemp(ts::ThermodynamicState) =
 liquid_ice_pottemp(ts::PhaseDry) = dry_pottemp(ts)
 
 """
-    dry_pottemp(T, p[, q::PhasePartition])
+    dry_pottemp(T, ρ[, q::PhasePartition])
 
 The dry potential temperature where
 
  - `T` temperature
- - `ρ` density
+ - `ρ` (moist-)air density
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
  """
@@ -902,7 +891,52 @@ dry_pottemp(ts::ThermodynamicState) =
 dry_pottemp(ts::PhaseDry) = air_temperature(ts) / exner(ts)
 
 """
-    air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p[, q::PhasePartition])
+    air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, q::PhasePartition)
+
+Air temperature
+``
+  T = θ_{liq-ice}*(ρ*R_m*θ_{liq-ice}/MSLP)^{R_m/c_{vm}} + latent_heat_liq_ice(q)/c_{vm}
+``
+given
+ - `θ_liq_ice` liquid-ice potential temperature
+ - `ρ` (moist-)air density
+and, optionally,
+ - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
+"""
+function air_temperature_from_liquid_ice_pottemp(θ_liq_ice::FT, ρ::FT,
+  q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
+
+  R_m = gas_constant_air(q)
+  # Solve for temperature from liquid_ice_pottemp assuming no condensate:
+  T_dry = θ_liq_ice * (ρ*R_m*θ_liq_ice/FT(MSLP))^(R_m/cv_d)
+
+  # Now, add correction from condensate, assuming the relevant temperature is T_dry:
+  T_linearized = T_dry + latent_heat_liq_ice(q)/cv_d
+
+  T_non_linear = air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice, ρ, q)
+  return T_non_linear
+  # return T_linearized # Fails tests at the moment
+end
+
+"""
+    air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice, ρ, q::PhasePartition)
+
+Solves the non-linear equation
+``
+  T = θ_{liq_ice}*(ρ R_m T/MSLP)^(R_m/cp_m) + (LH_{v0} q_{liq} + LH_{s0} q_{ice}) / cp_m
+``
+for temperature `T`
+"""
+function air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice::FT, ρ::FT,
+  q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
+  T, converged = find_zero(
+    T -> T - air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice, air_pressure(T, ρ, q), q),
+    FT(T_min), FT(T_max), SecantMethod(), FT(1e-3), 10)
+  return T
+end
+
+"""
+    air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice, p[, q::PhasePartition])
 
 The air temperature, where
 
@@ -911,7 +945,7 @@ The air temperature, where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-function air_temperature_from_liquid_ice_pottemp(θ_liq_ice::FT,
+function air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice::FT,
                                                  p::FT,
                                                  q::PhasePartition{FT}=q_pt_0(FT)
                                                  ) where {FT<:Real}
@@ -926,7 +960,7 @@ end
 The virtual temperature where
 
  - `T` temperature
- - `ρ` density
+ - `ρ` (moist-)air density
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
@@ -949,7 +983,7 @@ virtual_pottemp(ts::PhaseDry{FT}) where {FT<:Real} = gas_constant_air(ts) / FT(R
 The saturated liquid ice potential temperature where
 
  - `T` temperature
- - `ρ` density
+ - `ρ` (moist-)air density
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
@@ -964,7 +998,7 @@ end
 The saturated liquid ice potential temperature where
 
  - `T` temperature
- - `ρ` density
+ - `ρ` (moist-)air density
  - `q_tot` total specific humidity
 """
 liquid_ice_pottemp_sat(T::FT, ρ::FT, q_tot::FT) where {FT<:Real} =
@@ -1001,7 +1035,7 @@ end
 
 The Exner function where
  - `T` temperature
- - `ρ` density
+ - `ρ` (moist-)air density
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """

--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -23,7 +23,7 @@ export total_energy, internal_energy, internal_energy_sat
 export cp_m, cv_m, gas_constant_air, gas_constants
 
 # Latent heats
-export latent_heat_vapor, latent_heat_sublim, latent_heat_fusion
+export latent_heat_vapor, latent_heat_sublim, latent_heat_fusion, latent_heat_liq_ice
 
 # Saturation vapor pressures and specific humidities over liquid and ice
 export Liquid, Ice
@@ -36,6 +36,7 @@ export liquid_fraction_equil, liquid_fraction_nonequil, saturation_adjustment, P
 
 # Auxiliary functions, e.g., for diagnostic purposes
 export air_temperature_from_liquid_ice_pottemp, air_temperature_from_liquid_ice_pottemp_given_pressure
+export air_temperature_from_liquid_ice_pottemp_non_linear
 export dry_pottemp, dry_pottemp_given_pressure, virtual_pottemp, exner, exner_given_pressure
 export liquid_ice_pottemp, liquid_ice_pottemp_given_pressure, liquid_ice_pottemp_sat, relative_humidity
 

--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -35,11 +35,12 @@ export saturation_excess
 export liquid_fraction_equil, liquid_fraction_nonequil, saturation_adjustment, PhasePartition_equil
 
 # Auxiliary functions, e.g., for diagnostic purposes
-export air_temperature_from_liquid_ice_pottemp, dry_pottemp, dry_pottemp_given_pressure, virtual_pottemp, exner
+export air_temperature_from_liquid_ice_pottemp, dry_pottemp, dry_pottemp_given_pressure, virtual_pottemp, exner, exner_given_pressure
 export liquid_ice_pottemp, liquid_ice_pottemp_given_pressure, liquid_ice_pottemp_sat, relative_humidity
 
 include("states.jl")
 
+@inline q_pt_0(::Type{FT}) where FT = PhasePartition{FT}(FT(0), FT(0), FT(0))
 
 """
     gas_constant_air([q::PhasePartition])
@@ -49,7 +50,7 @@ The specific gas constant of moist air given
 """
 gas_constant_air(q::PhasePartition{FT}) where {FT<:Real} =
   FT(R_d) * ( 1 +  (FT(molmass_ratio) - 1)*q.tot - FT(molmass_ratio)*(q.liq + q.ice) )
-gas_constant_air(::Type{FT}) where {FT<:Real} = gas_constant_air(PhasePartition{FT}(FT(0), FT(0), FT(0)))
+gas_constant_air(::Type{FT}) where {FT<:Real} = gas_constant_air(q_pt_0(FT))
 
 """
     gas_constant_air(ts::ThermodynamicState)
@@ -73,7 +74,7 @@ The air pressure from the equation of state
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-air_pressure(T::FT, ρ::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+air_pressure(T::FT, ρ::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   gas_constant_air(q) * ρ * T
 
 """
@@ -98,7 +99,7 @@ The air pressure, linearized around a dry rest state, from the equation of state
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-linearized_air_pressure(ρ::FT, e_tot::FT, e_pot::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+linearized_air_pressure(ρ::FT, e_tot::FT, e_pot::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   ρ*FT(R_d)*FT(T_0) + FT(R_d)/FT(cv_d)*(ρ*e_tot - ρ*e_pot - (ρ*q.tot - ρ*q.liq)*FT(e_int_v0) + ρ*q.ice*(FT(e_int_i0) + FT(e_int_v0)))
 
 linearized_air_pressure(e_kin::FT, e_pot::FT, ts::ThermodynamicState{FT}) where {FT<:Real} =
@@ -121,7 +122,7 @@ The (moist-)air density from the equation of state
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-air_density(T::FT, p::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+air_density(T::FT, p::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   p / (gas_constant_air(q) * T)
 
 """
@@ -143,7 +144,7 @@ state (ideal gas law) where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-specific_volume(T::FT, p::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+specific_volume(T::FT, p::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   (gas_constant_air(q) * T) / p
 
 """
@@ -164,7 +165,7 @@ air where, optionally,
 """
 cp_m(q::PhasePartition{FT}) where {FT<:Real} =
   FT(cp_d) + (FT(cp_v) - FT(cp_d))*q.tot + (FT(cp_l) - FT(cp_v))*q.liq + (FT(cp_i) - FT(cp_v))*q.ice
-cp_m(::Type{FT}) where {FT<:Real} = cp_m(PhasePartition{FT}(FT(0), FT(0), FT(0)))
+cp_m(::Type{FT}) where {FT<:Real} = cp_m(q_pt_0(FT))
 
 """
     cp_m(ts::ThermodynamicState)
@@ -184,7 +185,7 @@ air where optionally,
 """
 cv_m(q::PhasePartition{FT}) where {FT<:Real} =
   FT(cv_d) + (FT(cv_v) - FT(cv_d))*q.tot + (FT(cv_l) - FT(cv_v))*q.liq + (FT(cv_i) - FT(cv_v))*q.ice
-cv_m(::Type{FT}) where {FT<:Real} = cv_m(PhasePartition{FT}(FT(0), FT(0), FT(0)))
+cv_m(::Type{FT}) where {FT<:Real} = cv_m(q_pt_0(FT))
 
 """
     cv_m(ts::ThermodynamicState)
@@ -211,7 +212,7 @@ The function returns a tuple of
 Without the specific humidity arguments, the results
 are that of dry air.
 """
-function moist_gas_constants(q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
+function moist_gas_constants(q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
     R_gas  = gas_constant_air(q)
     cp = cp_m(q)
     cv = cv_m(q)
@@ -249,7 +250,7 @@ The air temperature, where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-function air_temperature(e_int::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
+function air_temperature(e_int::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
   T_0 +
     (e_int - (q.tot - q.liq) * FT(e_int_v0) + q.ice * (FT(e_int_v0) + FT(e_int_i0))) /
     cv_m(q)
@@ -260,8 +261,8 @@ end
 
 The air temperature, given a thermodynamic state `ts`.
 """
-air_temperature(ts::ThermodynamicState) = air_temperature(ts.e_int, PhasePartition(ts))
-air_temperature(ts::PhaseDry{FT}) where {FT<:Real} = FT(T_0) + ts.e_int / cv_m(ts)
+air_temperature(ts::ThermodynamicState) = air_temperature(internal_energy(ts), PhasePartition(ts))
+air_temperature(ts::PhaseDry{FT}) where {FT<:Real} = FT(T_0) + internal_energy(ts) / cv_m(ts)
 air_temperature(ts::PhaseEquil) = ts.T
 
 
@@ -274,7 +275,7 @@ The internal energy per unit mass, given a thermodynamic state `ts` or
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-internal_energy(T::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+internal_energy(T::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   cv_m(q) * (T - FT(T_0)) +
   (q.tot - q.liq) * FT(e_int_v0) - q.ice * (FT(e_int_v0) + FT(e_int_i0))
 
@@ -343,7 +344,7 @@ and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 
 """
-total_energy(e_kin::FT, e_pot::FT, T::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+total_energy(e_kin::FT, e_pot::FT, T::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   e_kin + e_pot + internal_energy(T, q)
 
 """
@@ -365,7 +366,7 @@ and, optionally,
 Without the specific humidity arguments, the results
 are that of dry air.
 """
-function soundspeed_air(T::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
+function soundspeed_air(T::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
   γ   = cp_m(q) / cv_m(q)
   R_m = gas_constant_air(q)
   return sqrt(γ*R_m*T)
@@ -660,7 +661,7 @@ them.
 Otherwise, the fraction of liquid is a function that is 1 above `T_freeze` and goes to
 zero below `T_freeze`.
 """
-function liquid_fraction_equil(T::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
+function liquid_fraction_equil(T::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
   q_c = q.liq + q.ice     # condensate specific humidity
   if q_c > 0
     return q.liq / q_c
@@ -765,58 +766,57 @@ function saturation_adjustment(e_int::FT, ρ::FT, q_tot::FT) where {FT<:Real}
   end
 end
 
-
 """
-    saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ[, p])
+    saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ)
 
 Compute the temperature that is consistent with
 
  - `θ_liq_ice` liquid-ice potential temperature
  - `q_tot` total specific humidity
  - `ρ` density
- - `p` pressure
 
 See also [`saturation_adjustment`](@ref).
 """
-function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, q_tot::FT, ρ::FT, p::FT) where {FT<:Real}
-  T_1 = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p, PhasePartition(q_tot)) # Assume all vapor
-  q_v_sat = q_vap_saturation(T_1, ρ)
-  if q_tot <= q_v_sat # If not saturated
-    return T_1
-  else  # If saturated, iterate
-    T_2 = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p, PhasePartition(q_tot, FT(0), q_tot)) # Assume all ice
-    T, converged = find_zero(
-      T -> θ_liq_ice - liquid_ice_pottemp_sat_given_pressure(T, p, PhasePartition_equil(T, ρ, q_tot)),
-      T_1, T_2, SecantMethod(), FT(1e-3), 10)
-    return T
-  end
-end
 function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, q_tot::FT, ρ::FT) where {FT<:Real}
+  # TODO/FIXME: The initial guesses are computed via iteration,
+  # which is potentially expensive. Other options should
+  # be investigated. Also, the tolerance/iterations are large
+  # when iterated. Perhaps this can be reduced with better guesses.
+
+  # TODO/FIXME: The iteration process seems brittle, and needs to
+  # be reviewed/improved
   T_1 = air_temperature_initial_guess(θ_liq_ice, ρ, PhasePartition(q_tot)) # Assume all vapor
   q_v_sat = q_vap_saturation(T_1, ρ)
-  if q_tot <= q_v_sat # If not saturated
+  saturated = q_tot <= q_v_sat
+  if saturated
     return T_1
-  else  # If saturated, iterate
+  else
     T_2 = air_temperature_initial_guess(θ_liq_ice, ρ, PhasePartition(q_tot, FT(0), q_tot)) # Assume all vapor
     T, converged = find_zero(
-      T -> θ_liq_ice - liquid_ice_pottemp_sat(T, ρ, PhasePartition_equil(T, ρ, q_tot)),
-      T_1, T_2, SecantMethod(), FT(1e-3), 10)
+      T -> liquid_ice_pottemp_sat(T, ρ, q_tot) - θ_liq_ice,
+      T_1, T_2, SecantMethod(), FT(1e-5), 40)
+      if !converged
+        error("saturation adjustment did not converge")
+      end
     return T
   end
 end
 
-function air_temperature_initial_guess(θ_liq_ice::FT, ρ::FT,
-  q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
-  T, converged = find_zero(
-    T -> air_temperature_initial_guess_roots(T, θ_liq_ice, ρ, q),
-    FT(T_min), FT(T_max), SecantMethod(), FT(1e-3), 10)
-  @assert converged
-  return T
-end
+"""
+    air_temperature_initial_guess(θ_liq_ice, ρ, q::PhasePartition)
 
-function air_temperature_initial_guess_roots(T::FT, θ_liq_ice::FT, ρ::FT,
-  q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
-  return θ_liq_ice*exner(T, ρ, q) + latent_heat_liq_ice(q) / cp_m(q) - T
+Solves the non-linear equation
+``
+  T = θ_{liq_ice}*(ρ R_m T/MSLP)^(R_m/cp_m) + (LH_{v0} q_{liq} + LH_{s0} q_{ice}) / cp_m
+``
+for temperature `T`
+"""
+function air_temperature_initial_guess(θ_liq_ice::FT, ρ::FT,
+  q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
+  T, converged = find_zero(
+    T -> T - air_temperature_from_liquid_ice_pottemp(θ_liq_ice, air_pressure(T, ρ, q), q),
+    FT(T_min), FT(T_max), SecantMethod(), FT(1e-3), 10)
+  return T
 end
 
 """
@@ -824,7 +824,7 @@ end
 
 Latent heat for liquid and ice phases
 """
-latent_heat_liq_ice(q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+latent_heat_liq_ice(q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   FT(LH_v0)*q.liq + FT(LH_s0)*q.ice
 
 """
@@ -837,7 +837,7 @@ and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
 function liquid_ice_pottemp_given_pressure(T::FT, p::FT,
-  q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
+  q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
     # liquid-ice potential temperature, approximating latent heats
     # of phase transitions as constants
     return dry_pottemp_given_pressure(T, p, q) * (1 - latent_heat_liq_ice(q)/(cp_m(q)*T))
@@ -853,11 +853,8 @@ The liquid-ice potential temperature where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-function liquid_ice_pottemp(T::FT, ρ::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
-    # liquid-ice potential temperature, approximating latent heats
-    # of phase transitions as constants
-    return dry_pottemp(T, ρ, q) * (1 - latent_heat_liq_ice(q)/(cp_m(q)*T))
-end
+liquid_ice_pottemp(T::FT, ρ::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
+  liquid_ice_pottemp_given_pressure(T, air_pressure(T, ρ, q), q)
 
 """
     liquid_ice_pottemp(ts::ThermodynamicState)
@@ -879,7 +876,7 @@ The dry potential temperature where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
  """
-dry_pottemp(T::FT, ρ::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+dry_pottemp(T::FT, ρ::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   T / exner(T, ρ, q)
 
 """
@@ -892,8 +889,8 @@ The dry potential temperature where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
  """
-dry_pottemp_given_pressure(T::FT, p::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
-  T / exner(p, q)
+dry_pottemp_given_pressure(T::FT, p::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
+  T / exner_given_pressure(p, q)
 
 """
     dry_pottemp(ts::ThermodynamicState)
@@ -916,20 +913,11 @@ and, optionally,
 """
 function air_temperature_from_liquid_ice_pottemp(θ_liq_ice::FT,
                                                  p::FT,
-                                                 q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))
+                                                 q::PhasePartition{FT}=q_pt_0(FT)
                                                  ) where {FT<:Real}
   # liquid-ice potential temperature, approximating latent heats
   # of phase transitions as constants
-  return θ_liq_ice*exner(p, q) + latent_heat_liq_ice(q) / cp_m(q)
-end
-function air_temperature_from_liquid_ice_pottemp(θ_liq_ice::FT,
-                                                 T::FT,
-                                                 ρ::FT,
-                                                 q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))
-                                                 ) where {FT<:Real}
-  # liquid-ice potential temperature, approximating latent heats
-  # of phase transitions as constants
-  return θ_liq_ice*exner(T, ρ, q) + latent_heat_liq_ice(q) / cp_m(q)
+  return θ_liq_ice*exner_given_pressure(p, q) + latent_heat_liq_ice(q) / cp_m(q)
 end
 
 """
@@ -942,7 +930,7 @@ The virtual temperature where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-virtual_pottemp(T::FT, ρ::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real} =
+virtual_pottemp(T::FT, ρ::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   gas_constant_air(q) / FT(R_d) * dry_pottemp(T, ρ, q)
 
 """
@@ -956,36 +944,31 @@ virtual_pottemp(ts::ThermodynamicState) =
 virtual_pottemp(ts::PhaseDry{FT}) where {FT<:Real} = gas_constant_air(ts) / FT(R_d) * dry_pottemp(ts)
 
 """
-    liquid_ice_pottemp_sat_given_pressure(T, p[, q::PhasePartition])
+    liquid_ice_pottemp_sat(T, ρ[, q::PhasePartition])
 
 The saturated liquid ice potential temperature where
 
  - `T` temperature
- - `p` pressure
+ - `ρ` density
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-function liquid_ice_pottemp_sat_given_pressure(T::FT, p::FT,
-  q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
-    ρ = air_density(T, p, q)
-    q_v_sat = q_vap_saturation(T, ρ, q)
-    return liquid_ice_pottemp(T, p, PhasePartition(q_v_sat))
-end
-
-"""
-    liquid_ice_pottemp_sat(T, p[, q::PhasePartition])
-
-The saturated liquid ice potential temperature where
-
- - `T` temperature
- - `p` pressure
-and, optionally,
- - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
-"""
-function liquid_ice_pottemp_sat(T::FT, ρ::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
+function liquid_ice_pottemp_sat(T::FT, ρ::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
     q_v_sat = q_vap_saturation(T, ρ, q)
     return liquid_ice_pottemp(T, ρ, PhasePartition(q_v_sat))
 end
+
+"""
+    liquid_ice_pottemp_sat(T, ρ, q_tot)
+
+The saturated liquid ice potential temperature where
+
+ - `T` temperature
+ - `ρ` density
+ - `q_tot` total specific humidity
+"""
+liquid_ice_pottemp_sat(T::FT, ρ::FT, q_tot::FT) where {FT<:Real} =
+    liquid_ice_pottemp(T, ρ, PhasePartition_equil(T, ρ, q_tot))
 
 """
     liquid_ice_pottemp_sat(ts::ThermodynamicState)
@@ -998,14 +981,14 @@ liquid_ice_pottemp_sat(ts::PhaseDry) =
   liquid_ice_pottemp(air_temperature(ts), air_density(ts), PhasePartition(q_vap_saturation(ts)))
 
 """
-    exner(p[, q::PhasePartition])
+    exner_given_pressure(p[, q::PhasePartition])
 
 The Exner function where
  - `p` pressure
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-function exner(p::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
+function exner_given_pressure(p::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
     # gas constant and isobaric specific heat of moist air
     _R_m    = gas_constant_air(q)
     _cp_m   = cp_m(q)
@@ -1022,21 +1005,15 @@ The Exner function where
 and, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument the results are that of dry air.
 """
-function exner(T::FT, ρ::FT, q::PhasePartition{FT}=PhasePartition{FT}(FT(0), FT(0), FT(0))) where {FT<:Real}
-    # gas constant and isobaric specific heat of moist air
-    _R_m    = gas_constant_air(q)
-    _cp_m   = cp_m(q)
-
-    return (air_pressure(T, ρ, q)/FT(MSLP))^(_R_m/_cp_m)
-end
+exner(T::FT, ρ::FT, q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
+   exner_given_pressure(air_pressure(T, ρ, q), q)
 
 """
     exner(ts::ThermodynamicState)
 
 The Exner function, given a thermodynamic state `ts`.
 """
-exner(ts::ThermodynamicState) =
-  exner(air_pressure(ts), PhasePartition(ts))
+exner(ts::ThermodynamicState) = exner(air_temperature(ts), air_density(ts), PhasePartition(ts))
 exner(ts::PhaseDry{FT}) where {FT<:Real} = (air_pressure(ts)/FT(MSLP))^(gas_constant_air(ts)/cp_m(ts))
 
 """

--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -761,7 +761,7 @@ function saturation_adjustment(e_int::FT, ρ::FT, q_tot::FT) where {FT<:Real}
       T -> internal_energy_sat(T, ρ, q_tot) - e_int,
       T_1, T_2, SecantMethod(), FT(1e-3), 10)
       if !converged
-        error("saturation adjustment did not converge")
+        error("saturation_adjustment did not converge")
       end
     return T
   end
@@ -796,7 +796,7 @@ function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, q_tot::FT, ρ::F
       T -> liquid_ice_pottemp_sat(T, ρ, q_tot) - θ_liq_ice,
       T_1, T_2, SecantMethod(), FT(1e-5), 40)
       if !converged
-        error("saturation adjustment did not converge")
+        error("saturation_adjustment_q_tot_θ_liq_ice did not converge")
       end
     return T
   end
@@ -919,6 +919,9 @@ function air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice::FT, ρ::
   T, converged = find_zero(
     T -> T - air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice, air_pressure(T, ρ, q), q),
     FT(T_min), FT(T_max), SecantMethod(), FT(1e-3), 10)
+  if !converged
+    error("air_temperature_from_liquid_ice_pottemp_non_linear did not converge")
+  end
   return T
 end
 

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -163,7 +163,7 @@ Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
  - `ρ` - density
 """
 function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT) where {FT<:Real}
-    T = air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice, ρ, q_pt)
+    T = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, q_pt)
     e_int = internal_energy(T, q_pt)
     PhaseNonEquil(e_int, q_pt, ρ)
 end

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -6,8 +6,7 @@ export ThermodynamicState,
        PhaseNonEquil,
        TemperatureSHumEquil,
        LiquidIcePotTempSHumEquil,
-       LiquidIcePotTempSHumEquil_no_ρ,
-       LiquidIcePotTempSHumNonEquil_no_ρ
+       LiquidIcePotTempSHumNonEquil
 
 """
     PhasePartition
@@ -98,56 +97,28 @@ struct PhaseDry{FT} <: ThermodynamicState{FT}
 end
 
 """
-    LiquidIcePotTempSHumEquil(θ_liq_ice, q_tot, ρ, p)
+    LiquidIcePotTempSHumEquil(θ_liq_ice, q_tot, ρ)
+    LiquidIcePotTempSHumEquil(θ_liq_ice, q_tot, ρ[, p])
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 
  - `θ_liq_ice` - liquid-ice potential temperature
  - `q_tot` - total specific humidity
  - `ρ` - density
+and, optionally
  - `p` - pressure
 """
-function LiquidIcePotTempSHumEquil(θ_liq_ice::FT, q_tot::FT, ρ::FT, p::FT) where {FT<:Real}
-    T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ, p)
-    q = PhasePartition_equil(T, ρ, q_tot)
-    e_int = internal_energy(T, q)
-    PhaseEquil(e_int, q_tot, ρ, T)
-end
-
-"""
-    LiquidIcePotTempSHumEquil_no_ρ(θ_liq_ice, q_tot, p)
-
-Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
-
- - `θ_liq_ice` - liquid-ice potential temperature
- - `q_tot` - total specific humidity
- - `p` - pressure
-"""
-function LiquidIcePotTempSHumEquil_no_ρ(θ_liq_ice::FT, q_tot::FT, p::FT) where {FT<:Real}
-    q_pt_dry = PhasePartition(q_tot)
-    T_dry = θ_liq_ice * exner(p, q_pt_dry)
-    ρ_dry = air_density(T_dry, p, q_pt_dry)
-    T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ_dry, p)
-    ρ = air_density(T, p, q_pt_dry)
+function LiquidIcePotTempSHumEquil(θ_liq_ice::FT, q_tot::FT, ρ::FT) where {FT<:Real}
+    T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ)
     q_pt = PhasePartition_equil(T, ρ, q_tot)
     e_int = internal_energy(T, q_pt)
-    PhaseEquil(e_int, q_tot, ρ, T)
+    return PhaseEquil(e_int, q_tot, ρ, T)
 end
-
-"""
-    LiquidIcePotTempSHumEquil_no_ρ(θ_liq_ice, q_tot, p)
-
-Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
-
- - `θ_liq_ice` - liquid-ice potential temperature
- - `q_pt` - phase partition
- - `p` - pressure
-"""
-function LiquidIcePotTempSHumEquil_no_ρ(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT) where {FT<:Real}
-    T = θ_liq_ice * exner(p, q_pt)
-    ρ = air_density(T, p, q_pt)
+function LiquidIcePotTempSHumEquil(θ_liq_ice::FT, q_tot::FT, ρ::FT, p::FT) where {FT<:Real}
+    T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ, p)
+    q_pt = PhasePartition_equil(T, ρ, q_tot)
     e_int = internal_energy(T, q_pt)
-    PhaseEquil(e_int, q_pt.tot, ρ, T)
+    return PhaseEquil(e_int, q_tot, ρ, T)
 end
 
 """
@@ -191,7 +162,7 @@ struct PhaseNonEquil{FT} <: ThermodynamicState{FT}
 end
 
 """
-    LiquidIcePotTempSHumNonEquil_no_ρ(θ_liq_ice, q_tot, p)
+    LiquidIcePotTempSHumNonEquil(θ_liq_ice, q_tot, p)
 
 Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 
@@ -199,8 +170,8 @@ Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
  - `q_pt` - phase partition
  - `p` - pressure
 """
-function LiquidIcePotTempSHumNonEquil_no_ρ(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT) where {FT<:Real}
-    T = θ_liq_ice * exner(p, q_pt)
+function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT) where {FT<:Real}
+    T = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p, q_pt)
     ρ = air_density(T, p, q_pt)
     e_int = internal_energy(T, q_pt)
     PhaseNonEquil(e_int, q_pt, ρ)

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -7,7 +7,7 @@ export ThermodynamicState,
        TemperatureSHumEquil,
        LiquidIcePotTempSHumEquil,
        LiquidIcePotTempSHumNonEquil,
-       LiquidIcePotTempSHumNonEquil_density
+       LiquidIcePotTempSHumNonEquil_given_pressure
 
 """
     PhasePartition
@@ -154,23 +154,7 @@ struct PhaseNonEquil{FT} <: ThermodynamicState{FT}
 end
 
 """
-    LiquidIcePotTempSHumNonEquil(θ_liq_ice, q_pt, p)
-
-Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
-
- - `θ_liq_ice` - liquid-ice potential temperature
- - `q_pt` - phase partition
- - `p` - pressure
-"""
-function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT) where {FT<:Real}
-    T = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p, q_pt)
-    ρ = air_density(T, p, q_pt)
-    e_int = internal_energy(T, q_pt)
-    PhaseNonEquil(e_int, q_pt, ρ)
-end
-
-"""
-    LiquidIcePotTempSHumNonEquil_density(θ_liq_ice, q_pt, ρ)
+    LiquidIcePotTempSHumNonEquil(θ_liq_ice, q_pt, ρ)
 
 Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 
@@ -178,8 +162,24 @@ Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
  - `q_pt` - phase partition
  - `ρ` - density
 """
-function LiquidIcePotTempSHumNonEquil_density(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT) where {FT<:Real}
-    T = air_temperature_initial_guess(θ_liq_ice, ρ, q_pt)
+function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT) where {FT<:Real}
+    T = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, q_pt)
+    e_int = internal_energy(T, q_pt)
+    PhaseNonEquil(e_int, q_pt, ρ)
+end
+
+"""
+    LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice, q_pt, p)
+
+Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
+
+ - `θ_liq_ice` - liquid-ice potential temperature
+ - `q_pt` - phase partition
+ - `p` - pressure
+"""
+function LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT) where {FT<:Real}
+    T = air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice, p, q_pt)
+    ρ = air_density(T, p, q_pt)
     e_int = internal_energy(T, q_pt)
     PhaseNonEquil(e_int, q_pt, ρ)
 end

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -6,7 +6,8 @@ export ThermodynamicState,
        PhaseNonEquil,
        TemperatureSHumEquil,
        LiquidIcePotTempSHumEquil,
-       LiquidIcePotTempSHumNonEquil
+       LiquidIcePotTempSHumNonEquil,
+       LiquidIcePotTempSHumNonEquil_density
 
 """
     PhasePartition
@@ -98,24 +99,15 @@ end
 
 """
     LiquidIcePotTempSHumEquil(θ_liq_ice, q_tot, ρ)
-    LiquidIcePotTempSHumEquil(θ_liq_ice, q_tot, ρ[, p])
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 
  - `θ_liq_ice` - liquid-ice potential temperature
  - `q_tot` - total specific humidity
  - `ρ` - density
-and, optionally
- - `p` - pressure
 """
 function LiquidIcePotTempSHumEquil(θ_liq_ice::FT, q_tot::FT, ρ::FT) where {FT<:Real}
     T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ)
-    q_pt = PhasePartition_equil(T, ρ, q_tot)
-    e_int = internal_energy(T, q_pt)
-    return PhaseEquil(e_int, q_tot, ρ, T)
-end
-function LiquidIcePotTempSHumEquil(θ_liq_ice::FT, q_tot::FT, ρ::FT, p::FT) where {FT<:Real}
-    T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ, p)
     q_pt = PhasePartition_equil(T, ρ, q_tot)
     e_int = internal_energy(T, q_pt)
     return PhaseEquil(e_int, q_tot, ρ, T)
@@ -162,7 +154,7 @@ struct PhaseNonEquil{FT} <: ThermodynamicState{FT}
 end
 
 """
-    LiquidIcePotTempSHumNonEquil(θ_liq_ice, q_tot, p)
+    LiquidIcePotTempSHumNonEquil(θ_liq_ice, q_pt, p)
 
 Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 
@@ -173,6 +165,21 @@ Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT) where {FT<:Real}
     T = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, p, q_pt)
     ρ = air_density(T, p, q_pt)
+    e_int = internal_energy(T, q_pt)
+    PhaseNonEquil(e_int, q_pt, ρ)
+end
+
+"""
+    LiquidIcePotTempSHumNonEquil_density(θ_liq_ice, q_pt, ρ)
+
+Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
+
+ - `θ_liq_ice` - liquid-ice potential temperature
+ - `q_pt` - phase partition
+ - `ρ` - density
+"""
+function LiquidIcePotTempSHumNonEquil_density(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT) where {FT<:Real}
+    T = air_temperature_initial_guess(θ_liq_ice, ρ, q_pt)
     e_int = internal_energy(T, q_pt)
     PhaseNonEquil(e_int, q_pt, ρ)
 end

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -163,7 +163,7 @@ Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
  - `ρ` - density
 """
 function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT) where {FT<:Real}
-    T = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, q_pt)
+    T = air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice, ρ, q_pt)
     e_int = internal_energy(T, q_pt)
     PhaseNonEquil(e_int, q_pt, ρ)
 end

--- a/src/Common/PlanetParameters/PlanetParameters.jl
+++ b/src/Common/PlanetParameters/PlanetParameters.jl
@@ -39,6 +39,7 @@ using ..ParametersType
 @exportparameter cv_i              cp_i          "Isochoric specific heat ice (J/kg/K)"
 @exportparameter T_freeze          273.15        "Freezing point temperature (K)"
 @exportparameter T_min             150.0         "Minimum temperature guess in saturation adjustment (K)"
+@exportparameter T_max             450.0         "Maximum temperature guess in saturation adjustment (K)"
 @exportparameter T_icenuc          233.00        "Homogeneous nucleation temperature (K)"
 @exportparameter T_triple          273.16        "Triple point temperature (K)"
 @exportparameter T_0               T_triple      "Reference temperature (K)"

--- a/src/Common/PlanetParameters/PlanetParameters.jl
+++ b/src/Common/PlanetParameters/PlanetParameters.jl
@@ -39,7 +39,7 @@ using ..ParametersType
 @exportparameter cv_i              cp_i          "Isochoric specific heat ice (J/kg/K)"
 @exportparameter T_freeze          273.15        "Freezing point temperature (K)"
 @exportparameter T_min             150.0         "Minimum temperature guess in saturation adjustment (K)"
-@exportparameter T_max             450.0         "Maximum temperature guess in saturation adjustment (K)"
+@exportparameter T_max             1000.0        "Maximum temperature guess in saturation adjustment (K)"
 @exportparameter T_icenuc          233.00        "Homogeneous nucleation temperature (K)"
 @exportparameter T_triple          273.16        "Triple point temperature (K)"
 @exportparameter T_0               T_triple      "Reference temperature (K)"

--- a/test/Common/MoistThermodynamics/runtests.jl
+++ b/test/Common/MoistThermodynamics/runtests.jl
@@ -217,12 +217,7 @@ end
 
   # LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT): Moist case
   ts = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, q_pt_moist, ρ)
-
-  q = PhasePartition.(ts)
-  err_bounds = 0.0004*(latent_heat_liq_ice.(q)./cv_m.(q)).^2
-  θ_liq_ice_diff = abs.(θ_liq_ice - liquid_ice_pottemp.(ts))
-  @test θ_liq_ice_diff[1] ≈ 0 # Dry case
-  @test all(θ_liq_ice_diff[2:end] .< err_bounds[2:end])
+  @test all(θ_liq_ice .≈ liquid_ice_pottemp.(ts))
   @test all(air_density.(ts) .≈ ρ)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt_moist,:tot))
   @test all(getproperty.(PhasePartition.(ts),:liq) .≈ getproperty.(q_pt_moist,:liq))


### PR DESCRIPTION
Adds consistency tests to `ThermoDynamicState` constructors:

 - Tests that getter functions return the same value as input arguments to the thermo state.

@tapios 10 of these tests are failing (related to pressure and liquid-ice potential temperature), and I may need your help in resolving some of these tests. This is likely the issue that @smarras79, @slifer50 is running into with initial conditions prescribed by liquid ice potential temperature.