### PR TITLE
Reformulate ARK timesteppers

### DIFF
--- a/src/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -3,6 +3,16 @@ export AdditiveRungeKutta
 export ARK2GiraldoKellyConstantinescu
 export ARK548L2SA2KennedyCarpenter, ARK437L2SA1KennedyCarpenter
 
+# Naive formulation that uses equation 3.8 from Giraldo, Kelly, and Constantinescu (2013) directly.
+# Seems to cut the number of solver iterations by half but requires Nstages - 1 additional storage.
+struct NaiveVariant end
+additional_storage(::NaiveVariant, Q, Nstages) = (Lstages = ntuple(i -> similar(Q), Nstages),)
+
+# Formulation that does things exactly as in Giraldo, Kelly, and Constantinescu (2013).
+# Uses only one additional vector of storage regardless of the number of stages.
+struct LowStorageVariant end
+additional_storage(::LowStorageVariant, Q, Nstages) = (Qtt = similar(Q),)
+
 using GPUifyLoops
 include("AdditiveRungeKuttaMethod_kernels.jl")
 
@@ -41,31 +51,44 @@ function (op::EulerOperator)(LQ, Q, args...)
 end
 
 """
-    AdditiveRungeKutta(f, l, linsol, RKAe, RKAi, RKB, RKC, Q; dt, t0 = 0)
+    AdditiveRungeKutta(f, l, linearsolver, RKAe, RKAi, RKB, RKC, Q;
+                       split_nonlinear_linear, variant, dt, t0 = 0)
 
-This is a time stepping object for implicit-explicit time stepping of the
-decomposed differential equation given by the chosen linear operator `l`,
-the full right-hand-side function `f` and the state `Q`, i.e.,
+This is a time stepping object for implicit-explicit time stepping of a
+decomposed differential equation. When `split_nonlinear_linear == false`
+the equation is assumed to be decomposed as
 
 ```math
   \\dot{Q} = [l(Q, t)] + [f(Q, t) - l(Q, t)]
 ```
 
-with the required time step size `dt` and optional initial time `t0`. The
+where `Q` is the state, `f` is the full tendency and
+`l` is the chosen linear operator. When `split_nonlinear_linear == true`
+the assumed decomposition is
+
+```math
+  \\dot{Q} = [l(Q, t)] + [f(Q, t)]
+```
+
+where `f` is now only the nonlinear tendency. For both decompositions the
 linear operator `l` is integrated implicitly whereas the remaining part
-`f - l` is integrated explicitly. This time stepping object is intended
+is integrated explicitly. Other arguments are the required time step size `dt`
+and the optional initial time `t0`. The resulting linear systems are solved
+using the provided `linearsolver` solver. This time stepping object is intended
 to be passed to the `solve!` command.
 
 The constructor builds an additive Runge--Kutta scheme 
 based on the provided `RKAe`, `RKAi`, `RKB` and `RKC` coefficient arrays.
-The resulting linear systems are solved using the provided `linsol` function.
+Additionally `variant` specifies which of the analytically equivalent but numerically
+different formulations of the scheme is used.
 
 The available concrete implementations are:
 
   - [`ARK2GiraldoKellyConstantinescu`](@ref)
   - [`ARK548L2SA2KennedyCarpenter`](@ref)
+  - [`ARK437L2SA1KennedyCarpenter`](@ref)
 """
-mutable struct AdditiveRungeKutta{T, RT, AT, LT, Nstages, Nstages_sq} <: ODEs.AbstractODESolver
+mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <: ODEs.AbstractODESolver
   "time step"
   dt::RT
   "time"
@@ -84,8 +107,6 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, Nstages, Nstages_sq} <: ODEs.Ab
   Rstages::NTuple{Nstages, AT}
   "Storage for the linear solver rhs vector"
   Qhat::AT
-  "Storage for the linear solver solution variable"
-  Qtt::AT
   "RK coefficient matrix A for the explicit scheme"
   RKA_explicit::SArray{NTuple{2, Nstages}, RT, 2, Nstages_sq}
   "RK coefficient matrix A for the implicit scheme"
