### PR TITLE
Symmetric treatment of metrics for 2nd derivatives

### DIFF
--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -53,9 +53,9 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
   l_rhs = @scratch FT (nstate, Nq, Nq, Nqk) 3
 
   source! !== nothing && (l_S = MArray{Tuple{nstate}, FT}(undef))
-  l_Q = MArray{Tuple{nstate}, FT}(undef)
+  l_Q = @scratch FT (nstate, Nq, Nq, Nqk) 3
   l_Qvisc = MArray{Tuple{nviscstate}, FT}(undef)
-  l_aux = MArray{Tuple{nauxstate}, FT}(undef)
+  l_aux = @scratch FT (nauxstate, Nq, Nq, Nqk) 3
   l_F = MArray{Tuple{3, nstate}, FT}(undef)
   l_M = @scratch FT (Nq, Nq, Nqk) 3
   l_ξ1x1 = @scratch FT (Nq, Nq, Nqk) 3
@@ -106,25 +106,17 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
           end
 
           @unroll for s = 1:nstate
-            l_Q[s] = Q[ijk, s, e]
-          end
-
-          @unroll for s = 1:nviscstate
-            l_Qvisc[s] = Qvisc[ijk, s, e]
+            l_Q[s, i, j, k] = Q[ijk, s, e]
           end
 
           @unroll for s = 1:nauxstate
-            l_aux[s] = auxstate[ijk, s, e]
+            l_aux[s, i, j, k] = auxstate[ijk, s, e]
           end
 
           fill!(l_F, -zero(eltype(l_F)))
           flux_nondiffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                             Vars{vars_state(bl,FT)}(l_Q),
-                             Vars{vars_aux(bl,FT)}(l_aux), t)
-          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                          Vars{vars_state(bl,FT)}(l_Q),
-                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
-                          Vars{vars_aux(bl,FT)}(l_aux), t)
+                             Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                             Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
 
           @unroll for s = 1:nstate
             s_F[1,i,j,k,s] = l_F[1,s]
@@ -134,13 +126,13 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
 
           # if source! !== nothing
           fill!(l_S, -zero(eltype(l_S)))
-          source!(bl, Vars{vars_state(bl,FT)}(l_S), Vars{vars_state(bl,FT)}(l_Q),
-                  Vars{vars_aux(bl,FT)}(l_aux), t)
+          source!(bl, Vars{vars_state(bl,FT)}(l_S),
+                  Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
 
           @unroll for s = 1:nstate
             l_rhs[s, i, j, k] += l_S[s]
           end
-          # end
         end
       end
     end
@@ -185,12 +177,31 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
     end
     @synchronize
 
-    # Build "inside metrics" flux
+    # Add in the diffusive flux (multiply by 2 since derivative is halfed)
+    # This allows symmetric treament of the 2nd order derivative terms
+    # as well as build "inside metrics" flux
     @loop for k in (1:Nqk; threadIdx().z)
       @loop for j in (1:Nq; threadIdx().y)
         @loop for i in (1:Nq; threadIdx().x)
+          ijk = i + Nq * ((j-1) + Nq * (k-1))
+
+          @unroll for s = 1:nviscstate
+            l_Qvisc[s] = Qvisc[ijk, s, e]
+          end
+
+          fill!(l_F, -zero(eltype(l_F)))
+          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
+                          Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
+                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+
           @unroll for s = 1:nstate
             F1, F2, F3 = s_F[1,i,j,k,s], s_F[2,i,j,k,s], s_F[3,i,j,k,s]
+
+            F1 += 2l_F[1,s]
+            F2 += 2l_F[2,s]
+            F3 += 2l_F[3,s]
+
             s_F[1,i,j,k,s] = l_M[i, j, k] * (l_ξ1x1[i, j, k] * F1 +
                                               l_ξ1x2[i, j, k] * F2 +
                                               l_ξ1x3[i, j, k] * F3)
@@ -269,9 +280,9 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
   l_rhs = @scratch FT (nstate, Nq, Nq, Nqk) 3
 
   source! !== nothing && (l_S = MArray{Tuple{nstate}, FT}(undef))
-  l_Q = MArray{Tuple{nstate}, FT}(undef)
+  l_Q = @scratch FT (nstate, Nq, Nq, Nqk) 3
   l_Qvisc = MArray{Tuple{nviscstate}, FT}(undef)
-  l_aux = MArray{Tuple{nauxstate}, FT}(undef)
+  l_aux = @scratch FT (nauxstate, Nq, Nq, Nqk) 3
   l_F = MArray{Tuple{3, nstate}, FT}(undef)
   l_M = @scratch FT (Nq, Nq, Nqk) 3
 
@@ -307,25 +318,17 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           end
 
           @unroll for s = 1:nstate
-            l_Q[s] = Q[ijk, s, e]
-          end
-
-          @unroll for s = 1:nviscstate
-            l_Qvisc[s] = Qvisc[ijk, s, e]
+            l_Q[s, i, j, k] = Q[ijk, s, e]
           end
 
           @unroll for s = 1:nauxstate
-            l_aux[s] = auxstate[ijk, s, e]
+            l_aux[s, i, j, k] = auxstate[ijk, s, e]
           end
 
           fill!(l_F, -zero(eltype(l_F)))
           flux_nondiffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                             Vars{vars_state(bl,FT)}(l_Q),
-                             Vars{vars_aux(bl,FT)}(l_aux), t)
-          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                          Vars{vars_state(bl,FT)}(l_Q),
-                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
-                          Vars{vars_aux(bl,FT)}(l_aux), t)
+                             Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                             Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
 
           @unroll for s = 1:nstate
             s_F[1,i,j,k,s] = l_F[1,s]
