### PR TITLE
Add minimum node distance function

### DIFF
--- a/examples/Atmos/heldsuarez.jl
+++ b/examples/Atmos/heldsuarez.jl
@@ -1,6 +1,6 @@
 using CLIMA
 using CLIMA.Mesh.Topologies: StackedCubedSphereTopology, cubedshellwarp, grid1d
-using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
+using CLIMA.Mesh.Grids
 using CLIMA.Mesh.Filters
 using CLIMA.DGmethods: DGModel, init_ode_state
 using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
@@ -80,8 +80,8 @@ function run(mpicomm, polynomialorder, numelem_horz, numelem_vert,
   # determine the time step
   element_size = (setup.domain_height / numelem_vert)
   acoustic_speed = soundspeed_air(FT(315))
-  lucas_magic_factor = 14
-  dt = lucas_magic_factor * element_size / acoustic_speed / polynomialorder ^ 2
+  lucas_magic_factor = 5
+  dt = lucas_magic_factor * min_node_distance(grid) / acoustic_speed
 
   Q = init_ode_state(dg, FT(0))
   lsrk = LSRK144NiegemannDiehlBusch(dg, Q; dt = dt, t0 = 0)

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -1,8 +1,3 @@
-abstract type Direction end
-struct EveryDirection <: Direction end
-struct HorizontalDirection <: Direction end
-struct VerticalDirection <: Direction end
-
 struct DGModel{BL,G,NFND,NFD,GNF,AS,DS,D}
   balancelaw::BL
   grid::G

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -7,6 +7,7 @@ using .NumericalFluxes: GradNumericalPenalty, diffusive_boundary_penalty!,
                         numerical_boundary_flux_diffusive!
 
 using ..Mesh.Geometry
+using ..Mesh.Grids: EveryDirection, VerticalDirection, HorizontalDirection
 
 using Requires
 @init @require CUDAnative = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -99,3 +99,24 @@ function writevtk_helper(prefix, vgeo::Array, Q::Array, grid,
   end
   writemesh(prefix, X...; fields=fields, realelems=grid.topology.realelems)
 end
+
+"""
+    writegrid(prefix, grid::DiscontinuousSpectralElementGrid)
+
+Write a vtk file for the grid.  The filename will start with `prefix` which
+may also contain a directory path.
+"""
+function writevtk(prefix, grid::DiscontinuousSpectralElementGrid)
+  dim = dimensionality(grid)
+  N = polynomialorder(grid)
+  Nq  = N+1
+
+  vgeo = grid.vgeo isa Array ? grid.vgeo : Array(grid.vgeo)
+
+  nelem = size(vgeo)[end]
+  Xid = (grid.x1id, grid.x2id, grid.x3id)
+  X = ntuple(j->reshape((@view vgeo[:, Xid[j], :]),
+                        ntuple(j->Nq, dim)...,
+                        nelem), dim)
+  writemesh(prefix, X...; realelems=grid.topology.realelems)
+end

--- a/src/LinearSolvers/ColumnwiseLUSolver.jl
+++ b/src/LinearSolvers/ColumnwiseLUSolver.jl
@@ -3,9 +3,10 @@ module ColumnwiseLUSolver
 export ManyColumnLU, SingleColumnLU
 
 using ..Mesh.Grids
+using ..Mesh.Grids: VerticalDirection
 using ..Mesh.Topologies
 using ..DGmethods
-using ..DGmethods: BalanceLaw, DGModel, VerticalDirection, num_state, num_diffusive
+using ..DGmethods: BalanceLaw, DGModel, num_state, num_diffusive
 using ..LinearSolvers
 const LS = LinearSolvers
 using ..MPIStateArrays

--- a/src/Mesh/Filters.jl
+++ b/src/Mesh/Filters.jl
@@ -2,6 +2,7 @@ module Filters
 
 using LinearAlgebra, GaussQuadrature, GPUifyLoops
 using ..Grids
+using ..Grids: Direction, EveryDirection
 
 export AbstractSpectralFilter, AbstractFilter
 export ExponentialFilter, CutoffFilter, TMARFilter
@@ -129,19 +130,18 @@ end
 
 """
     apply!(Q, states, grid::DiscontinuousSpectralElementGrid,
-           filter::AbstractSpectralFilter; horizontal = true,
-           vertical = true)
+           filter::AbstractSpectralFilter,
+           direction::Direction = EveryDirection())
 
 Applies `filter` to the `states` of `Q`.
 
-The arguments `horizontal` and `vertical` are used to control if the filter
-is applied in the horizontal and vertical reference directions, respectively.
-Note, it is assumed that the trailing dimension is the vertical dimension and
-the rest are horizontal.
+The `direction` argument controls if the filter is applied in the horizontal
+and/or vertical directions. It is assumed that the trailing dimension on the
+reference element is the vertical dimension and the rest are horizontal.
 """
 function apply!(Q, states, grid::DiscontinuousSpectralElementGrid,
-                filter::AbstractSpectralFilter;
-                horizontal = true, vertical = true)
+                filter::AbstractSpectralFilter,
+                direction::Direction = EveryDirection())
   topology = grid.topology
 
   dim = dimensionality(grid)
@@ -159,7 +159,7 @@ function apply!(Q, states, grid::DiscontinuousSpectralElementGrid,
   nrealelem = length(topology.realelems)
 
   @launch(device, threads=(Nq, Nq, Nqk), blocks=nrealelem,
-          knl_apply_filter!(Val(dim), Val(N), Val(nstate), Val(horizontal), Val(vertical),
+          knl_apply_filter!(Val(dim), Val(N), Val(nstate), Val(direction),
                             Q.data, Val(states), filtermatrix, topology.realelems))
 end
 

--- a/src/Mesh/Filters_kernels.jl
+++ b/src/Mesh/Filters_kernels.jl
@@ -6,32 +6,33 @@ end
 const _M = Grids._M
 
 """
-    knl_apply_filter!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{horizontal},
-                      ::Val{vertical}, Q, ::Val{states}, filtermatrix,
-                      elems) where {dim, N, nstate, states, horizontal, vertical}
+    knl_apply_filter!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{direction},
+                      Q, ::Val{states}, filtermatrix,
+                      elems) where {dim, N, nstate, states, direction}
 
 Computational kernel: Applies the `filtermatrix` to the `states` of `Q`.
 
-The arguments `horizontal` and `vertical` are used to control if the filter is
-applied in the horizontal and vertical reference directions, respectively.
+The `direction` argument is used to control if the filter is applied in the
+horizontal and/or vertical reference directions.
 """
 function knl_apply_filter!(::Val{dim}, ::Val{N}, ::Val{nstate},
-                           ::Val{horizontal}, ::Val{vertical}, Q,
-                           ::Val{states}, filtermatrix,
-                           elems) where {dim, N, nstate, horizontal, vertical,
-                                         states}
+                           ::Val{direction}, Q, ::Val{states}, filtermatrix,
+                           elems) where {dim, N, nstate, direction, states}
   FT = eltype(Q)
 
   Nq = N + 1
   Nqk = dim == 2 ? 1 : Nq
 
-  filterinξ1 = horizontal
-  filterinξ2 = dim == 2 ? vertical : horizontal
-  filterinξ3 = dim == 2 ? false : vertical
-
-  # Return if we are not filtering in any direction
-  if !(filterinξ1 || filterinξ2 || filterinξ3)
-    return
+  if direction isa EveryDirection
+    filterinξ1 = filterinξ2 = filterinξ3 = true
+  elseif direction isa HorizontalDirection
+    filterinξ1 = true
+    filterinξ2 = dim == 2 ? false : true
+    filterinξ3 = false
+  elseif direction isa VerticalDirection
+    filterinξ1 = false
+    filterinξ2 = dim == 2 ? true : false
+    filterinξ3 = dim == 2 ? false : true
   end
 
   nfilterstates = length(states)

--- a/src/Mesh/Grids_kernels.jl
+++ b/src/Mesh/Grids_kernels.jl
@@ -1,0 +1,88 @@
+using Requires
+@init @require CUDAnative = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
+  using .CUDAnative
+end
+
+using StaticArrays
+
+const _x1 = Grids._x1
+const _x2 = Grids._x2
+const _x3 = Grids._x3
+
+"""
+    knl_min_neighbor_distance!(::Val{N}, ::Val{dim}, direction,
+                             min_neighbor_distance, vgeo, topology.realelems)
+
+Computational kernel: Computes the minimum physical distance between node
+neighbors within an element.
+
+The `direction` in the reference element controls which nodes are considered
+neighbors.
+"""
+function knl_min_neighbor_distance!(::Val{N}, ::Val{dim}, direction,
+                                    min_neighbor_distance, vgeo, elems
+                                   ) where {N, dim}
+
+  FT = eltype(min_neighbor_distance)
+  Nq = N + 1
+  Nqk = dim == 2 ? 1 : Nq
+
+  if direction isa EveryDirection
+    mininξ = (true, true, true)
+  elseif direction isa HorizontalDirection
+    mininξ = (true, dim == 2 ? false : true, false)
+  elseif direction isa VerticalDirection
+    mininξ = (false, dim == 2 ? true : false, dim == 2 ? false : true)
+  end
+
+  @inbounds @loop for e in (elems; blockIdx().x)
+    @loop for k in (1:Nqk; threadIdx().z)
+      @loop for j in (1:Nq; threadIdx().y)
+        @loop for i in (1:Nq; threadIdx().x)
+          md = typemax(FT)
+
+          ijk = i + Nq * (j - 1) + Nq * Nq * (k - 1)
+          x = SVector(vgeo[ijk, _x1, e], vgeo[ijk, _x2, e], vgeo[ijk, _x3, e])
+
+          if mininξ[1]
+            @unroll for î = (i-1, i+1)
+              if 1 ≤ î ≤ Nq
+                îjk = î + Nq * (j-1) + Nq * Nq * (k-1)
+                x̂ = SVector(vgeo[îjk, _x1, e],
+                            vgeo[îjk, _x2, e],
+                            vgeo[îjk, _x3, e])
+                md = min(md, norm(x - x̂))
+              end
+            end
+          end
+
+          if mininξ[2]
+            @unroll for ĵ = (j-1, j+1)
+              if 1 ≤ ĵ ≤ Nq
+                iĵk = i + Nq * (ĵ-1) + Nq * Nq * (k-1)
+                x̂ = SVector(vgeo[iĵk, _x1, e],
+                            vgeo[iĵk, _x2, e],
+                            vgeo[iĵk, _x3, e])
+                md = min(md, norm(x - x̂))
+              end
+            end
+          end
+
+          if mininξ[3]
+            @unroll for k̂ = (k-1, k+1)
+              if 1 ≤ k̂ ≤ Nqk
+                ijk̂ = i + Nq * (j-1) + Nq * Nq * (k̂-1)
+                x̂ = SVector(vgeo[ijk̂, _x1, e],
+                            vgeo[ijk̂, _x2, e],
+                            vgeo[ijk̂, _x3, e])
+                md = min(md, norm(x - x̂))
+              end
+            end
+          end
+
+          min_neighbor_distance[ijk, e] = md
+        end
+      end
+    end
+  end
+end

--- a/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -13,7 +13,7 @@ using Dates
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.ODESolvers: solve!, gettime
 using CLIMA.VTK: writevtk, writepvtu
-using CLIMA.DGmethods: EveryDirection, HorizontalDirection, VerticalDirection
+using CLIMA.Mesh.Grids: EveryDirection, HorizontalDirection, VerticalDirection
 
 const ArrayType = CLIMA.array_type()
 

--- a/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -18,7 +18,7 @@ using Dates
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.ODESolvers: solve!, gettime
 using CLIMA.VTK: writevtk, writepvtu
-using CLIMA.DGmethods: EveryDirection, HorizontalDirection, VerticalDirection
+using CLIMA.Mesh.Grids: EveryDirection, HorizontalDirection, VerticalDirection
 
 const ArrayType = CLIMA.array_type()
 

--- a/test/LinearSolvers/bandedsystem.jl
+++ b/test/LinearSolvers/bandedsystem.jl
@@ -2,13 +2,13 @@ using CLIMA
 using MPI
 using CLIMA.Mesh.Topologies
 using CLIMA.Mesh.Grids
+using CLIMA.Mesh.Grids: VerticalDirection
 using CLIMA.VTK: writemesh
 using Logging
 using LinearAlgebra
 using Random
 using StaticArrays
-using CLIMA.DGmethods: VerticalDirection, DGModel, Vars, vars_state,
-                       num_state, init_ode_state
+using CLIMA.DGmethods: DGModel, Vars, vars_state, num_state, init_ode_state
 using CLIMA.ColumnwiseLUSolver: banded_matrix, banded_matrix_vector_product!
 using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxDiffusive,
                                        CentralGradPenalty

--- a/test/Mesh/min_node_distance.jl
+++ b/test/Mesh/min_node_distance.jl
@@ -1,0 +1,84 @@
+using Test
+using MPI
+using CLIMA
+using CLIMA.Mesh.Topologies
+using CLIMA.Mesh.Grids
+using CLIMA.Mesh.Grids: VerticalDirection, HorizontalDirection, EveryDirection
+using CLIMA.VTK
+using Logging
+using Printf
+using LinearAlgebra
+
+const ArrayType = CLIMA.array_type()
+
+let
+  # boiler plate MPI stuff
+  CLIMA.init()
+  mpicomm = MPI.COMM_WORLD
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+    ll == "WARN"  ? Logging.Warn  :
+    ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
+
+  # Mesh generation parameters
+  N = 4
+  Nq = N+1
+  Neh = 10
+  Nev = 4
+
+  @testset "$(@__FILE__) DGModel matrix" begin
+    for FT in (Float64, Float32)
+      for dim = (2, 3)
+        if dim == 2
+          brickrange = (range(FT(0); length=Neh+1, stop=1),
+                        range(FT(1); length=Nev+1, stop=2))
+        elseif dim == 3
+          brickrange = (range(FT(0); length=Neh+1, stop=1),
+                        range(FT(0); length=Neh+1, stop=1),
+                        range(FT(1); length=Nev+1, stop=2))
+        end
+
+        topl = StackedBrickTopology(mpicomm, brickrange)
+
+        function warpfun(ξ1, ξ2, ξ3)
+          FT = eltype(ξ1)
+
+          ξ1 ≥ FT(1//2) && (ξ1 = FT(1//2) + 2(ξ1 - FT(1//2)))
+          if dim == 2
+            ξ2 ≥ FT(3//2) && (ξ2 = FT(3//2) + 2(ξ2 - FT(3//2)))
+          elseif dim == 3
+            ξ2 ≥ FT(1//2) && (ξ2 = FT(1//2) + 2(ξ2 - FT(1//2)))
+            ξ3 ≥ FT(3//2) && (ξ3 = FT(3//2) + 2(ξ3 - FT(3//2)))
+          end
+          (ξ1, ξ2, ξ3)
+        end
+
+        grid = DiscontinuousSpectralElementGrid(topl,
+                                                FloatType = FT,
+                                                DeviceArray = ArrayType,
+                                                polynomialorder = N,
+                                                meshwarp = warpfun)
+
+        # testname = "grid_poly$(N)_dim$(dim)_$(ArrayType)_$(FT)"
+        # filename(rank) = @sprintf("%s_mpirank%04d", testname, rank)
+        # writevtk(filename(MPI.Comm_rank(mpicomm)), grid)
+        # if MPI.Comm_rank(mpicomm) == 0
+        #   writepvtu(testname, filename.(0:MPI.Comm_size(mpicomm)-1), ())
+        # end
+
+        ξ = referencepoints(grid)
+        hmnd = (ξ[2] - ξ[1]) / (2Neh)
+        vmnd = (ξ[2] - ξ[1]) / (2Nev)
+
+        @test hmnd ≈ min_node_distance(grid, EveryDirection())
+        @test vmnd ≈ min_node_distance(grid, VerticalDirection())
+        @test hmnd ≈ min_node_distance(grid, HorizontalDirection())
+
+      end
+    end
+end
+end
+
+nothing


### PR DESCRIPTION
This adds a function that approximates the minimum node distance for a given grid in the horizontal and / or vertical directions of the reference element.  In addition, the way direction is specified for the filter is changed to match that of the DGmodel.  This addressed issue #573.