@@ -95,12 +116,16 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, Nstages, Nstages_sq} <: ODEs.Ab
   "RK coefficient vector C (time scaling)"
   RKC::SArray{Tuple{Nstages}, RT, 1, Nstages}
   split_nonlinear_linear::Bool
+  "Variant of the ARK scheme"
+  variant::V
+  "Storage dependent on the variant of the ARK scheme"
+  variant_storage::VS
 
   function AdditiveRungeKutta(rhs!,
                               rhs_linear!,
                               linearsolver::AbstractLinearSolver,
                               RKA_explicit, RKA_implicit, RKB, RKC,
-                              split_nonlinear_linear,
+                              split_nonlinear_linear, variant,
                               Q::AT; dt=nothing, t0=0) where {AT<:AbstractArray}
 
     @assert dt != nothing
@@ -109,17 +134,19 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, Nstages, Nstages_sq} <: ODEs.Ab
     LT = typeof(linearsolver)
     RT = real(T)
     
-    nstages = length(RKB)
+    Nstages = length(RKB)
 
-    Qstages = (Q, ntuple(i -> similar(Q), nstages - 1)...)
-    Rstages = ntuple(i -> similar(Q), nstages)
-    
+    Qstages = (Q, ntuple(i -> similar(Q), Nstages - 1)...)
+    Rstages = ntuple(i -> similar(Q), Nstages)
     Qhat = similar(Q)
-    Qtt = similar(Q)
+    
+    V = typeof(variant)
+    variant_storage = additional_storage(variant, Q, Nstages)
+    VS = typeof(variant_storage)
 
     # The code throughout assumes SDIRK implicit tableau so we assert that
     # here.
-    for is = 2:nstages
+    for is = 2:Nstages
       @assert RKA_implicit[is, is] ≈ RKA_implicit[2, 2]
     end
 
@@ -130,11 +157,12 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, Nstages, Nstages_sq} <: ODEs.Ab
     implicitoperator! = prefactorize(EulerOperator(rhs_linear!, -α),
                                      linearsolver, Q, nothing, T(NaN))
 
-    new{T, RT, AT, LT, nstages, nstages ^ 2}(RT(dt), RT(t0),
-                                             rhs!, rhs_linear!, implicitoperator!, linearsolver,
-                                             Qstages, Rstages, Qhat, Qtt,
-                                             RKA_explicit, RKA_implicit, RKB, RKC,
-                                             split_nonlinear_linear)
+    new{T, RT, AT, LT, V, VS, Nstages, Nstages ^ 2}(RT(dt), RT(t0),
+                                                    rhs!, rhs_linear!, implicitoperator!, linearsolver,
+                                                    Qstages, Rstages, Qhat,
+                                                    RKA_explicit, RKA_implicit, RKB, RKC,
+                                                    split_nonlinear_linear,
+                                                    variant, variant_storage)
   end
 end
 
@@ -142,13 +170,13 @@ function AdditiveRungeKutta(spacedisc::AbstractSpaceMethod,
                             spacedisc_linear::AbstractSpaceMethod,
                             linearsolver::AbstractLinearSolver,
                             RKA_explicit, RKA_implicit, RKB, RKC,
-                            split_nonlinear_linear,
+                            split_nonlinear_linear, variant,
                             Q::AT; dt=nothing, t0=0) where {AT<:AbstractArray}
   rhs! = (x...; increment) -> SpaceMethods.odefun!(spacedisc, x..., increment = increment)
   rhs_linear! = (x...; increment) -> SpaceMethods.odefun!(spacedisc_linear, x..., increment = increment)
   AdditiveRungeKutta(rhs!, rhs_linear!, linearsolver,
                      RKA_explicit, RKA_implicit, RKB, RKC,
-                     split_nonlinear_linear,
+                     split_nonlinear_linear, variant,
                      Q; dt=dt, t0=t0)
 end
 
@@ -182,13 +210,85 @@ end
 function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
                       slow_δ = nothing, slow_rv_dQ = nothing,
                       slow_scaling = nothing)
