### PR TITLE
Pass args in similar order

### DIFF
--- a/examples/Microphysics/ex_1_saturation_adjustment.jl
+++ b/examples/Microphysics/ex_1_saturation_adjustment.jl
@@ -249,7 +249,7 @@ function main(mpicomm, FT, topl::AbstractTopology{dim}, N, timeend,
         p = aux[_c_p]
 
         e_int = e_tot - 1//2 * (u^2 + w^2) - grav * z
-        ts = PhaseEquil(e_int, q_tot, ρ)  # saturation adjustment happens here
+        ts = PhaseEquil(e_int, ρ, q_tot)  # saturation adjustment happens here
         pp = PhasePartition(ts)
         R[v_T] = ts.T
         R[v_p] = p

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -111,29 +111,29 @@ end
 function atmos_boundary_state!(::Rusanov, bc::DYCOMS_BC, m::AtmosModel,
                                stateP::Vars, auxP::Vars, nM, stateM::Vars,
                                auxM::Vars, bctype, t, state1::Vars, aux1::Vars)
-  # stateM is the 𝐘⁻ state while stateP is the 𝐘⁺ state at an interface. 
+  # stateM is the 𝐘⁻ state while stateP is the 𝐘⁺ state at an interface.
   # at the boundaries the ⁻, minus side states are the interior values
-  # state1 is 𝐘 at the first interior nodes relative to the bottom wall 
+  # state1 is 𝐘 at the first interior nodes relative to the bottom wall
   FT = eltype(stateP)
   # Get values from minus-side state
-  ρM = stateM.ρ 
+  ρM = stateM.ρ
   UM, VM, WM = stateM.ρu
   EM = stateM.ρe
   QTM = stateM.moisture.ρq_tot
   uM, vM, wM  = UM/ρM, VM/ρM, WM/ρM
   q_totM = QTM/ρM
   UnM = nM[1] * UM + nM[2] * VM + nM[3] * WM
-  
+
   # Assign reflection wall boundaries (top wall)
-  stateP.ρu = SVector(UM - 2 * nM[1] * UnM, 
+  stateP.ρu = SVector(UM - 2 * nM[1] * UnM,
                       VM - 2 * nM[2] * UnM,
                       WM - 2 * nM[3] * UnM)
 
-  # Assign scalar values at the boundaries 
+  # Assign scalar values at the boundaries
   stateP.ρ = ρM
   stateP.moisture.ρq_tot = QTM
-  
-  if bctype == 1 # bctype identifies bottom wall 
+
+  if bctype == 1 # bctype identifies bottom wall
     stateP.ρu = SVector(0,0,0)
   end
 end
@@ -142,12 +142,12 @@ function atmos_boundary_state!(::CentralNumericalFluxDiffusive, bc::DYCOMS_BC,
                                auxP::Vars, nM, stateM::Vars, diffM::Vars,
                                auxM::Vars, bctype, t, state1::Vars, diff1::Vars,
                                aux1::Vars)
-  # stateM is the 𝐘⁻ state while stateP is the 𝐘⁺ state at an interface. 
+  # stateM is the 𝐘⁻ state while stateP is the 𝐘⁺ state at an interface.
   # at the boundaries the ⁻, minus side states are the interior values
-  # state1 is 𝐘 at the first interior nodes relative to the bottom wall 
+  # state1 is 𝐘 at the first interior nodes relative to the bottom wall
   FT = eltype(stateP)
   # Get values from minus-side state
-  ρM = stateM.ρ 
+  ρM = stateM.ρ
   UM, VM, WM = stateM.ρu
   EM = stateM.ρe
   QTM = stateM.moisture.ρq_tot
@@ -156,18 +156,18 @@ function atmos_boundary_state!(::CentralNumericalFluxDiffusive, bc::DYCOMS_BC,
   UnM = nM[1] * UM + nM[2] * VM + nM[3] * WM
 
   # Assign reflection wall boundaries (top wall)
-  stateP.ρu = SVector(UM - 2 * nM[1] * UnM, 
+  stateP.ρu = SVector(UM - 2 * nM[1] * UnM,
                       VM - 2 * nM[2] * UnM,
                       WM - 2 * nM[3] * UnM)
 
-  # Assign scalar values at the boundaries 
+  # Assign scalar values at the boundaries
   stateP.ρ = ρM
   stateP.moisture.ρq_tot = QTM
   # Assign diffusive fluxes at boundaries
   diffP = diffM
   xvert = auxM.coord[3]
 
-  if bctype == 1 # bctype identifies bottom wall 
+  if bctype == 1 # bctype identifies bottom wall
     # ------------------------------------------------------------------------
     # (<var>_FN) First node values (First interior node from bottom wall)
     # ------------------------------------------------------------------------
@@ -179,17 +179,17 @@ function atmos_boundary_state!(::CentralNumericalFluxDiffusive, bc::DYCOMS_BC,
     windspeed_FN     = sqrt(u_FN^2 + v_FN^2 + w_FN^2)
     q_tot_FN         = state1.moisture.ρq_tot / ρ_FN
     e_int_FN         = E_FN/ρ_FN - windspeed_FN^2/2 - grav*z_FN
-    TS_FN            = PhaseEquil(e_int_FN, q_tot_FN, ρ_FN) 
+    TS_FN            = PhaseEquil(e_int_FN, ρ_FN, q_tot_FN)
     T_FN             = air_temperature(TS_FN)
     q_vap_FN         = q_tot_FN - PhasePartition(TS_FN).liq
     # --------------------------
-    # Bottom boundary quantities 
+    # Bottom boundary quantities
     # --------------------------
-    zM          = auxM.coord[3] 
+    zM          = auxM.coord[3]
     q_totM      = QTM/ρM
     windspeed   = sqrt(uM^2 + vM^2 + wM^2)
     e_intM      = EM/ρM - windspeed^2/2 - grav*zM
-    TSM         = PhaseEquil(e_intM, q_totM, ρM) 
+    TSM         = PhaseEquil(e_intM, ρM, q_totM)
     q_vapM      = q_totM - PhasePartition(TSM).liq
     TM          = air_temperature(TSM)
     # ----------------------------------------------------------
@@ -203,10 +203,10 @@ function atmos_boundary_state!(::CentralNumericalFluxDiffusive, bc::DYCOMS_BC,
     # Case specific for flat bottom topography, normal vector is n⃗ = k⃗ = [0, 0, 1]ᵀ
     # A more general implementation requires (n⃗ ⋅ ∇A) to be defined where A is replaced by the appropriate flux terms
     C_drag = bc.C_drag
-    ρτ13P  = -ρM * C_drag * windspeed_FN * u_FN 
-    ρτ23P  = -ρM * C_drag * windspeed_FN * v_FN 
+    ρτ13P  = -ρM * C_drag * windspeed_FN * u_FN
+    ρτ23P  = -ρM * C_drag * windspeed_FN * v_FN
     # Assign diffusive momentum and moisture fluxes
-    # (i.e. ρ𝛕 terms)  
+    # (i.e. ρ𝛕 terms)
     stateP.ρu = SVector(0,0,0)
     diffP.ρτ = SHermitianCompact{3,FT,6}(SVector(FT(0),ρτM[2,1],ρτ13P, FT(0), ρτ23P,FT(0)))
 
@@ -219,7 +219,7 @@ function atmos_boundary_state!(::CentralNumericalFluxDiffusive, bc::DYCOMS_BC,
     # ----------------------------------------------------------
     # Boundary energy fluxes
     # ----------------------------------------------------------
-    # Assign diffusive enthalpy flux (i.e. ρ(J+D) terms) 
+    # Assign diffusive enthalpy flux (i.e. ρ(J+D) terms)
     diffP.ρd_h_tot  = SVector(FT(0),
                               FT(0),
                               bc.LHF + bc.SHF)
@@ -248,10 +248,10 @@ function atmos_boundary_state!(::Rusanov, bc::RayleighBenardBC, m::AtmosModel,
     ρP = stateM.ρ
     stateP.ρ = ρP
     stateP.ρu = SVector{3,FT}(0,0,0)
-    if bctype == 1 
+    if bctype == 1
       E_intP = ρP * cv_d * (bc.T_bot - T_0)
     else
-      E_intP = ρP * cv_d * (bc.T_top - T_0) 
+      E_intP = ρP * cv_d * (bc.T_top - T_0)
     end
     stateP.ρe = (E_intP + ρP * auxP.coord[3] * grav)
     nothing
@@ -267,10 +267,10 @@ function atmos_boundary_state!(::CentralNumericalFluxDiffusive, bc::RayleighBena
     ρP = stateM.ρ
     stateP.ρ = ρP
     stateP.ρu = SVector{3,FT}(0,0,0)
-    if bctype == 1 
+    if bctype == 1
       E_intP = ρP * cv_d * (bc.T_bot - T_0)
     else
-      E_intP = ρP * cv_d * (bc.T_top - T_0) 
+      E_intP = ρP * cv_d * (bc.T_top - T_0)
     end
     stateP.ρe = (E_intP + ρP * auxP.coord[3] * grav)
     diffP.ρd_h_tot = SVector(diffP.ρd_h_tot[1], diffP.ρd_h_tot[2], FT(0))

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -73,7 +73,7 @@ vars_aux(::EquilMoist,FT) = @vars(temperature::FT, θ_v::FT, q_liq::FT)
 @inline function atmos_nodal_update_aux!(moist::EquilMoist, atmos::AtmosModel,
                                          state::Vars, aux::Vars, t::Real)
   e_int = internal_energy(moist, atmos.orientation, state, aux)
-  TS = PhaseEquil(e_int, state.moisture.ρq_tot/state.ρ, state.ρ)
+  TS = PhaseEquil(e_int, state.ρ, state.moisture.ρq_tot/state.ρ)
   aux.moisture.temperature = air_temperature(TS)
   aux.moisture.θ_v = virtual_pottemp(TS)
   aux.moisture.q_liq = PhasePartition(TS).liq
@@ -82,7 +82,7 @@ end
 
 function thermo_state(moist::EquilMoist, orientation::Orientation, state::Vars, aux::Vars)
   e_int = internal_energy(moist, orientation, state, aux)
-  PhaseEquil(e_int, state.moisture.ρq_tot/state.ρ, state.ρ, aux.moisture.temperature)
+  PhaseEquil(e_int, state.ρ, state.moisture.ρq_tot/state.ρ, aux.moisture.temperature)
 end
 
 function gradvariables!(moist::EquilMoist, transform::Vars, state::Vars, aux::Vars, t::Real)
@@ -97,7 +97,7 @@ end
 
 function flux_moisture!(moist::EquilMoist, flux::Grad, state::Vars, aux::Vars, t::Real)
   u = state.ρu / state.ρ
-  flux.moisture.ρq_tot += state.moisture.ρq_tot * u 
+  flux.moisture.ρq_tot += state.moisture.ρq_tot * u
 end
 
 function flux_diffusive!(moist::EquilMoist, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real)

--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -728,7 +728,7 @@ function saturation_adjustment(e_int::FT, ρ::FT, q_tot::FT) where {FT<:Real}
 end
 
 """
-    saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ)
+    saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, ρ, q_tot)
 
 Compute the temperature `T` that is consistent with
 
@@ -744,7 +744,7 @@ by finding the root of
 
 See also [`saturation_adjustment`](@ref).
 """
-function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, q_tot::FT, ρ::FT) where {FT<:Real}
+function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, ρ::FT, q_tot::FT) where {FT<:Real}
   T_1 = air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, PhasePartition(q_tot)) # Assume all vapor
   q_v_sat = q_vap_saturation(T_1, ρ)
   unsaturated = q_tot <= q_v_sat
@@ -763,7 +763,7 @@ function saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice::FT, q_tot::FT, ρ::F
 end
 
 """
-    saturation_adjustment_q_tot_θ_liq_ice_given_pressure(θ_liq_ice, q_tot, p)
+    saturation_adjustment_q_tot_θ_liq_ice_given_pressure(θ_liq_ice, p, q_tot)
 
 Compute the temperature `T` that is consistent with
 
@@ -779,7 +779,7 @@ by finding the root of
 
 See also [`saturation_adjustment`](@ref).
 """
-function saturation_adjustment_q_tot_θ_liq_ice_given_pressure(θ_liq_ice::FT, q_tot::FT, p::FT) where {FT<:Real}
+function saturation_adjustment_q_tot_θ_liq_ice_given_pressure(θ_liq_ice::FT, p::FT, q_tot::FT) where {FT<:Real}
   T_1 = air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice, p, PhasePartition(q_tot)) # Assume all vapor
   ρ = air_density(T_1, p, PhasePartition(q_tot))
   q_v_sat = q_vap_saturation(T_1, ρ)

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -59,7 +59,7 @@ may be needed).
 
 # Constructors
 
-    PhaseEquil(e_int, q_tot, ρ)
+    PhaseEquil(e_int, ρ, q_tot)
 
 # Fields
 
@@ -68,15 +68,15 @@ $(DocStringExtensions.FIELDS)
 struct PhaseEquil{FT} <: ThermodynamicState{FT}
   "internal energy"
   e_int::FT
-  "total specific humidity"
-  q_tot::FT
   "density of air (potentially moist)"
   ρ::FT
+  "total specific humidity"
+  q_tot::FT
   "temperature: computed via [`saturation_adjustment`](@ref)"
   T::FT
 end
-PhaseEquil(e_int::FT, q_tot::FT, ρ::FT) where {FT<:Real} =
-  PhaseEquil(e_int, q_tot, ρ, saturation_adjustment(e_int, ρ, q_tot))
+PhaseEquil(e_int::FT, ρ::FT, q_tot::FT) where {FT<:Real} =
+  PhaseEquil(e_int, ρ, q_tot, saturation_adjustment(e_int, ρ, q_tot))
 
 """
     PhaseDry{FT} <: ThermodynamicState
@@ -99,52 +99,52 @@ struct PhaseDry{FT} <: ThermodynamicState{FT}
 end
 
 """
-    LiquidIcePotTempSHumEquil(θ_liq_ice, q_tot, ρ)
+    LiquidIcePotTempSHumEquil(θ_liq_ice, ρ, q_tot)
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 
  - `θ_liq_ice` - liquid-ice potential temperature
- - `q_tot` - total specific humidity
  - `ρ` - density
+ - `q_tot` - total specific humidity
 """
-function LiquidIcePotTempSHumEquil(θ_liq_ice::FT, q_tot::FT, ρ::FT) where {FT<:Real}
-    T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, q_tot, ρ)
+function LiquidIcePotTempSHumEquil(θ_liq_ice::FT, ρ::FT, q_tot::FT) where {FT<:Real}
+    T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, ρ, q_tot)
     q_pt = PhasePartition_equil(T, ρ, q_tot)
     e_int = internal_energy(T, q_pt)
-    return PhaseEquil(e_int, q_tot, ρ, T)
+    return PhaseEquil(e_int, ρ, q_tot, T)
 end
 
 """
-    LiquidIcePotTempSHumEquil_given_pressure(θ_liq_ice, q_tot, p)
+    LiquidIcePotTempSHumEquil_given_pressure(θ_liq_ice, p, q_tot)
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 
  - `θ_liq_ice` - liquid-ice potential temperature
- - `q_tot` - total specific humidity
  - `p` - pressure
+ - `q_tot` - total specific humidity
 """
-function LiquidIcePotTempSHumEquil_given_pressure(θ_liq_ice::FT, q_tot::FT, p::FT) where {FT<:Real}
-    T = saturation_adjustment_q_tot_θ_liq_ice_given_pressure(θ_liq_ice, q_tot, p)
+function LiquidIcePotTempSHumEquil_given_pressure(θ_liq_ice::FT, p::FT, q_tot::FT) where {FT<:Real}
+    T = saturation_adjustment_q_tot_θ_liq_ice_given_pressure(θ_liq_ice, p, q_tot)
     ρ = air_density(T, p, PhasePartition(q_tot))
     q = PhasePartition_equil(T, ρ, q_tot)
     e_int = internal_energy(T, q)
-    return PhaseEquil(e_int, q.tot, ρ, T)
+    return PhaseEquil(e_int, ρ, q.tot, T)
 end
 
 """
-    TemperatureSHumEquil(T, q_tot, p)
+    TemperatureSHumEquil(T, p, q_tot)
 
 Constructs a [`PhaseEquil`](@ref) thermodynamic state from temperature.
 
  - `T` - temperature
- - `q_tot` - total specific humidity
  - `p` - pressure
+ - `q_tot` - total specific humidity
 """
-function TemperatureSHumEquil(T::FT, q_tot::FT, p::FT) where {FT<:Real}
+function TemperatureSHumEquil(T::FT, p::FT, q_tot::FT) where {FT<:Real}
     ρ = air_density(T, p, PhasePartition(q_tot))
     q = PhasePartition_equil(T, ρ, q_tot)
     e_int = internal_energy(T, q)
-    PhaseEquil(e_int, q_tot, ρ, T)
+    PhaseEquil(e_int, ρ, q_tot, T)
 end
 
 """
@@ -165,39 +165,39 @@ $(DocStringExtensions.FIELDS)
 struct PhaseNonEquil{FT} <: ThermodynamicState{FT}
   "internal energy"
   e_int::FT
-  "phase partition"
-  q::PhasePartition{FT}
   "density of air (potentially moist)"
   ρ::FT
+  "phase partition"
+  q::PhasePartition{FT}
 end
 
 """
-    LiquidIcePotTempSHumNonEquil(θ_liq_ice, q_pt, ρ)
+    LiquidIcePotTempSHumNonEquil(θ_liq_ice, ρ, q_pt)
 
 Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 
  - `θ_liq_ice` - liquid-ice potential temperature
- - `q_pt` - phase partition
  - `ρ` - density
+ - `q_pt` - phase partition
 """
-function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT) where {FT<:Real}
+function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, ρ::FT, q_pt::PhasePartition{FT}) where {FT<:Real}
     T = air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice, ρ, q_pt)
     e_int = internal_energy(T, q_pt)
-    PhaseNonEquil(e_int, q_pt, ρ)
+    return PhaseNonEquil(e_int, ρ, q_pt)
 end
 
 """
-    LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice, q_pt, p)
+    LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice, p, q_pt)
 
 Constructs a [`PhaseNonEquil`](@ref) thermodynamic state from:
 
  - `θ_liq_ice` - liquid-ice potential temperature
- - `q_pt` - phase partition
  - `p` - pressure
+ - `q_pt` - phase partition
 """
-function LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT) where {FT<:Real}
+function LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice::FT, p::FT, q_pt::PhasePartition{FT}) where {FT<:Real}
     T = air_temperature_from_liquid_ice_pottemp_given_pressure(θ_liq_ice, p, q_pt)
     ρ = air_density(T, p, q_pt)
     e_int = internal_energy(T, q_pt)
