### PR TITLE
Fix docs, remove sat adjust from export

### DIFF
--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -35,10 +35,6 @@ export saturation_excess
 
 export liquid_fraction, PhasePartition_equil
 
-export saturation_adjustment # should remove from export
-export saturation_adjustment_q_tot_θ_liq_ice_given_pressure # should remove from export
-export saturation_adjustment_NewtonsMethod # should remove from export
-
 # Auxiliary functions, e.g., for diagnostic purposes
 export dry_pottemp, dry_pottemp_given_pressure, virtual_pottemp, exner, exner_given_pressure
 export liquid_ice_pottemp, liquid_ice_pottemp_given_pressure, liquid_ice_pottemp_sat, relative_humidity
@@ -135,7 +131,7 @@ air_density(ts::ThermodynamicState) = ts.ρ
 """
     specific_volume(ts::ThermodynamicState)
 
-The (moist-)air specific, given a thermodynamic state `ts`.
+The (moist-)air specific volume, given a thermodynamic state `ts`.
 """
 specific_volume(ts::ThermodynamicState) = 1/air_density(ts)
 
@@ -822,7 +818,8 @@ end
 """
     latent_heat_liq_ice(q::PhasePartition{FT})
 
-Effective latent heat of condensate (weighted sum of liquid and ice)
+Effective latent heat of condensate (weighted sum of liquid and ice),
+with specific latent heat evaluated at reference temperature `T_0`.
 """
 latent_heat_liq_ice(q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real} =
   FT(LH_v0)*q.liq + FT(LH_s0)*q.ice
@@ -919,11 +916,17 @@ end
 """
     air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice, ρ, q::PhasePartition)
 
-Solves the non-linear equation
+Computes temperature `T` given
+
+ - `θ_liq_ice` liquid-ice potential temperature
+ - `ρ` (moist-)air density
+and, optionally,
+ - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air,
+
+by finding the root of
 ``
-  T = θ_{liq_ice}*(exner(T,ρ,q) + (LH_{v0} q_{liq} + LH_{s0} q_{ice}) / cp_m
+  T - air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice, air_pressure(T, ρ, q), q) = 0
 ``
-for temperature `T`
 """
 function air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice::FT, ρ::FT,
   q::PhasePartition{FT}=q_pt_0(FT)) where {FT<:Real}

--- a/test/Common/MoistThermodynamics/runtests.jl
+++ b/test/Common/MoistThermodynamics/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using CLIMA.MoistThermodynamics
+MT = MoistThermodynamics
 
 using CLIMA.PlanetParameters
 using LinearAlgebra
@@ -90,12 +91,12 @@ using LinearAlgebra
   # variables E_int, p, q_tot, compute the temperature and partitioning of the phases
   tol_T = 1e-2
   q_tot = FT(0); ρ = FT(1)
-  @test saturation_adjustment(internal_energy_sat(300.0, ρ, q_tot), ρ, q_tot) ≈ 300.0
-  @test abs(saturation_adjustment_NewtonsMethod(internal_energy_sat(300.0, ρ, q_tot), ρ, q_tot) - 300.0) < tol_T
+  @test MT.saturation_adjustment(internal_energy_sat(300.0, ρ, q_tot), ρ, q_tot) ≈ 300.0
+  @test abs(MT.saturation_adjustment_NewtonsMethod(internal_energy_sat(300.0, ρ, q_tot), ρ, q_tot) - 300.0) < tol_T
 
   q_tot = FT(0.21); ρ = FT(0.1)
-  @test saturation_adjustment(internal_energy_sat(200.0, ρ, q_tot), ρ, q_tot) ≈ 200.0
-  @test abs(saturation_adjustment_NewtonsMethod(internal_energy_sat(200.0, ρ, q_tot), ρ, q_tot) - 200.0) < tol_T
+  @test MT.saturation_adjustment(internal_energy_sat(200.0, ρ, q_tot), ρ, q_tot) ≈ 200.0
+  @test abs(MT.saturation_adjustment_NewtonsMethod(internal_energy_sat(200.0, ρ, q_tot), ρ, q_tot) - 200.0) < tol_T
   q = PhasePartition_equil(T, ρ, q_tot)
   @test q.tot - q.liq - q.ice ≈ q_vap_saturation(T, ρ)
 


### PR DESCRIPTION
 - Fixes/cleans up some docs
 - Removes saturation adjustment from export, as this should not be called from outside of MoistThermo