### PR TITLE
Add CFL computation function

### DIFF
--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -23,7 +23,7 @@ cpu_gpu = [
   { file = "test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods/compressible_Navier_Stokes/rising_bubble-model-imex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods/compressible_Navier_Stokes/density_current-model.jl", slurmargs = ["--ntasks=3"], args = [] },
-  { file = "test/DGmethods/cfl.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/DGmethods/courant.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/RTB_IMEX.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/isentropic_vortex_standalone.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/isentropic_vortex_standalone_IMEX.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -23,6 +23,7 @@ cpu_gpu = [
   { file = "test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods/compressible_Navier_Stokes/rising_bubble-model-imex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods/compressible_Navier_Stokes/density_current-model.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/DGmethods/cfl.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/RTB_IMEX.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/isentropic_vortex_standalone.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/isentropic_vortex_standalone_IMEX.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -294,7 +294,7 @@ function cfl(wavespeed_dt, dg::DGModel, m::BalanceLaw, Q::MPIStateArray,
   nrealelem = length(topology.realelems)
 
   if nrealelem > 0
-    N = polynomialorder(dg.grid)
+    N = polynomialorder(grid)
     dim = dimensionality(grid)
     Nq = N + 1
     Nqk = dim == 2 ? 1 : Nq

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -287,7 +287,7 @@ The function `wavespeed_dt` should compute `c * Δt` given the `state`, `aux`
 and `diffusive` variables.  The `direction` controls which reference
 directions are considered when computing the minimum node distance `Δx`.
 """
-function cfl(wavespeed_dt, dg::DGModel, m::BalanceLaw, Q::MPIStateArray,
+function cfl(wavespeed_dt::Function, dg::DGModel, m::BalanceLaw, Q::MPIStateArray,
              direction=EveryDirection())
   grid = dg.grid
   topology = grid.topology

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -1080,8 +1080,8 @@ function knl_nodal_update_aux!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, f!, Q,
   end
 end
 
-function knl_local_cfl!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, local_cfl,
-                        wavespeed_dt, Q, auxstate, diffstate,
+function knl_local_cfl!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, pointwisecfl,
+                        localcfl, Q, auxstate, diffstate,
                         elems) where {dim, N}
   FT = eltype(Q)
   nstate = num_state(bl,FT)
@@ -1112,11 +1112,12 @@ function knl_local_cfl!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, local_cfl,
         l_diff[s] = diffstate[n, s, e]
       end
 
-      c_dt = wavespeed_dt(bl, Vars{vars_state(bl,FT)}(l_Q),
-                          Vars{vars_aux(bl,FT)}(l_aux),
-                          Vars{vars_diffusive(bl,FT)}(l_diff))
+      Δx = pointwisecfl[n, e]
+      c = localcfl(bl, Vars{vars_state(bl,FT)}(l_Q),
+                       Vars{vars_aux(bl,FT)}(l_aux),
+                       Vars{vars_diffusive(bl,FT)}(l_diff), Δx)
 
-      local_cfl[n, e] = c_dt / local_cfl[n, e]
+      pointwisecfl[n, e] = c
     end
   end
 end

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -1080,6 +1080,47 @@ function knl_nodal_update_aux!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, f!, Q,
   end
 end
 
+function knl_local_cfl!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, local_cfl,
+                        wavespeed_dt, Q, auxstate, diffstate,
+                        elems) where {dim, N}
+  FT = eltype(Q)
+  nstate = num_state(bl,FT)
+  nviscstate = num_diffusive(bl,FT)
+  nauxstate = num_aux(bl,FT)
+
+  Nq = N + 1
+
+  Nqk = dim == 2 ? 1 : Nq
+
+  Np = Nq * Nq * Nqk
+
+  l_Q = MArray{Tuple{nstate}, FT}(undef)
+  l_aux = MArray{Tuple{nauxstate}, FT}(undef)
+  l_diff = MArray{Tuple{nviscstate}, FT}(undef)
+
+  @inbounds @loop for e in (elems; blockIdx().x)
+    @loop for n in (1:Np; threadIdx().x)
+      @unroll for s = 1:nstate
+        l_Q[s] = Q[n, s, e]
+      end
+
+      @unroll for s = 1:nauxstate
+        l_aux[s] = auxstate[n, s, e]
+      end
+
+      @unroll for s = 1:nviscstate
+        l_diff[s] = diffstate[n, s, e]
+      end
+
+      c_dt = wavespeed_dt(bl, Vars{vars_state(bl,FT)}(l_Q),
+                          Vars{vars_aux(bl,FT)}(l_aux),
+                          Vars{vars_diffusive(bl,FT)}(l_diff))
+
+      local_cfl[n, e] = c_dt / local_cfl[n, e]
+    end
+  end
+end
+
 """
     knl_indefinite_stack_integral!(::Val{dim}, ::Val{N}, ::Val{nstate},
                                             ::Val{nauxstate}, ::Val{nvertelem},

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -1080,9 +1080,9 @@ function knl_nodal_update_aux!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, f!, Q,
   end
 end
 
-function knl_local_cfl!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, pointwisecfl,
-                        localcfl, Q, auxstate, diffstate,
-                        elems) where {dim, N}
+function knl_local_courant!(bl::BalanceLaw, ::Val{dim}, ::Val{N},
+                            pointwise_courant, local_courant, Q, auxstate,
+                            diffstate, elems) where {dim, N}
   FT = eltype(Q)
   nstate = num_state(bl,FT)
   nviscstate = num_diffusive(bl,FT)
@@ -1112,12 +1112,12 @@ function knl_local_cfl!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, pointwisecfl,
         l_diff[s] = diffstate[n, s, e]
       end
 
-      Δx = pointwisecfl[n, e]
-      c = localcfl(bl, Vars{vars_state(bl,FT)}(l_Q),
-                       Vars{vars_aux(bl,FT)}(l_aux),
-                       Vars{vars_diffusive(bl,FT)}(l_diff), Δx)
+      Δx = pointwise_courant[n, e]
+      c = local_courant(bl, Vars{vars_state(bl,FT)}(l_Q),
+                        Vars{vars_aux(bl,FT)}(l_aux),
+                        Vars{vars_diffusive(bl,FT)}(l_diff), Δx)
 
-      pointwisecfl[n, e] = c
+      pointwise_courant[n, e] = c
     end
   end
 end

--- a/test/DGmethods/cfl.jl
+++ b/test/DGmethods/cfl.jl
@@ -119,11 +119,11 @@ let
 
         Δt = FT(1//2)
 
-        function wavespeed_dt(m::AtmosModel, state::Vars, aux::Vars,
-                              diffusive::Vars)
+        function localcfl(m::AtmosModel, state::Vars, aux::Vars,
+                              diffusive::Vars, Δx)
           u = state.ρu/state.ρ
           return Δt * (norm(u) + soundspeed(m.moisture, m.orientation, state,
-                                            aux))
+                                            aux)) / Δx
         end
 
         Q = init_ode_state(dg, FT(0))
@@ -138,9 +138,9 @@ let
         c_h = Δt*(translation_speed + soundspeed_air(T∞))/Δx_h
         c_v = Δt*(translation_speed + soundspeed_air(T∞))/Δx_v
 
-        @test  c   ≈ cfl(wavespeed_dt, dg, model, Q, EveryDirection())
-        @test  c_h ≈ cfl(wavespeed_dt, dg, model, Q, HorizontalDirection())
-        @test  c_v ≈ cfl(wavespeed_dt, dg, model, Q, VerticalDirection())
+        @test  c   ≈ cfl(localcfl, dg, model, Q, EveryDirection())
+        @test  c_h ≈ cfl(localcfl, dg, model, Q, HorizontalDirection())
+        @test  c_v ≈ cfl(localcfl, dg, model, Q, VerticalDirection())
       end
     end
   end

--- a/test/DGmethods/cfl.jl
+++ b/test/DGmethods/cfl.jl
@@ -1,0 +1,149 @@
+using Test
+using MPI
+using CLIMA
+using CLIMA.Mesh.Topologies
+using CLIMA.Mesh.Grids
+using CLIMA.Mesh.Grids: VerticalDirection, HorizontalDirection, EveryDirection
+using CLIMA.VTK
+using Logging
+using Printf
+using LinearAlgebra
+using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry, cfl
+using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+                                       CentralNumericalFluxDiffusive
+
+using CLIMA.PlanetParameters: kappa_d
+using CLIMA.Atmos: AtmosModel,
+                   AtmosAcousticLinearModel, RemainderModel,
+                   NoOrientation,
+                   NoReferenceState, ReferenceState,
+                   DryModel, NoRadiation, NoSubsidence, PeriodicBC,
+                   Gravity, HydrostaticState, IsothermalProfile,
+                   ConstantViscosityWithDivergence, vars_state, soundspeed
+
+const ArrayType = CLIMA.array_type()
+
+using CLIMA.MoistThermodynamics: air_density, total_energy, internal_energy,
+                                 soundspeed_air
+
+using CLIMA.VariableTemplates: Vars
+using StaticArrays
+
+function initialcondition!(state, aux, coords, t)
+  FT = eltype(state)
+
+  p∞::FT = 10 ^ 5
+  T∞::FT = 300
+  translation_speed::FT = 150
+  translation_angle::FT = pi / 4
+  α = translation_angle
+  u∞ = SVector(translation_speed * cos(α), translation_speed * sin(α), 0)
+
+  u = u∞
+  T = T∞
+  # adiabatic/isentropic relation
+  p = p∞ * (T / T∞) ^ (FT(1) / kappa_d)
+  ρ = air_density(T, p)
+
+  state.ρ = ρ
+  state.ρu = ρ * u
+  e_kin = u' * u / 2
+  state.ρe = ρ * total_energy(e_kin, FT(0), T)
+
+  nothing
+end
+
+
+let
+  # boiler plate MPI stuff
+  CLIMA.init()
+  mpicomm = MPI.COMM_WORLD
+  ll = uppercase(get(ENV, "JULIA_LOG_LEVEL", "INFO"))
+  loglevel = ll == "DEBUG" ? Logging.Debug :
+  ll == "WARN"  ? Logging.Warn  :
+  ll == "ERROR" ? Logging.Error : Logging.Info
+  logger_stream = MPI.Comm_rank(mpicomm) == 0 ? stderr : devnull
+  global_logger(ConsoleLogger(logger_stream, loglevel))
+
+  # Mesh generation parameters
+  N = 4
+  Nq = N+1
+  Neh = 10
+  Nev = 4
+
+  @testset "$(@__FILE__) DGModel matrix" begin
+    for FT in (Float64, Float32)
+      for dim = (2, 3)
+        if dim == 2
+          brickrange = (range(FT(0); length=Neh+1, stop=1),
+                        range(FT(1); length=Nev+1, stop=2))
+        elseif dim == 3
+          brickrange = (range(FT(0); length=Neh+1, stop=1),
+                        range(FT(0); length=Neh+1, stop=1),
+                        range(FT(1); length=Nev+1, stop=2))
+        end
+
+        topl = StackedBrickTopology(mpicomm, brickrange)
+
+        function warpfun(ξ1, ξ2, ξ3)
+          FT = eltype(ξ1)
+
+          ξ1 ≥ FT(1//2) && (ξ1 = FT(1//2) + 2(ξ1 - FT(1//2)))
+          if dim == 2
+            ξ2 ≥ FT(3//2) && (ξ2 = FT(3//2) + 2(ξ2 - FT(3//2)))
+          elseif dim == 3
+            ξ2 ≥ FT(1//2) && (ξ2 = FT(1//2) + 2(ξ2 - FT(1//2)))
+            ξ3 ≥ FT(3//2) && (ξ3 = FT(3//2) + 2(ξ3 - FT(3//2)))
+          end
+          (ξ1, ξ2, ξ3)
+        end
+
+        grid = DiscontinuousSpectralElementGrid(topl,
+                                                FloatType = FT,
+                                                DeviceArray = ArrayType,
+                                                polynomialorder = N,
+                                                meshwarp = warpfun)
+
+        model = AtmosModel(NoOrientation(),
+                           NoReferenceState(),
+                           ConstantViscosityWithDivergence(FT(0)),
+                           DryModel(),
+                           NoRadiation(),
+                           NoSubsidence{FT}(),
+                           Gravity(),
+                           PeriodicBC(),
+                           initialcondition!)
+
+        dg = DGModel(model, grid, Rusanov(), CentralNumericalFluxDiffusive(),
+                     CentralGradPenalty())
+
+        Δt = FT(1//2)
+
+        function wavespeed_dt(m::AtmosModel, state::Vars, aux::Vars,
+                              diffusive::Vars)
+          u = state.ρu/state.ρ
+          return Δt * (norm(u) + soundspeed(m.moisture, m.orientation, state,
+                                            aux))
+        end
+
+        Q = init_ode_state(dg, FT(0))
+
+        Δx = min_node_distance(grid, EveryDirection())
+        Δx_v = min_node_distance(grid, VerticalDirection())
+        Δx_h = min_node_distance(grid, HorizontalDirection())
+
+        T∞ = FT(300)
+        translation_speed = FT(150)
+        c = Δt*(translation_speed + soundspeed_air(T∞))/Δx
+        c_h = Δt*(translation_speed + soundspeed_air(T∞))/Δx_h
+        c_v = Δt*(translation_speed + soundspeed_air(T∞))/Δx_v
+
+        @test  c   ≈ cfl(wavespeed_dt, dg, model, Q, EveryDirection())
+        @test  c_h ≈ cfl(wavespeed_dt, dg, model, Q, HorizontalDirection())
+        @test  c_v ≈ cfl(wavespeed_dt, dg, model, Q, VerticalDirection())
+      end
+    end
+  end
+end
+
+nothing

--- a/test/DGmethods/courant.jl
+++ b/test/DGmethods/courant.jl
@@ -8,7 +8,7 @@ using CLIMA.VTK
 using Logging
 using Printf
 using LinearAlgebra
-using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry, cfl
+using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry, courant
 using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
                                        CentralNumericalFluxDiffusive
 
@@ -119,8 +119,8 @@ let
 
         Δt = FT(1//2)
 
-        function localcfl(m::AtmosModel, state::Vars, aux::Vars,
-                              diffusive::Vars, Δx)
+        function local_courant(m::AtmosModel, state::Vars, aux::Vars,
+                               diffusive::Vars, Δx)
           u = state.ρu/state.ρ
           return Δt * (norm(u) + soundspeed(m.moisture, m.orientation, state,
                                             aux)) / Δx
@@ -138,9 +138,9 @@ let
         c_h = Δt*(translation_speed + soundspeed_air(T∞))/Δx_h
         c_v = Δt*(translation_speed + soundspeed_air(T∞))/Δx_v
 
-        @test  c   ≈ cfl(localcfl, dg, model, Q, EveryDirection())
-        @test  c_h ≈ cfl(localcfl, dg, model, Q, HorizontalDirection())
-        @test  c_v ≈ cfl(localcfl, dg, model, Q, VerticalDirection())
+        @test c   ≈ courant(local_courant, dg, model, Q, EveryDirection())
+        @test c_h ≈ courant(local_courant, dg, model, Q, HorizontalDirection())
+        @test c_v ≈ courant(local_courant, dg, model, Q, VerticalDirection())
       end
     end
   end


### PR DESCRIPTION
During the simulation it can be useful to compute the effective CFL
number (`CFL = Δt*wavespeed/Δx`).

This adds a function similar to the minimum node distance function that
returns the maximum CFL number given a function that computes the local
wave speed times the time step size.