-    PhaseNonEquil(e_int, q_pt, ρ)
+    return PhaseNonEquil(e_int, ρ, q_pt)
 end

--- a/test/Common/MoistThermodynamics/runtests.jl
+++ b/test/Common/MoistThermodynamics/runtests.jl
@@ -156,7 +156,7 @@ end
   # Accurate but expensive `LiquidIcePotTempSHumNonEquil` constructor (Non-linear temperature from θ_liq_ice)
   T_non_linear = air_temperature_from_liquid_ice_pottemp_non_linear.(θ_liq_ice, ρ, q_pt_moist)
   e_int_ = internal_energy.(T_non_linear, q_pt_moist)
-  ts = PhaseNonEquil.(e_int_, q_pt_moist, ρ)
+  ts = PhaseNonEquil.(e_int_, ρ, q_pt_moist)
   @test all(T_non_linear .≈ air_temperature.(ts))
   @test all(θ_liq_ice .≈ liquid_ice_pottemp.(ts))
 
@@ -166,19 +166,19 @@ end
   @test all(air_density.(ts) .≈ ρ)
 
   # PhaseEquil: Dry case
-  ts = PhaseEquil.(e_int, q_tot_dry, ρ)
+  ts = PhaseEquil.(e_int, ρ, q_tot_dry)
   @test all(internal_energy.(ts) .≈ e_int)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ q_tot_dry)
   @test all(air_density.(ts) .≈ ρ)
 
   # PhaseEquil: Moist case