+  ODEs.dostep!(Q, ark, ark.variant, p, time, dt, slow_δ, slow_rv_dQ, slow_scaling)
+end
+
+function ODEs.dostep!(Q, ark::AdditiveRungeKutta, variant::NaiveVariant,
+                      p, time::Real, dt::Real,
+                      slow_δ = nothing, slow_rv_dQ = nothing,
+                      slow_scaling = nothing)
   implicitoperator!, linearsolver = ark.implicitoperator!, ark.linearsolver
   RKA_explicit, RKA_implicit = ark.RKA_explicit, ark.RKA_implicit
   RKB, RKC = ark.RKB, ark.RKC
   rhs!, rhs_linear! = ark.rhs!, ark.rhs_linear!
   Qstages, Rstages = ark.Qstages, ark.Rstages
-  Qhat, Qtt = ark.Qhat, ark.Qtt
+  Qhat = ark.Qhat
   split_nonlinear_linear = ark.split_nonlinear_linear
+  Lstages = ark.variant_storage.Lstages
+
+  rv_Q = realview(Q)
+  rv_Qstages = realview.(Qstages)
+  rv_Lstages = realview.(Lstages)
+  rv_Rstages = realview.(Rstages)
+  rv_Qhat = realview(Qhat)
+
+  Nstages = length(RKB)
+
+  threads = 256
+  blocks = div(length(rv_Q) + threads - 1, threads)
+
+  # calculate the rhs at first stage to initialize the stage loop
+  rhs!(Rstages[1], Qstages[1], p, time + RKC[1] * dt, increment = false)
+  
+  if dt != ark.dt
+    α = dt * RKA_implicit[2, 2]
+    implicitoperator! = EulerOperator(rhs_linear!, -α)
+  end
+
+  rhs_linear!(Lstages[1], Qstages[1], p, time + RKC[1] * dt, increment = false)
+
+  # note that it is important that this loop does not modify Q!
+  for istage = 2:Nstages
+    stagetime = time + RKC[istage] * dt
+
+    # this kernel also initializes Qstages[istage] with an initial guess
+    # for the linear solver
+    @launch(device(Q), threads = threads, blocks = blocks,
+            stage_update!(variant, rv_Q, rv_Qstages, rv_Lstages, rv_Rstages, rv_Qhat,
+                          RKA_explicit, RKA_implicit, dt, Val(istage),
+                          Val(split_nonlinear_linear), slow_δ, slow_rv_dQ))
+
+    #solves Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_linear!(Q_tt)
+    α = dt * RKA_implicit[istage, istage]
+    linearoperator! = function(LQ, Q)
+      rhs_linear!(LQ, Q, p, stagetime; increment = false)
+      @. LQ = Q - α * LQ
+    end
+    linearsolve!(implicitoperator!, linearsolver, Qstages[istage], Qhat, p, stagetime)
+    
+    rhs!(Rstages[istage], Qstages[istage], p, stagetime, increment = false)
+    rhs_linear!(Lstages[istage], Qstages[istage], p, stagetime, increment = false)
+  end
+
+  # compose the final solution
+  @launch(device(Q), threads = threads, blocks = blocks,
+          solution_update!(variant, rv_Q, rv_Lstages, rv_Rstages, RKB, dt,
+                           Val(Nstages), Val(split_nonlinear_linear),
+                           slow_δ, slow_rv_dQ, slow_scaling))
+end
+
+function ODEs.dostep!(Q, ark::AdditiveRungeKutta, variant::LowStorageVariant,
+                      p, time::Real, dt::Real,
+                      slow_δ = nothing, slow_rv_dQ = nothing,
+                      slow_scaling = nothing)
+  implicitoperator!, linearsolver = ark.implicitoperator!, ark.linearsolver
+  RKA_explicit, RKA_implicit = ark.RKA_explicit, ark.RKA_implicit
+  RKB, RKC = ark.RKB, ark.RKC
+  rhs!, rhs_linear! = ark.rhs!, ark.rhs_linear!
+  Qstages, Rstages = ark.Qstages, ark.Rstages
+  Qhat = ark.Qhat
+  split_nonlinear_linear = ark.split_nonlinear_linear
+  Qtt = ark.variant_storage.Qtt
 
   rv_Q = realview(Q)
   rv_Qstages = realview.(Qstages)
