### PR TITLE
Add hooks for prefactorization of linear solvers

### DIFF
--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -12,7 +12,7 @@ LinearAlgebra.norm(A::MVector, p::Real, weighted::Bool) = norm(A, p)
 LinearAlgebra.norm(A::MVector, weighted::Bool) = norm(A, 2, weighted)
 LinearAlgebra.dot(A::MVector, B::MVector, weighted) = dot(A, B)
 
-export linearsolve!, settolerance!
+export linearsolve!, settolerance!, prefactorize
 export AbstractLinearSolver, AbstractIterativeLinearSolver
 
 """
@@ -47,7 +47,15 @@ initialize!(Q, Qrhs, solver::AbstractIterativeLinearSolver) =
   throw(MethodError(initialize!, (Q, Qrhs, solver))) 
 
 """
-    linearsolve!(linearoperator!, Q, Qrhs, solver::AbstractIterativeLinearSolver)
+  prefactorize(linop!, linearsolver, args...)
+
+Prefactorize the in-place linear operator `linop!` for use with `linearsolver`. 
+"""
+prefactorize(linop!, linearsolver::AbstractIterativeLinearSolver, args...) =
+  linop!
+
+"""
+    linearsolve!(linearoperator!, solver::AbstractIterativeLinearSolver, Q, Qrhs)
 
 Solves a linear problem defined by the `linearoperator!` function and the state
 `Qrhs`, i.e,
@@ -58,7 +66,7 @@ Solves a linear problem defined by the `linearoperator!` function and the state
 
 using the `solver` and the initial guess `Q`. After the call `Q` contains the solution.
 """
-function linearsolve!(linearoperator!, Q, Qrhs, solver::AbstractIterativeLinearSolver)
+function linearsolve!(linearoperator!, solver::AbstractIterativeLinearSolver, Q, Qrhs)
   converged = false
   iters = 0
 

--- a/src/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -14,6 +14,32 @@ using ..SpaceMethods
 using ..LinearSolvers
 using ..MPIStateArrays: device, realview
 
+
+
+"""
+    op! = EulerOperator(f!, ϵ)
+
+Construct a linear operator which performs an explicit Euler step ``Q + α f(Q)``,
+where `f!` and `op!` both operate inplace, with extra arguments passed through, i.e.
+```
+op!(LQ, Q, args...)
+```
+is equivalent to
+```
+f!(dQ, Q, args...)
+LQ .= Q .+ ϵ .* dQ
+```
+"""
+mutable struct EulerOperator{F,FT}
+  f!::F
+  ϵ::FT
+end
+
+function (op::EulerOperator)(LQ, Q, args...)
+  op.f!(LQ, Q, args..., increment=false)
+  @. LQ = Q + op.ϵ * LQ
+end
+
 """
     AdditiveRungeKutta(f, l, linsol, RKAe, RKAi, RKB, RKC, Q; dt, t0 = 0)
 
@@ -48,6 +74,8 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, Nstages, Nstages_sq} <: ODEs.Ab
   rhs!
   "rhs linear operator"
   rhs_linear!
+  "implicit operator, pre-factorized"
+  implicitoperator!
   "linear solver"
   linearsolver::LT
   "Storage for solution during the AdditiveRungeKutta update"
@@ -89,8 +117,13 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, Nstages, Nstages_sq} <: ODEs.Ab
     Qhat = similar(Q)
     Qtt = similar(Q)
 
+    # this assumes all elements of the diagonal are identical
+    # true for currently implemented models
+    α = dt * RKA_implicit[2, 2]
+    implicitoperator! = prefactorize(EulerOperator(rhs_linear!, -α), linearsolver, Q, nothing, t0)
+
     new{T, RT, AT, LT, nstages, nstages ^ 2}(RT(dt), RT(t0),
-                                             rhs!, rhs_linear!, linearsolver,
+                                             rhs!, rhs_linear!, implicitoperator!, linearsolver,
                                              Qstages, Rstages, Qhat, Qtt,
                                              RKA_explicit, RKA_implicit, RKB, RKC,
                                              split_nonlinear_linear)
@@ -111,7 +144,13 @@ function AdditiveRungeKutta(spacedisc::AbstractSpaceMethod,
                      Q; dt=dt, t0=t0)
 end
 
-ODEs.updatedt!(ark::AdditiveRungeKutta, dt) = (ark.dt = dt)
+function ODEs.updatedt!(ark::AdditiveRungeKutta, dt)
+  ark.dt = dt
+  # this will only work for iterative solves
+  # direct solvers will throw an error as they expect a factorized object
+  α = dt * ark.RKA_implicit[2, 2]
+  ark.implicitoperator! = EulerOperator(ark.rhs_linear!, -α)
+end
 ODEs.updatetime!(ark::AdditiveRungeKutta, time) = (ark.t = time)
 
 function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, timeend::Real,
