### PR TITLE
Fix `liquid_ice_pottemp_given_pressure`

### DIFF
--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -840,7 +840,7 @@ function liquid_ice_pottemp_given_pressure(T::FT, p::FT,
   q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}
     # liquid-ice potential temperature, approximating latent heats
     # of phase transitions as constants
-    return dry_pottemp_given_pressure(T, p, q) * (1 - latent_heat_liq_ice(q)/(cp_m(q)*T))
+    return dry_pottemp_given_pressure(T, p, q) * (1 - latent_heat_liq_ice(q)/(FT(cp_d)*T))
 end
 
 


### PR DESCRIPTION
After looking through equations for the Dycoms case with @smarras79, we believe a bug may exist in computing `θ_liq_ice` in `liquid_ice_pottemp_given_pressure`. @smarras79 has a reference that indicates that the dry `c_p` should be used in place of the moist `c_p`. This change nearly fixes the `q_liq` profile in the Dycoms initialization (and may also have an impact on dynamics). I'd like confirmation that this change is accurate @tapios.

References:
 - Cotton, Bryan, van Den Heever   Storm an cloud dynamics (book)
 - Betts (1973) Non-precipitating cumulus convection and its parameterization QJRMS 99:178-196