@@ -196,7 +296,7 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
   rv_Qhat = realview(Qhat)
   rv_Qtt = realview(Qtt)
 
-  nstages = length(RKB)
+  Nstages = length(RKB)
 
   threads = 256
   blocks = div(length(rv_Q) + threads - 1, threads)
@@ -210,12 +310,12 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
   end
 
   # note that it is important that this loop does not modify Q!
-  for istage = 2:nstages
+  for istage = 2:Nstages
     stagetime = time + RKC[istage] * dt
 
     # this kernel also initializes Qtt for the linear solver
     @launch(device(Q), threads = threads, blocks = blocks,
-            stage_update!(rv_Q, rv_Qstages, rv_Rstages, rv_Qhat, rv_Qtt,
+            stage_update!(variant, rv_Q, rv_Qstages, rv_Rstages, rv_Qhat, rv_Qtt,
                           RKA_explicit, RKA_implicit, dt, Val(istage),
                           Val(split_nonlinear_linear), slow_δ, slow_rv_dQ))
 
@@ -229,7 +329,7 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
   end
 
   if split_nonlinear_linear
-    for istage = 1:nstages
+    for istage = 1:Nstages
       stagetime = time + RKC[istage] * dt
       rhs_linear!(Rstages[istage], Qstages[istage], p, stagetime, increment = true)
     end
@@ -237,30 +337,17 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
 
   # compose the final solution
   @launch(device(Q), threads = threads, blocks = blocks,
-          solution_update!(rv_Q, rv_Rstages, RKB, dt, Val(nstages), slow_δ,
-                           slow_rv_dQ, slow_scaling))
-
-
+          solution_update!(variant, rv_Q, rv_Rstages, RKB, dt, Val(Nstages),
+                           slow_δ, slow_rv_dQ, slow_scaling))
 end
 
 """
-    ARK2GiraldoKellyConstantinescu(f, l, linsol, Q; dt, t0 = 0)
+    ARK2GiraldoKellyConstantinescu(f, l, linearsolver, Q; dt, t0,
+                                   split_nonlinear_linear, variant)
 
-This function returns an [`AdditiveRungeKutta`](@ref) 
-time stepping object for implicit-explicit time stepping of the
-decomposed differential equation given by the chosen linear operator `l`,
-the full right-hand-side function `f` and the state `Q`, i.e.,
-
-```math
-  \\dot{Q} = [l(Q, t)] + [f(Q, t) - l(Q, t)]
-```
-
-with the required time step size `dt` and optional initial time `t0`. The
-linear operator `l` is integrated implicitly whereas the remaining part
-`f - l` is integrated explicitly. This time stepping object is intended
-to be passed to the `solve!` command.
-
-The resulting linear systems are solved using the provided `linsol` function.
+This function returns an [`AdditiveRungeKutta`](@ref) time stepping object,
+see the documentation of [`AdditiveRungeKutta`](@ref) for arguments definitions.
+This time stepping object is intended to be passed to the `solve!` command.
 
 This uses the second-order-accurate 3-stage additive Runge--Kutta scheme of
 Giraldo, Kelly and Constantinescu (2013).
@@ -280,7 +367,8 @@ Giraldo, Kelly and Constantinescu (2013).
 function ARK2GiraldoKellyConstantinescu(F, L,
                                         linearsolver::AbstractLinearSolver,
                                         Q::AT; dt=nothing, t0=0,
-                                        split_nonlinear_linear=false) where {AT<:AbstractArray}
+                                        split_nonlinear_linear=false,
+                                        variant=LowStorageVariant()) where {AT<:AbstractArray}
 
   @assert dt != nothing
 
@@ -299,32 +387,22 @@ function ARK2GiraldoKellyConstantinescu(F, L,
   RKB = [RT(1 / (2sqrt(2))), RT(1 / (2sqrt(2))), RT(1 - 1 / sqrt(2))]
   RKC = [RT(0), RT(2 - sqrt(2)), RT(1)]
   
-  nstages = length(RKB)
+  Nstages = length(RKB)
 
   AdditiveRungeKutta(F, L, linearsolver,
                      RKA_explicit, RKA_implicit, RKB, RKC,
                      split_nonlinear_linear,
+                     variant,
                      Q; dt=dt, t0=t0)
 end
 
 """
