### PR TITLE
Azure: attempt to fix occasional Mac build failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
   - bash: |
       set -o xtrace
       sudo apt-get update
-      sudo apt-get install cmake gfortran mpich libmpich-dev
+      sudo apt-get install mpich libmpich-dev
     displayName: 'Install dependencies'
   - bash: |
       set -o xtrace
@@ -75,9 +75,10 @@ jobs:
     displayName: 'Download and extract Julia'
   - bash: |
       set -o xtrace
+      echo "127.0.0.1  $HOSTNAME" | sudo tee -a /private/etc/hosts  # fix https://stackoverflow.com/a/31222970/392585
       brew update
       brew upgrade
-      brew install mpich cmake
+      brew install mpich
     displayName: 'Install dependencies'
   - bash: |
       set -o xtrace
@@ -137,7 +138,7 @@ jobs:
   - bash: |
       set -o xtrace
       sudo apt-get update
-      sudo apt-get install cmake gfortran mpich libmpich-dev
+      sudo apt-get install mpich libmpich-dev
     displayName: 'Install dependencies'
   - bash: |
       set -o xtrace


### PR DESCRIPTION
We are seeing occasional Azure Pipelines failures on MacOS, e.g.:

https://dev.azure.com/spjbyrne/CLIMA/_build/results?buildId=1504&view=logs&jobId=93056758-5bfb-5750-f113-e720ddefdb4c&taskId=c73b3de0-27be-598b-c922-0c24c64f8585&lineStart=324&lineEnd=333&colStart=1&colEnd=1

According to https://stackoverflow.com/a/31222970/392585, this can be fixed by manually adding the current hostname to /private/etc/hosts

Also remove cmake and gfortran build dependencies as they are no longer required.