### PR TITLE
Extend init args

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -250,8 +250,8 @@ boundary_state!(nf, m::AtmosModel, x...) =
 # FIXME: This is probably not right....
 boundary_state!(::CentralGradPenalty, bl::AtmosModel, _...) = nothing
 
-function init_state!(m::AtmosModel, state::Vars, aux::Vars, coords, t)
-  m.init_state(state, aux, coords, t)
+function init_state!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)
+  m.init_state(state, aux, coords, t, args...)
 end
 
 end # module


### PR DESCRIPTION
Extends arguments for `init_state!`, since we'll need [many additional arguments](https://github.com/climate-machine/CLIMA/pull/601/files#diff-30c477a58b9368ed896dc001fedda8f8R57) in the Squal line setup. Hopefully, this will limit how many files #601 touches.