-    ARK548L2SA2KennedyCarpenter(f, l, linsol, Q; dt, t0 = 0)
+    ARK548L2SA2KennedyCarpenter(f, l, linearsolver, Q; dt, t0,
+                                split_nonlinear_linear, variant)
 
-This function returns an [`AdditiveRungeKutta`](@ref) 
-time stepping object for implicit-explicit time stepping of the
-decomposed differential equation given by the chosen linear operator `l`,
-the full right-hand-side function `f` and the state `Q`, i.e.,
-
-```math
-  \\dot{Q} = [l(Q, t)] + [f(Q, t) - l(Q, t)]
-```
-
-with the required time step size `dt` and optional initial time `t0`. The
-linear operator `l` is integrated implicitly whereas the remaining part
-`f - l` is integrated explicitly. This time stepping object is intended
-to be passed to the `solve!` command.
-
-The resulting linear systems are solved using the provided `linsol` function.
+This function returns an [`AdditiveRungeKutta`](@ref) time stepping object,
+see the documentation of [`AdditiveRungeKutta`](@ref) for arguments definitions.
+This time stepping object is intended to be passed to the `solve!` command.
 
 This uses the fifth-order-accurate 8-stage additive Runge--Kutta scheme of
 Kennedy and Carpenter (2013).
@@ -344,24 +422,25 @@ Kennedy and Carpenter (2013).
 function ARK548L2SA2KennedyCarpenter(F, L,
                                      linearsolver::AbstractLinearSolver,
                                      Q::AT; dt=nothing, t0=0,
-                                     split_nonlinear_linear=false) where {AT<:AbstractArray}
+                                     split_nonlinear_linear=false,
+                                     variant=LowStorageVariant()) where {AT<:AbstractArray}
 
   @assert dt != nothing
 
   T = eltype(Q)
   RT = real(T)
 