-  ts = PhaseEquil.(e_int, q_tot_moist, ρ)
+  ts = PhaseEquil.(e_int, ρ, q_tot_moist)
   @test all(internal_energy.(ts) .≈ e_int)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ q_tot_moist)
   @test all(air_density.(ts) .≈ ρ)
 
   # PhaseNonEquil: Dry case
-  ts = PhaseNonEquil.(e_int, q_pt_dry, ρ)
+  ts = PhaseNonEquil.(e_int, ρ, q_pt_dry)
   @test all(internal_energy.(ts) .≈ e_int)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt_dry, :tot))
   @test all(getproperty.(PhasePartition.(ts),:liq) .≈ getproperty.(q_pt_dry, :liq))
@@ -186,7 +186,7 @@ end
   @test all(air_density.(ts) .≈ ρ)
 
   # PhaseNonEquil: Moist case
-  ts = PhaseNonEquil.(e_int, q_pt_moist, ρ)
+  ts = PhaseNonEquil.(e_int, ρ, q_pt_moist)
   @test all(internal_energy.(ts) .≈ e_int)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt_moist, :tot))
   @test all(getproperty.(PhasePartition.(ts),:liq) .≈ getproperty.(q_pt_moist, :liq))
@@ -194,34 +194,34 @@ end
   @test all(air_density.(ts) .≈ ρ)
 
   # LiquidIcePotTempSHumEquil: Dry case
