### PR TITLE
Make arguments to update_aux! more general

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -184,18 +184,20 @@ function diffusive!(m::AtmosModel, diffusive::Vars, ∇transform::Grad, state::V
   diffusive!(m.turbulence, diffusive, ∇transform, state, aux, t, ρD_t)
 end
 
-function update_aux!(dg::DGModel, m::AtmosModel, Q::MPIStateArray,
-                     auxstate::MPIStateArray, t::Real)
+function update_aux!(dg::DGModel, m::AtmosModel, Q::MPIStateArray, t::Real)
   FT = eltype(Q)
+  auxstate = dg.auxstate
+
   if num_integrals(m, FT) > 0
     indefinite_stack_integral!(dg, m, Q, auxstate, t)
     reverse_indefinite_stack_integral!(dg, m, auxstate, t)
   end
 
-  nodal_update_aux!(atmos_nodal_update_aux!, dg, m, Q, auxstate, t)
+  nodal_update_aux!(atmos_nodal_update_aux!, dg, m, Q, t)
 end
 
-function atmos_nodal_update_aux!(m::AtmosModel, state::Vars, aux::Vars, t::Real)
+function atmos_nodal_update_aux!(m::AtmosModel, state::Vars, aux::Vars,
+                                 diff::Vars, t::Real)
   atmos_nodal_update_aux!(m.moisture, m, state, aux, t)
   atmos_nodal_update_aux!(m.radiation, m, state, aux, t)
   atmos_nodal_update_aux!(m.turbulence, m, state, aux, t)

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -9,7 +9,7 @@ vars_aux(lm::AtmosLinearModel, FT) = vars_aux(lm.atmos,FT)
 vars_integrals(lm::AtmosLinearModel, FT) = @vars()
 
 
-update_aux!(dg::DGModel, lm::AtmosLinearModel, Q::MPIStateArray, auxstate::MPIStateArray, t::Real) = nothing
+update_aux!(dg::DGModel, lm::AtmosLinearModel, Q::MPIStateArray, t::Real) = nothing
 integrate_aux!(lm::AtmosLinearModel, integ::Vars, state::Vars, aux::Vars) = nothing
 flux_diffusive!(lm::AtmosLinearModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) = nothing
 function wavespeed(lm::AtmosLinearModel, nM, state::Vars, aux::Vars, t::Real)

--- a/src/Atmos/Model/remainder.jl
+++ b/src/Atmos/Model/remainder.jl
@@ -14,8 +14,8 @@ vars_diffusive(rem::RemainderModel, FT) = vars_diffusive(rem.main,FT)
 vars_aux(rem::RemainderModel, FT) = vars_aux(rem.main,FT)
 vars_integrals(rem::RemainderModel,FT) = vars_integrals(rem.main,FT)
 
-update_aux!(dg::DGModel, rem::RemainderModel, Q::MPIStateArray, auxstate::MPIStateArray, t::Real) =
-  update_aux!(dg, rem.main, Q, auxstate, t)
+update_aux!(dg::DGModel, rem::RemainderModel, Q::MPIStateArray, t::Real) =
+  update_aux!(dg, rem.main, Q, t)
 
 integrate_aux!(rem::RemainderModel, integ::Vars, state::Vars, aux::Vars) =
   integrate_aux!(rem.main, integ, state, aux)

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -55,9 +55,8 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment=false)
   communicate = !(isstacked(topology) &&
                   typeof(dg.direction) <: VerticalDirection)
 
-  if hasmethod(update_aux!, Tuple{typeof(dg), typeof(bl), typeof(Q),
-                                  typeof(auxstate), typeof(t)})
-    update_aux!(dg, bl, Q, auxstate, t)
+  if hasmethod(update_aux!, Tuple{typeof(dg), typeof(bl), typeof(Q), typeof(t)})
+    update_aux!(dg, bl, Q, t)
   end
 
   ########################
@@ -226,7 +225,7 @@ function reverse_indefinite_stack_integral!(dg::DGModel, m::BalanceLaw,
 end
 
 function nodal_update_aux!(f!, dg::DGModel, m::BalanceLaw, Q::MPIStateArray,
-                           auxstate::MPIStateArray, t::Real)
+                           t::Real)
   device = typeof(Q.data) <: Array ? CPU() : CUDA()
 
   grid = dg.grid