-  nstages = 8
+  Nstages = 8
   gamma = RT(2 // 9)
 
   # declared as Arrays for mutability, later these will be converted to static arrays
-  RKA_explicit = zeros(RT, nstages, nstages)
-  RKA_implicit = zeros(RT, nstages, nstages)
-  RKB = zeros(RT, nstages)
-  RKC = zeros(RT, nstages)
+  RKA_explicit = zeros(RT, Nstages, Nstages)
+  RKA_implicit = zeros(RT, Nstages, Nstages)
+  RKB = zeros(RT, Nstages)
+  RKC = zeros(RT, Nstages)
 
   # the main diagonal
-  for is = 2:nstages
+  for is = 2:Nstages
     RKA_implicit[is, is] = gamma
   end
 
@@ -423,59 +502,48 @@ function ARK548L2SA2KennedyCarpenter(F, L,
   RKC[6] = RT(18 // 25)
   RKC[7] = RT(191 // 200)
   
-  for is = 2:nstages
+  for is = 2:Nstages
     RKA_implicit[is, 1] = RKA_implicit[is, 2]
   end
  
-  for is = 1:nstages-1
-    RKA_implicit[nstages, is] = RKB[is]
+  for is = 1:Nstages-1
+    RKA_implicit[Nstages, is] = RKB[is]
   end
 
   RKB[1] = RKB[2]
   RKB[8] = gamma
 
   RKA_explicit[2, 1] = RKC[2]
-  RKA_explicit[nstages, 1] = RKA_explicit[nstages, 2]
+  RKA_explicit[Nstages, 1] = RKA_explicit[Nstages, 2]
 
   RKC[1] = 0
-  RKC[nstages] = 1
+  RKC[Nstages] = 1
 
   # conversion to static arrays
-  RKA_explicit = SMatrix{nstages, nstages}(RKA_explicit)
-  RKA_implicit = SMatrix{nstages, nstages}(RKA_implicit)
-  RKB = SVector{nstages}(RKB)
-  RKC = SVector{nstages}(RKC)
+  RKA_explicit = SMatrix{Nstages, Nstages}(RKA_explicit)
+  RKA_implicit = SMatrix{Nstages, Nstages}(RKA_implicit)
+  RKB = SVector{Nstages}(RKB)
+  RKC = SVector{Nstages}(RKC)
 
   ark = AdditiveRungeKutta(F, L, linearsolver,
                            RKA_explicit, RKA_implicit, RKB, RKC,
                            split_nonlinear_linear,
+                           variant,
                            Q; dt=dt, t0=t0)
 end
 
 """
-    ARK437L2SA1KennedyCarpenter(f, l, linsol, Q; dt, t0 = 0)
+    ARK437L2SA1KennedyCarpenter(f, l, linearsolver, Q; dt, t0,
+                                split_nonlinear_linear, variant)
 
-This function returns an [`AdditiveRungeKutta`](@ref) 
-time stepping object for implicit-explicit time stepping of the
-decomposed differential equation given by the chosen linear operator `l`,
-the full right-hand-side function `f` and the state `Q`, i.e.,
-
-```math
-  \\dot{Q} = [l(Q, t)] + [f(Q, t) - l(Q, t)]
-```
-
-with the required time step size `dt` and optional initial time `t0`. The
-linear operator `l` is integrated implicitly whereas the remaining part
-`f - l` is integrated explicitly. This time stepping object is intended
-to be passed to the `solve!` command.
-
-The resulting linear systems are solved using the provided `linsol` function.
+This function returns an [`AdditiveRungeKutta`](@ref) time stepping object,
+see the documentation of [`AdditiveRungeKutta`](@ref) for arguments definitions.
+This time stepping object is intended to be passed to the `solve!` command.
 
 This uses the fourth-order-accurate 7-stage additive Runge--Kutta scheme of
 Kennedy and Carpenter (2013).
 
 ### References
-
     @article{kennedy2019higher,
       title={Higher-order additive Runge--Kutta schemes for ordinary differential equations},
       author={Kennedy, Christopher A and Carpenter, Mark H},
@@ -489,24 +557,25 @@ Kennedy and Carpenter (2013).
 function ARK437L2SA1KennedyCarpenter(F, L,
                                      linearsolver::AbstractLinearSolver,
                                      Q::AT; dt=nothing, t0=0,
-                                     split_nonlinear_linear=false) where {AT<:AbstractArray}
+                                     split_nonlinear_linear=false,
+                                     variant=LowStorageVariant()) where {AT<:AbstractArray}
 
   @assert dt != nothing
 
   T = eltype(Q)
   RT = real(T)
 
-  nstages = 7
+  Nstages = 7
   gamma = RT(1235 // 10000)
 
   # declared as Arrays for mutability, later these will be converted to static arrays
-  RKA_explicit = zeros(RT, nstages, nstages)
-  RKA_implicit = zeros(RT, nstages, nstages)
-  RKB = zeros(RT, nstages)
-  RKC = zeros(RT, nstages)
+  RKA_explicit = zeros(RT, Nstages, Nstages)
+  RKA_implicit = zeros(RT, Nstages, Nstages)
+  RKB = zeros(RT, Nstages)
+  RKC = zeros(RT, Nstages)
 
   # the main diagonal
-  for is = 2:nstages
+  for is = 2:Nstages
     RKA_implicit[is, is] = gamma
   end
 
@@ -559,31 +628,32 @@ function ARK437L2SA1KennedyCarpenter(F, L,
   RKC[5] = RT(3 // 40)
   RKC[6] = RT(7 // 10)
 
-  for is = 2:nstages
+  for is = 2:Nstages
     RKA_implicit[is, 1] = RKA_implicit[is, 2]
   end
 
-  for is = 1:nstages-1
-    RKA_implicit[nstages, is] = RKB[is]
+  for is = 1:Nstages-1
+    RKA_implicit[Nstages, is] = RKB[is]
   end
 
   RKB[1] = RKB[2]
 
   RKA_explicit[2, 1] = RKC[2]
-  RKA_explicit[nstages, 1] = RKA_explicit[nstages, 2]
+  RKA_explicit[Nstages, 1] = RKA_explicit[Nstages, 2]
 
   RKC[1] = 0
-  RKC[nstages] = 1
+  RKC[Nstages] = 1
 
   # conversion to static arrays
-  RKA_explicit = SMatrix{nstages, nstages}(RKA_explicit)
-  RKA_implicit = SMatrix{nstages, nstages}(RKA_implicit)
-  RKB = SVector{nstages}(RKB)
-  RKC = SVector{nstages}(RKC)
+  RKA_explicit = SMatrix{Nstages, Nstages}(RKA_explicit)
+  RKA_implicit = SMatrix{Nstages, Nstages}(RKA_implicit)
+  RKB = SVector{Nstages}(RKB)
+  RKC = SVector{Nstages}(RKC)
 
   ark = AdditiveRungeKutta(F, L, linearsolver,
                            RKA_explicit, RKA_implicit, RKB, RKC,
                            split_nonlinear_linear,
+                           variant,
                            Q; dt=dt, t0=t0)
 end
 

--- a/src/ODESolvers/AdditiveRungeKuttaMethod_kernels.jl
+++ b/src/ODESolvers/AdditiveRungeKuttaMethod_kernels.jl
@@ -3,7 +3,39 @@ using Requires
   using .CUDAnative
 end
 
-function stage_update!(Q, Qstages, Rstages, Qhat, Qtt, RKA_explicit, RKA_implicit, dt,
+function stage_update!(::NaiveVariant,
+                       Q, Qstages, Lstages, Rstages, Qhat,
+                       RKA_explicit, RKA_implicit, dt,
+                       ::Val{is}, ::Val{split_nonlinear_linear},
+                       slow_δ, slow_dQ) where {is, split_nonlinear_linear}
+  @inbounds @loop for i = (1:length(Q);
+                           (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+    Qhat_i = Q[i]
+    Qstages_is_i = Q[i]
+
+    if slow_δ !== nothing
+      Rstages[is-1][i] += slow_δ * slow_dQ[i]
+    end
+
+    @unroll for js = 1:is-1
+      R_explicit = dt * RKA_explicit[is, js] * Rstages[js][i]
+      L_explicit = dt * RKA_explicit[is, js] * Lstages[js][i]
+      L_implicit = dt * RKA_implicit[is, js] * Lstages[js][i]
+      Qhat_i += (R_explicit + L_implicit)
+      Qstages_is_i += R_explicit
+      if split_nonlinear_linear
+        Qstages_is_i += L_explicit
+      else
+        Qhat_i -= L_explicit
+      end
+    end
+    Qstages[is][i] = Qstages_is_i
+    Qhat[i] = Qhat_i
+  end
+end
+
+function stage_update!(::LowStorageVariant,
+                       Q, Qstages, Rstages, Qhat, Qtt, RKA_explicit, RKA_implicit, dt,
                        ::Val{is}, ::Val{split_nonlinear_linear}, slow_δ,
                        slow_dQ) where {is, split_nonlinear_linear}
   @inbounds @loop for i = (1:length(Q);
@@ -31,18 +63,41 @@ function stage_update!(Q, Qstages, Rstages, Qhat, Qtt, RKA_explicit, RKA_implici
   end
 end
 
-function solution_update!(Q, Rstages, RKB, dt, ::Val{nstages}, slow_δ,
-                          slow_dQ, slow_scaling) where nstages
+function solution_update!(::NaiveVariant,
+                          Q, Lstages, Rstages, RKB, dt,
+                          ::Val{Nstages}, ::Val{split_nonlinear_linear},
+                          slow_δ, slow_dQ, slow_scaling) where {Nstages, split_nonlinear_linear}
   @inbounds @loop for i = (1:length(Q);
                            (blockIdx().x - 1) * blockDim().x + threadIdx().x)
     if slow_δ !== nothing
-      Rstages[nstages][i] += slow_δ * slow_dQ[i]
+      Rstages[Nstages][i] += slow_δ * slow_dQ[i]
     end
     if slow_scaling !== nothing
       slow_dQ[i] *= slow_scaling
     end
 
-    @unroll for is = 1:nstages
+    @unroll for is = 1:Nstages
+      Q[i] += RKB[is] * dt * Rstages[is][i]
+      if split_nonlinear_linear
+        Q[i] += RKB[is] * dt * Lstages[is][i]
+      end
+    end
+  end
+end
+
+function solution_update!(::LowStorageVariant,
+                          Q, Rstages, RKB, dt, ::Val{Nstages}, slow_δ,
+                          slow_dQ, slow_scaling) where Nstages
+  @inbounds @loop for i = (1:length(Q);
+                           (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+    if slow_δ !== nothing
+      Rstages[Nstages][i] += slow_δ * slow_dQ[i]
+    end
+    if slow_scaling !== nothing
+      slow_dQ[i] *= slow_scaling
+    end
+
+    @unroll for is = 1:Nstages
       Q[i] += RKB[is] * dt * Rstages[is][i]
     end
   end

--- a/test/ODESolvers/runtests.jl
+++ b/test/ODESolvers/runtests.jl
@@ -4,6 +4,7 @@ using CLIMA.ODESolvers
 using CLIMA.LowStorageRungeKuttaMethod
 using CLIMA.StrongStabilityPreservingRungeKuttaMethod
 using CLIMA.AdditiveRungeKuttaMethod
+const ARK = CLIMA.AdditiveRungeKuttaMethod
 using CLIMA.MultirateRungeKuttaMethod
 using CLIMA.MultirateInfinitesimalStepMethod
 using CLIMA.LinearSolvers
@@ -135,23 +136,27 @@ end
     finaltime = pi / 2
     dts = [2.0 ^ (-k) for k = 2:13]
     errors = similar(dts)
-    q0 = ArrayType === Array ? [1.0] : range(-1.0, 1.0, length = 303)
+
+    q0 = ArrayType <: Array ? [1.0] : range(-1.0, 1.0, length = 303)
     for (method, expected_order) in imex_methods
       for split_nonlinear_linear in (false, true)
-        for (n, dt) in enumerate(dts)
-          Q = ArrayType{ComplexF64}(q0)
-          rhs! = split_nonlinear_linear ? rhs_nonlinear! : rhs_full!
-          solver = method(rhs!, rhs_linear!, DivideLinearSolver(),
-                          Q; dt = dt, t0 = 0.0,
-                          split_nonlinear_linear = split_nonlinear_linear)
-          solve!(Q, solver; timeend = finaltime)
-          Q = Array(Q)
-          errors[n] = maximum(@. abs(Q - exactsolution(q0, finaltime)))
-        end
+        for variant in (ARK.LowStorageVariant(), ARK.NaiveVariant())
+          for (n, dt) in enumerate(dts)
+            Q = ArrayType{ComplexF64}(q0)
+            rhs! = split_nonlinear_linear ? rhs_nonlinear! : rhs_full!
+            solver = method(rhs!, rhs_linear!, DivideLinearSolver(),
+                            Q; dt = dt, t0 = 0.0,
+                            split_nonlinear_linear = split_nonlinear_linear,
+                            variant = variant)
+            solve!(Q, solver; timeend = finaltime)
+            Q = Array(Q)
+            errors[n] = maximum(@. abs(Q - exactsolution(q0, finaltime)))
+          end
 
-        rates = log2.(errors[1:end-1] ./ errors[2:end])
-        @test errors[1] < 2.0
-        @test isapprox(rates[end], expected_order; atol = 0.1)
+          rates = log2.(errors[1:end-1] ./ errors[2:end])
+          @test errors[1] < 2.0
+          @test isapprox(rates[end], expected_order; atol = 0.1)
+        end
       end
     end
   end


### PR DESCRIPTION
Seems to decrease the number of iterations of GMRES by half at the cost of storing `Nstages - 1` extra vectors. I don't have a good theory why this works, only some hand-wavy arguments. Maybe worth checking if it changes anything for https://github.com/climate-machine/CLIMA/pull/505 @jkozdon 