### PR TITLE
Fix broken docs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
 
 - job: Documentation
 
-  timeoutInMinutes: 60
+  timeoutInMinutes: 180
 
   pool:
     vmImage: 'ubuntu-16.04'

--- a/docs/src/Common/MoistThermodynamics.md
+++ b/docs/src/Common/MoistThermodynamics.md
@@ -110,7 +110,7 @@ liquid_fraction_equil
 liquid_fraction_nonequil
 liquid_ice_pottemp
 liquid_ice_pottemp_sat
-moist_gas_constants
+gas_constants
 saturation_adjustment
 saturation_excess
 q_vap_saturation

--- a/docs/src/DGmethods_old.md
+++ b/docs/src/DGmethods_old.md
@@ -46,26 +46,22 @@ DGBalanceLawDiscretizations.dof_iteration!
 ```@docs
 CLIMA.MPIStateArrays.MPIStateArray(::DGBalanceLawDiscretizations.DGBalanceLaw)
 CLIMA.MPIStateArrays.MPIStateArray(::DGBalanceLawDiscretizations.DGBalanceLaw, ::Function)
-CLIMA.SpaceMethods.odefun!(::DGBalanceLawDiscretizations.DGBalanceLaw, dQ, Q, t)
+CLIMA.SpaceMethods.odefun!
 ```
 
 ### Kernels
 ```@docs
 DGBalanceLawDiscretizations.volumerhs!
 DGBalanceLawDiscretizations.facerhs!
-DGBalanceLawDiscretizations.volumeviscterms!
-DGBalanceLawDiscretizations.faceviscterms!
-DGBalanceLawDiscretizations.initauxstate!
 DGBalanceLawDiscretizations.initauxstate!
 DGBalanceLawDiscretizations.elem_grad_field!
 DGBalanceLawDiscretizations.knl_dof_iteration!
 DGBalanceLawDiscretizations.knl_indefinite_stack_integral!
-DGBalanceLawDiscretizations.knl_reverse_indefinite_stack_integral!
 ```
 
-## `DGBalanceLawDiscretizations.NumericalFluxes_old`
+## Numerical Fluxes
 
 ```@docs
-DGBalanceLawDiscretizations.NumericalFluxes_old.rusanov!
-DGBalanceLawDiscretizations.NumericalFluxes_old.rusanov_boundary_flux!
+DGBalanceLawDiscretizations.NumericalFluxes.rusanov!
+DGBalanceLawDiscretizations.NumericalFluxes.rusanov_boundary_flux!
 ```


### PR DESCRIPTION
 - Fixes broken `NumericalFluxes_old` docs.
 - Removes reference to missing docs for `faceviscterms!` and `volumeviscterms!`
 - Fixes and removes broken docs in `TurbulenceConvection`
 - The tests in `TurbulenceConvection` are duplicated from what's in the test folder, so I don't think it has much value in the docs