@@ -244,7 +243,8 @@ function nodal_update_aux!(f!, dg::DGModel, m::BalanceLaw, Q::MPIStateArray,
   ### update aux variables
   @launch(device, threads=(Np,), blocks=nrealelem,
           knl_nodal_update_aux!(m, Val(dim), Val(polyorder), f!,
-                          Q.data, auxstate.data, t, topology.realelems))
+                          Q.data, dg.auxstate.data, dg.diffstate.data, t,
+                          topology.realelems))
 end
 
 function MPIStateArrays.MPIStateArray(dg::DGModel, commtag=888)

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -55,9 +55,7 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment=false)
   communicate = !(isstacked(topology) &&
                   typeof(dg.direction) <: VerticalDirection)
 
-  if hasmethod(update_aux!, Tuple{typeof(dg), typeof(bl), typeof(Q), typeof(t)})
-    update_aux!(dg, bl, Q, t)
-  end
+  update_aux!(dg, bl, Q, t)
 
   ########################
   # Gradient Computation #
@@ -191,6 +189,10 @@ function indefinite_stack_integral!(dg::DGModel, m::BalanceLaw,
                                          Val(nvertelem), Q.data, auxstate.data,
                                          vgeo, grid.Imat, 1:nhorzelem,
                                          Val(nintegrals)))
+end
+
+# fallback
+function update_aux!(dg::DGModel, bl::BalanceLaw, Q::MPIStateArray, t::Real)
 end
 
 function reverse_indefinite_stack_integral!(dg::DGModel, m::BalanceLaw,

--- a/test/DGmethods/integral_test.jl
+++ b/test/DGmethods/integral_test.jl
@@ -61,10 +61,9 @@ function init_aux!(::IntegralTestModel{dim}, aux::Vars,
   end
 end
 
-function update_aux!(dg::DGModel, m::IntegralTestModel, Q::MPIStateArray,
-                     auxstate::MPIStateArray, t::Real)
-  indefinite_stack_integral!(dg, m, Q, auxstate, t)
-  reverse_indefinite_stack_integral!(dg, m, auxstate, t)
+function update_aux!(dg::DGModel, m::IntegralTestModel, Q::MPIStateArray, t::Real)
+  indefinite_stack_integral!(dg, m, Q, dg.auxstate, t)
+  reverse_indefinite_stack_integral!(dg, m, dg.auxstate, t)
 end
 
 @inline function integrate_aux!(m::IntegralTestModel, integrand::Vars,

--- a/test/DGmethods/integral_test_sphere.jl
+++ b/test/DGmethods/integral_test_sphere.jl
@@ -36,10 +36,9 @@ struct IntegralTestSphereModel{T} <: BalanceLaw
   Router::T
 end
 
-function update_aux!(dg::DGModel, m::IntegralTestSphereModel, Q::MPIStateArray,
-                     auxstate::MPIStateArray, t::Real)
-  indefinite_stack_integral!(dg, m, Q, auxstate, t)
-  reverse_indefinite_stack_integral!(dg, m, auxstate, t)
+function update_aux!(dg::DGModel, m::IntegralTestSphereModel, Q::MPIStateArray, t::Real)
+  indefinite_stack_integral!(dg, m, Q, dg.auxstate, t)
+  reverse_indefinite_stack_integral!(dg, m, dg.auxstate, t)
 end
 
 vars_integrals(::IntegralTestSphereModel, T) = @vars(v::T)


### PR DESCRIPTION
Our current call to `update_aux!` only allows one to use state and auxiliary variables during the function call. Since `auxstate` and `diffstate` are now members of the `DGModel` struct, I'd like to access them this way instead of being passed in as arguments. This would be very useful for the ocean model (PR #535) which needs to access the gradient variables during the `update_aux!` call. 

I'm not 100% happy with the current implementation, as it requires the function passed into `nodal_update_aux!` to always take all three arrays as arguments, but this is still fewer changes than passing the gradient variables as an argument in `update_aux!`. Please give suggestions if you can think of a better way to do this. This is also partially future-proofing for when we add an integral state to the `DGModel` struct. 

Also, why this is passing the tests that explicitly use `update_aux!` but not those that don't is a little obtuse to me. Help here would be much appreciated :)