-  ts = LiquidIcePotTempSHumEquil.(θ_liq_ice, q_tot_dry, ρ)
+  ts = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot_dry)
   @test all(liquid_ice_pottemp.(ts) .≈ θ_liq_ice)
   @test all(air_density.(ts) .≈ ρ)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ q_tot_dry)
 
   # LiquidIcePotTempSHumEquil: Moist case
-  ts = LiquidIcePotTempSHumEquil.(θ_liq_ice, q_tot_moist, ρ)
+  ts = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot_moist)
   @test all(abs.(liquid_ice_pottemp.(ts) - θ_liq_ice) .< FT(1e-8))
   @test maximum(abs.(liquid_ice_pottemp.(ts) - θ_liq_ice)) ./ eps(FT) < sqrt(1/(eps(FT)))
   @test all(air_density.(ts) .≈ ρ)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ q_tot_moist)
 
   # LiquidIcePotTempSHumEquil_given_pressure: Moist case
-  ts = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, q_tot_moist, p)
+  ts = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot_moist)
   @test all(liquid_ice_pottemp.(ts) .≈ θ_liq_ice)
   @test all(abs.(air_pressure.(ts) - p)./p.*100 .< 1)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt_moist, :tot))
 
-  # LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice::FT, q_pt::PhasePartition{FT}, p::FT): Moist case
-  ts = LiquidIcePotTempSHumNonEquil_given_pressure.(θ_liq_ice, q_pt_moist, p)
+  # LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice::FT, p::FT, q_pt::PhasePartition{FT}): Moist case
+  ts = LiquidIcePotTempSHumNonEquil_given_pressure.(θ_liq_ice, p, q_pt_moist)
   @test all(liquid_ice_pottemp.(ts) .≈ θ_liq_ice)
   @test all(air_pressure.(ts) .≈ p)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt_moist,:tot))
   @test all(getproperty.(PhasePartition.(ts),:liq) .≈ getproperty.(q_pt_moist,:liq))
   @test all(getproperty.(PhasePartition.(ts),:ice) .≈ getproperty.(q_pt_moist,:ice))
 