@@ -135,7 +174,7 @@ end
 function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
                       slow_δ = nothing, slow_rv_dQ = nothing,
                       slow_scaling = nothing)
-  linearsolver = ark.linearsolver
+  implicitoperator!, linearsolver = ark.implicitoperator!, ark.linearsolver
   RKA_explicit, RKA_implicit = ark.RKA_explicit, ark.RKA_implicit
   RKB, RKC = ark.RKB, ark.RKC
   rhs!, rhs_linear! = ark.rhs!, ark.rhs_linear!
@@ -157,6 +196,11 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
   # calculate the rhs at first stage to initialize the stage loop
   rhs!(Rstages[1], Qstages[1], p, time + RKC[1] * dt, increment = false)
 
+  if dt != ark.dt
+    α = dt * RKA_implicit[2, 2]
+    implicitoperator! = EulerOperator(rhs_linear!, -α)
+  end
+
   # note that it is important that this loop does not modify Q!
   for istage = 2:nstages
     stagetime = time + RKC[istage] * dt
@@ -168,12 +212,7 @@ function ODEs.dostep!(Q, ark::AdditiveRungeKutta, p, time::Real, dt::Real,
                           Val(split_nonlinear_linear), slow_δ, slow_rv_dQ))
 
     #solves Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_linear!(Q_tt)
-    α = dt * RKA_implicit[istage, istage]
-    linearoperator! = function(LQ, Q)
-      rhs_linear!(LQ, Q, p, stagetime; increment = false)
-      @. LQ = Q - α * LQ
-    end
-    linearsolve!(linearoperator!, Qtt, Qhat, linearsolver)
+    linearsolve!(implicitoperator!, linearsolver, Qtt, Qhat, p, stagetime)
 
     #update Qstages
     Qstages[istage] .+= Qtt

--- a/test/LinearSolvers/poisson.jl
+++ b/test/LinearSolvers/poisson.jl
@@ -127,7 +127,7 @@ function run(mpicomm, ArrayType, FT, dim, polynomialorder, brickrange, periodici
 
   linearsolver = linmethod(Q)
 
-  iters = linearsolve!(linearoperator!, Q, Qrhs, linearsolver)
+  iters = linearsolve!(linearoperator!, linearsolver, Q, Qrhs)
 
   error = euclidean_distance(Q, Qexact)
 

--- a/test/LinearSolvers/smallsystem.jl
+++ b/test/LinearSolvers/smallsystem.jl
@@ -34,7 +34,7 @@ using StaticArrays, LinearAlgebra, Random
     linearsolver = method(b, tol)
     
     x = @MVector rand(T, n)
-    iters = linearsolve!(mulbyA!, x, b, linearsolver)
+    iters = linearsolve!(mulbyA!, linearsolver, x, b)
 
     @test iters == expected_iters[m][T]
     @test norm(A * x - b) / norm(b) <= tol
@@ -42,7 +42,7 @@ using StaticArrays, LinearAlgebra, Random
     # test for convergence in 0 iterations by
     # initializing with the exact solution
     x = A \ b
-    iters = linearsolve!(mulbyA!, x, b, linearsolver)
+    iters = linearsolve!(mulbyA!, linearsolver, x, b)
     @test iters == 0
     @test norm(A * x - b) / norm(b) <= tol
    
@@ -50,7 +50,7 @@ using StaticArrays, LinearAlgebra, Random
     settolerance!(linearsolver, newtol)
     
     x = @MVector rand(T, n)
-    linearsolve!(mulbyA!, x, b, linearsolver)
+    linearsolve!(mulbyA!, linearsolver, x, b)
 
     @test norm(A * x - b) / norm(b) <= newtol
     @test norm(A * x - b) / norm(b) >= tol

--- a/test/ODESolvers/runtests.jl
+++ b/test/ODESolvers/runtests.jl
@@ -131,9 +131,12 @@ end
 
   @testset "IMEX methods" begin
     struct DivideLinearSolver <: AbstractLinearSolver end
-    function LinearSolvers.linearsolve!(linearoperator!, Qtt, Qhat, ::DivideLinearSolver)
+    function LinearSolvers.prefactorize(linearoperator!, ::DivideLinearSolver, args...)
+      linearoperator!
+    end
+    function LinearSolvers.linearsolve!(linearoperator!, ::DivideLinearSolver, Qtt, Qhat, args...)
       @. Qhat = 1 / Qhat
-      linearoperator!(Qtt, Qhat)
+      linearoperator!(Qtt, Qhat, args...)
       @. Qtt = 1 / Qtt
     end
 


### PR DESCRIPTION
Add a `prefactorize` function that can is applied to linear solvers at setup time. Also changes the argument order to `linearsolve!` to make it consistent.