@@ -335,13 +338,13 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
 
           # if source! !== nothing
           fill!(l_S, -zero(eltype(l_S)))
-          source!(bl, Vars{vars_state(bl,FT)}(l_S), Vars{vars_state(bl,FT)}(l_Q),
-                  Vars{vars_aux(bl,FT)}(l_aux), t)
+          source!(bl, Vars{vars_state(bl,FT)}(l_S),
+                  Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
 
           @unroll for s = 1:nstate
             l_rhs[s, i, j, k] += l_S[s]
           end
-          # end
         end
       end
     end
@@ -375,8 +378,25 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
     @loop for k in (1:Nqk; threadIdx().z)
       @loop for j in (1:Nq; threadIdx().y)
         @loop for i in (1:Nq; threadIdx().x)
+          ijk = i + Nq * ((j-1) + Nq * (k-1))
+
+          @unroll for s = 1:nviscstate
+            l_Qvisc[s] = Qvisc[ijk, s, e]
+          end
+
+          fill!(l_F, -zero(eltype(l_F)))
+          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
+                          Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
+                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+
           @unroll for s = 1:nstate
             F1, F2, F3 = s_F[1,i,j,k,s], s_F[2,i,j,k,s], s_F[3,i,j,k,s]
+
+            F1 += 2l_F[1,s]
+            F2 += 2l_F[2,s]
+            F3 += 2l_F[3,s]
+
             s_F[3,i,j,k,s] = l_M[i, j, k] * (l_ζx1[i, j, k] * F1 +
                                              l_ζx2[i, j, k] * F2 +
                                              l_ζx3[i, j, k] * F3)

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -197,8 +197,8 @@ let
   polynomialorder = 4
   base_num_elem = 4
 
-  expected_result = [1.5606226382564500e-01 5.3302790086802504e-03 2.2574728860707139e-04;
-                     2.5803100360042141e-02 1.1794776908545315e-03 6.1785354745749247e-05]
+  expected_result = [1.5606126271800694e-01 5.3315235468477966e-03 2.2572701271274964e-04;
+                     2.5754410198970158e-02 1.1781217145186288e-03 6.1752962472904071e-05]
 lvls = integration_testing ? size(expected_result, 2) : 1
 
 @testset "$(@__FILE__)" for ArrayType in ArrayTypes

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
@@ -112,8 +112,8 @@ let
   polynomialorder = 4
   base_num_elem = 4
 
-  expected_result = [1.5606226382564500e-01 5.3302790086802504e-03 2.2574728860707139e-04;
-                     2.5803100360042141e-02 1.1794776908545315e-03 6.1785354745749247e-05]
+  expected_result = [1.5606126271800713e-01 5.3315235468489059e-03 2.2572701271271977e-04;
+                     2.5754410198969766e-02 1.1781217145186925e-03 6.1752962472852435e-05]
   lvls = integration_testing ? size(expected_result, 2) : 1
 
   @testset "$(@__FILE__)" for ArrayType in ArrayTypes


### PR DESCRIPTION
The current way we treat metric terms for 2nd order derivatives is funky. This approach is a little more standard, and respects the symmetry of the operator.