-  # LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, q_pt::PhasePartition{FT}, ρ::FT): Moist case
-  ts = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, q_pt_moist, ρ)
+  # LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT, ρ::FT, q_pt::PhasePartition{FT}): Moist case
+  ts = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, ρ, q_pt_moist)
   @test all(θ_liq_ice .≈ liquid_ice_pottemp.(ts))
   @test all(air_density.(ts) .≈ ρ)
   @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt_moist,:tot))
@@ -249,14 +249,14 @@ end
   q_liq = FT(0.001)
   q_pt = PhasePartition(q_tot, q_liq, q_ice)
   θ_liq_ice = FT(300.0)
-  ts_eq = PhaseEquil(e_int, q_tot, ρ)
+  ts_eq = PhaseEquil(e_int, ρ, q_tot)
   ts_dry = PhaseDry(e_int, ρ)
-  ts_T = TemperatureSHumEquil(air_temperature(ts_dry), q_pt.tot, air_pressure(ts_dry))
-  ts_neq = PhaseNonEquil(e_int, PhasePartition(q_tot, q_liq, q_ice), ρ)
-  ts_θ_liq_ice_eq = LiquidIcePotTempSHumEquil(θ_liq_ice, q_tot, ρ)
-  ts_θ_liq_ice_eq_p = LiquidIcePotTempSHumEquil_given_pressure(θ_liq_ice, q_tot, p)
-  ts_θ_liq_ice_neq = LiquidIcePotTempSHumNonEquil(θ_liq_ice, q_pt, ρ)
-  ts_θ_liq_ice_neq_p = LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice, q_pt, p)
+  ts_T = TemperatureSHumEquil(air_temperature(ts_dry), air_pressure(ts_dry), q_pt.tot)
+  ts_neq = PhaseNonEquil(e_int, ρ, PhasePartition(q_tot, q_liq, q_ice))
+  ts_θ_liq_ice_eq = LiquidIcePotTempSHumEquil(θ_liq_ice, ρ, q_tot)
+  ts_θ_liq_ice_eq_p = LiquidIcePotTempSHumEquil_given_pressure(θ_liq_ice, p, q_tot)
+  ts_θ_liq_ice_neq = LiquidIcePotTempSHumNonEquil(θ_liq_ice, ρ, q_pt)
+  ts_θ_liq_ice_neq_p = LiquidIcePotTempSHumNonEquil_given_pressure(θ_liq_ice, p, q_pt)
   for ts in (ts_eq, ts_dry, ts_T, ts_neq, ts_θ_liq_ice_eq, ts_θ_liq_ice_eq_p, ts_θ_liq_ice_neq, ts_θ_liq_ice_neq_p)
     @test soundspeed_air(ts) isa typeof(e_int)
     @test gas_constant_air(ts) isa typeof(e_int)
@@ -296,7 +296,7 @@ end
   e_pot = FT(100.0)
   # PhasePartition test is noisy, so do this only once:
   ts_dry = PhaseDry(first(e_int_range), first(ρ_range))
-  ts_eq  = PhaseEquil(first(e_int_range), typeof(first(ρ_range))(0), first(ρ_range))
+  ts_eq  = PhaseEquil(first(e_int_range), first(ρ_range), typeof(first(ρ_range))(0))
   @test PhasePartition(ts_eq).tot                  ≈ PhasePartition(ts_dry).tot
   @test PhasePartition(ts_eq).liq                  ≈ PhasePartition(ts_dry).liq
   @test PhasePartition(ts_eq).ice                  ≈ PhasePartition(ts_dry).ice
@@ -304,7 +304,7 @@ end
   for e_int in e_int_range
     for ρ in ρ_range
       ts_dry = PhaseDry(e_int, ρ)
-      ts_eq  = PhaseEquil(e_int, typeof(ρ)(0), ρ)
+      ts_eq  = PhaseEquil(e_int, ρ, typeof(ρ)(0))
 
       @test gas_constant_air(ts_eq)                       ≈ gas_constant_air(ts_dry)
       @test relative_humidity(ts_eq)                      ≈ relative_humidity(ts_dry)
@@ -331,7 +331,7 @@ end
       @test exner(ts_eq)                                  ≈ exner(ts_dry)
       @test saturation_vapor_pressure(ts_eq, Ice())       ≈ saturation_vapor_pressure(ts_dry, Ice())
       @test saturation_vapor_pressure(ts_eq, Liquid())    ≈ saturation_vapor_pressure(ts_dry, Liquid())
-      @test all(gas_constants(ts_eq)               .≈ gas_constants(ts_dry))
+      @test all(gas_constants(ts_eq)                     .≈ gas_constants(ts_dry))
     end
   end
 

--- a/test/DGmethods_old/compressible_Navier_Stokes/MWE_grid_stretching.jl
+++ b/test/DGmethods_old/compressible_Navier_Stokes/MWE_grid_stretching.jl
@@ -427,7 +427,7 @@ function preodefun!(disc, Q, t)
       xvert = aux[_a_y]
       e_int = (E - (U^2 + V^2+ W^2)/(2*ρ) - ρ * grav * xvert) / ρ
       q_tot = QT / ρ
-      TS = PhaseEquil(e_int, q_tot, ρ)
+      TS = PhaseEquil(e_int, ρ, q_tot)
       T = air_temperature(TS)
       P = air_pressure(TS) # Test with dry atmosphere
       q_liq = PhasePartition(TS).liq


### PR DESCRIPTION
Fixes #353,

Specifically, I think it makes sense to have the same order of arguments in `PhaseDry` as `PhaseEquil`, so that the argument list of `PhaseEquil` extends that of `PhaseDry`, rather than swapping the order of density and specific total humidity.