### PR TITLE
diffusive_penalty! -> numerical_flux_gradient!

### DIFF
--- a/examples/Atmos/heldsuarez.jl
+++ b/examples/Atmos/heldsuarez.jl
@@ -3,7 +3,7 @@ using CLIMA.Mesh.Topologies: StackedCubedSphereTopology, cubedshellwarp, grid1d
 using CLIMA.Mesh.Grids
 using CLIMA.Mesh.Filters
 using CLIMA.DGmethods: DGModel, init_ode_state
-using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxGradient,
                                        CentralNumericalFluxDiffusive
 using CLIMA.ODESolvers: solve!, gettime
 using CLIMA.LowStorageRungeKuttaMethod: LSRK144NiegemannDiehlBusch
@@ -77,7 +77,7 @@ function run(mpicomm, polynomialorder, numelem_horz, numelem_vert,
                      setup)
 
   dg = DGModel(model, grid, Rusanov(),
-               CentralNumericalFluxDiffusive(), CentralGradPenalty())
+               CentralNumericalFluxDiffusive(), CentralNumericalFluxGradient())
 
   # determine the time step
   element_size = (setup.domain_height / numelem_vert)

--- a/examples/DGmethods/ex_001_dycoms-imex.jl
+++ b/examples/DGmethods/ex_001_dycoms-imex.jl
@@ -230,7 +230,7 @@ function run(mpicomm,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty(),
+               CentralNumericalFluxGradient(),
                direction=EveryDirection())
 
   linmodel = LinearModel(model)
@@ -239,7 +239,7 @@ function run(mpicomm,
                 grid,
                 Rusanov(),
                 CentralNumericalFluxDiffusive(),
-                CentralGradPenalty(),
+                CentralNumericalFluxGradient(),
                 auxstate=dg.auxstate,
                 direction=VerticalDirection())
 

--- a/examples/DGmethods/ex_001_dycoms.jl
+++ b/examples/DGmethods/ex_001_dycoms.jl
@@ -153,7 +153,7 @@ function run(mpicomm, ArrayType, dim, topl,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
   Q = init_ode_state(dg, FT(0))
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
   # Calculating initial condition norm

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -22,7 +22,7 @@ import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
                         nodal_update_aux!, indefinite_stack_integral!,
                         reverse_indefinite_stack_integral!, num_state
 import ..DGmethods.NumericalFluxes: boundary_state!, Rusanov,
-                                    CentralGradPenalty,
+                                    CentralNumericalFluxGradient,
                                     CentralNumericalFluxDiffusive,
                                     boundary_flux_diffusive!
 
@@ -246,7 +246,7 @@ boundary_state!(nf, m::AtmosModel, x...) =
   atmos_boundary_state!(nf, m.boundarycondition, m, x...)
 
 # FIXME: This is probably not right....
-boundary_state!(::CentralGradPenalty, bl::AtmosModel, _...) = nothing
+boundary_state!(::CentralNumericalFluxGradient, bl::AtmosModel, _...) = nothing
 
 function init_state!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)
   m.init_state(state, aux, coords, t, args...)

--- a/src/DGmethods/NumericalFluxes.jl
+++ b/src/DGmethods/NumericalFluxes.jl
@@ -1,7 +1,7 @@
 module NumericalFluxes
 
-export NumericalFluxNonDiffusive, NumericalFluxDiffusive, GradNumericalPenalty,
-       Rusanov, CentralGradPenalty, CentralNumericalFluxDiffusive,
+export NumericalFluxNonDiffusive, NumericalFluxDiffusive, NumericalFluxGradient,
+       Rusanov, CentralNumericalFluxGradient, CentralNumericalFluxDiffusive,
        CentralNumericalFluxNonDiffusive
 
 using StaticArrays, LinearAlgebra
@@ -14,52 +14,54 @@ import ..DGmethods: BalanceLaw, Grad, Vars, vars_state, vars_diffusive,
 
 
 """
-    GradNumericalPenalty
+    NumericalFluxGradient
 
-Any `P <: GradNumericalPenalty` should define methods for:
+Any `P <: NumericalFluxGradient` should define methods for:
 
-   diffusive_penalty!(gnf::P, bl::BalanceLaw, diffF, nM, QM, QdiffM, QauxM, QP,
-                      QdiffP, QauxP, t)
-   diffusive_boundary_penalty!(gnf::P, bl::BalanceLaw, l_Qvisc, nM, l_GM, l_QM,
-                               l_auxM, l_GP, l_QP, l_auxP, bctype, t)
-
-"""
-abstract type GradNumericalPenalty end
-
-function diffusive_penalty! end
-function diffusive_boundary_penalty! end
+   numerical_flux_gradient!(gnf::P, bl::BalanceLaw, diffF, nM, QM, QdiffM, QauxM, QP,
+                            QdiffP, QauxP, t)
+   numerical_boundary_flux_gradient!(gnf::P, bl::BalanceLaw, l_Qvisc, nM, l_GM, l_QM,
+                                     l_auxM, l_GP, l_QP, l_auxP, bctype, t)
 
 """
-    CentralGradPenalty <: GradNumericalPenalty
+abstract type NumericalFluxGradient end
+
+function numerical_flux_gradient! end
+function numerical_boundary_flux_gradient! end
 
 """
-struct CentralGradPenalty <: GradNumericalPenalty end
+    CentralNumericalFluxGradient <: NumericalFluxGradient
 
-function diffusive_penalty!(::CentralGradPenalty, bl::BalanceLaw,
-    diff_penalty::Vars{D}, n::SVector,
-    transform⁻::Vars{T}, state⁻::Vars{S}, aux⁻::Vars{A},
-    transform⁺::Vars{T}, state⁺::Vars{S}, aux⁺::Vars{A},
-    t) where {D,T,S,A}
+"""
+struct CentralNumericalFluxGradient <: NumericalFluxGradient end
 
-  G = n .* (parent(transform⁺) .- parent(transform⁻))' ./ 2
-  diffusive!(bl, diff_penalty, Grad{T}(G), state⁻, aux⁻, t)
+function numerical_flux_gradient!(::CentralNumericalFluxGradient, bl::BalanceLaw,
+                                  diff::Vars{D}, n::SVector,
+                                  transform⁻::Vars{T}, state⁻::Vars{S},
+                                  aux⁻::Vars{A}, transform⁺::Vars{T},
+                                  state⁺::Vars{S}, aux⁺::Vars{A},
+                                  t) where {D,T,S,A}
+
+  G = n .* (parent(transform⁺) .+ parent(transform⁻))' ./ 2
+  diffusive!(bl, diff, Grad{T}(G), state⁻, aux⁻, t)
 end
 
-function diffusive_boundary_penalty!(nf::CentralGradPenalty, bl::BalanceLaw,
-    diff_penalty::Vars{D}, n::SVector,
-    transform⁻::Vars{T}, state⁻::Vars{S}, aux⁻::Vars{A},
-    transform⁺::Vars{T}, state⁺::Vars{S}, aux⁺::Vars{A},
-    bctype, t, state1⁻::Vars{S}, aux1⁻::Vars{A}) where {D,T,S,A}
+function numerical_boundary_flux_gradient!(nf::CentralNumericalFluxGradient,
+                                           bl::BalanceLaw,
+                                           diff_penalty::Vars{D}, n::SVector,
+                                           transform⁻::Vars{T}, state⁻::Vars{S},
+                                           aux⁻::Vars{A}, transform⁺::Vars{T},
+                                           state⁺::Vars{S}, aux⁺::Vars{A},
+                                           bctype, t, state1⁻::Vars{S},
+                                           aux1⁻::Vars{A}) where {D,T,S,A}
 
   boundary_state!(nf, bl, state⁺, aux⁺, n, state⁻, aux⁻,
-    bctype, t, state1⁻, aux1⁻)
+                  bctype, t, state1⁻, aux1⁻)
 
   gradvariables!(bl, transform⁺, state⁺, aux⁺, t)
 
-  diffusive_penalty!(nf, bl, diff_penalty, n,
-    transform⁻, state⁻, aux⁻,
-    transform⁺, state⁺, aux⁺,
-    t)
+  numerical_flux_gradient!(nf, bl, diff_penalty, n, transform⁻, state⁻, aux⁻,
+                           transform⁺, state⁺, aux⁺, t)
 end
 
 

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -21,7 +21,7 @@ Subtypes `L` should define the following methods:
 - `diffusive!(::L, diffstate::State, ∇transformstate::Grad, auxstate::State, t::Real)`
 - `source!(::L, source::State, state::State, auxstate::State, t::Real)`
 - `wavespeed(::L, nM, state::State, aux::State, t::Real)`
-- `boundary_state!(::GradNumericalPenalty, ::L, stateP::State, auxP::State, normalM, stateM::State, auxM::State, bctype, t)`
+- `boundary_state!(::NumericalFluxGradient, ::L, stateP::State, auxP::State, normalM, stateM::State, auxM::State, bctype, t)`
 - `boundary_state!(::NumericalFluxNonDiffusive, ::L, stateP::State, auxP::State, normalM, stateM::State, auxM::State, bctype, t)`
 - `boundary_state!(::NumericalFluxDiffusive, ::L, stateP::State, diffP::State, auxP::State, normalM, stateM::State, diffM::State, auxM::State, bctype, t)`
 - `init_aux!(::L, aux::State, coords, args...)`

--- a/src/Driver/Configurations.jl
+++ b/src/Driver/Configurations.jl
@@ -52,7 +52,7 @@ struct DriverConfiguration{FT}
     # DGModel details
     numfluxnondiff::NumericalFluxNonDiffusive
     numfluxdiff::NumericalFluxDiffusive
-    gradnumflux::GradNumericalPenalty
+    gradnumflux::NumericalFluxGradient
 
     function DriverConfiguration(name::String, N::Int, FT, array_type,
                                  solver_type::AbstractSolverType,
@@ -61,7 +61,7 @@ struct DriverConfiguration{FT}
                                  grid::DiscontinuousSpectralElementGrid,
                                  numfluxnondiff::NumericalFluxNonDiffusive,
                                  numfluxdiff::NumericalFluxDiffusive,
-                                 gradnumflux::GradNumericalPenalty)
+                                 gradnumflux::NumericalFluxGradient)
         new{FT}(name, N, array_type, solver_type, bl, mpicomm, grid, numfluxnondiff, numfluxdiff, gradnumflux)
     end
 end
@@ -102,7 +102,7 @@ function LES_Configuration(name::String,
                            meshwarp       = (x...)->identity(x),
                            numfluxnondiff = Rusanov(),
                            numfluxdiff    = CentralNumericalFluxDiffusive(),
-                           gradnumflux    = CentralGradPenalty()
+                           gradnumflux    = CentralNumericalFluxGradient()
                           ) where {FT<:AbstractFloat}
     model = AtmosModel(orientation, ref_state, turbulence, moisture,
                        precipitation, radiation, subsidence, sources, bc, init_LES!)
@@ -152,7 +152,7 @@ function GCM_Configuration(name::String,
                            meshwarp::Function = cubedshellwarp,
                            numfluxnondiff     = Rusanov(),
                            numfluxdiff        = CentralNumericalFluxDiffusive(),
-                           gradnumflux        = CentralGradPenalty()
+                           gradnumflux        = CentralNumericalFluxGradient()
                           ) where {FT<:AbstractFloat}
     model = AtmosModel(orientation, ref_state, turbulence, moisture,
                        precipitation, radiation, subsidence, sources, bc, init_GCM!)

--- a/src/Ocean/Model/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/Model/HydrostaticBoussinesqModel.jl
@@ -11,7 +11,7 @@ using ..PlanetParameters: grav
 using ..Mesh.Filters: CutoffFilter, apply!, ExponentialFilter
 using ..Mesh.Grids: polynomialorder, VerticalDirection
 
-using ..DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+using ..DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxGradient,
                                    CentralNumericalFluxDiffusive,
                                    CentralNumericalFluxNonDiffusive
 
@@ -296,7 +296,8 @@ end
 end
 
 @inline function ocean_boundary_state!(::HBModel, ::CoastlineFreeSlip,
-                                       ::Union{Rusanov, CentralGradPenalty},
+                                       ::Union{Rusanov,
+                                               CentralNumericalFluxGradient},
                                        Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
   return nothing
 end
@@ -313,7 +314,8 @@ end
 end
 
 @inline function ocean_boundary_state!(::HBModel, ::CoastlineNoSlip,
-                                       ::Union{Rusanov, CentralGradPenalty},
+                                       ::Union{Rusanov,
+                                               CentralNumericalFluxGradient},
                                        Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
   Q⁺.u = -Q⁻.u
 
@@ -331,7 +333,8 @@ end
 end
 
 @inline function ocean_boundary_state!(m::HBModel, ::OceanFloorFreeSlip,
-                                       ::Union{Rusanov, CentralGradPenalty},
+                                       ::Union{Rusanov,
+                                               CentralNumericalFluxGradient},
                                        Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
   A⁺.w = -A⁻.w
 
@@ -351,7 +354,8 @@ end
 end
 
 @inline function ocean_boundary_state!(m::HBModel, ::OceanFloorNoSlip,
-                                       ::Union{Rusanov, CentralGradPenalty},
+                                       ::Union{Rusanov,
+                                               CentralNumericalFluxGradient},
                                        Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
   Q⁺.u = -Q⁻.u
   A⁺.w = -A⁻.w
@@ -377,7 +381,8 @@ end
                                        OceanSurfaceStressNoForcing,
                                        OceanSurfaceNoStressForcing,
                                        OceanSurfaceStressForcing},
-                                       ::Union{Rusanov, CentralGradPenalty},
+                                       ::Union{Rusanov,
+                                               CentralNumericalFluxGradient},
                                        Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
   return nothing
 end

--- a/src/Ocean/Model/ShallowWaterModel.jl
+++ b/src/Ocean/Model/ShallowWaterModel.jl
@@ -188,7 +188,7 @@ end
   return nothing
 end
 
-shallow_boundary_state!(::CentralGradPenalty, m::SWModel,
+shallow_boundary_state!(::CentralNumericalFluxGradient, m::SWModel,
                         ::LinearDrag, _...) = nothing
 
 shallow_boundary_state!(::CentralNumericalFluxDiffusive, m::SWModel,
@@ -208,7 +208,7 @@ end
   return nothing
 end
 
-@inline function shallow_boundary_state!(::CentralGradPenalty, m::SWModel,
+@inline function shallow_boundary_state!(::CentralNumericalFluxGradient, m::SWModel,
                                          ::ConstantViscosity, q⁺, α⁺, n⁻, q⁻, α⁻, t)
   q⁺.U = -q⁻.U
 

--- a/test/DGmethods/Euler/acousticwave-1d-imex.jl
+++ b/test/DGmethods/Euler/acousticwave-1d-imex.jl
@@ -3,7 +3,7 @@ using CLIMA.Mesh.Topologies: StackedCubedSphereTopology, cubedshellwarp, grid1d
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.Mesh.Filters
 using CLIMA.DGmethods: DGModel, init_ode_state, VerticalDirection
-using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxGradient,
                                        CentralNumericalFluxDiffusive
 using CLIMA.ODESolvers: solve!, gettime
 using CLIMA.AdditiveRungeKuttaMethod
@@ -85,10 +85,11 @@ function run(mpicomm, polynomialorder, numelem_horz, numelem_vert,
   linearmodel = AtmosAcousticGravityLinearModel(model)
 
   dg = DGModel(model, grid, Rusanov(),
-               CentralNumericalFluxDiffusive(), CentralGradPenalty())
+               CentralNumericalFluxDiffusive(), CentralNumericalFluxGradient())
 
   lineardg = DGModel(linearmodel, grid, Rusanov(),
-                     CentralNumericalFluxDiffusive(), CentralGradPenalty();
+                     CentralNumericalFluxDiffusive(),
+                     CentralNumericalFluxGradient();
                      direction=VerticalDirection(),
                      auxstate=dg.auxstate)
 

--- a/test/DGmethods/Euler/isentropicvortex-imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex-imex.jl
@@ -2,7 +2,7 @@ using CLIMA
 using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
-using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxGradient,
                                        CentralNumericalFluxDiffusive
 using CLIMA.ODESolvers: solve!, gettime
 using CLIMA.AdditiveRungeKuttaMethod
@@ -128,15 +128,17 @@ function run(mpicomm, polynomialorder, numelems, setup,
   linear_model = AtmosAcousticLinearModel(model)
   nonlinear_model = RemainderModel(model, (linear_model,))
 
-  dg = DGModel(model, grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty())
+  dg = DGModel(model, grid, Rusanov(), CentralNumericalFluxDiffusive(),
+               CentralNumericalFluxGradient())
 
   dg_linear = DGModel(linear_model,
-                      grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty();
-                      auxstate=dg.auxstate)
+                      grid, Rusanov(), CentralNumericalFluxDiffusive(),
+                      CentralNumericalFluxGradient(); auxstate=dg.auxstate)
 
   if split_nonlinear_linear
     dg_nonlinear = DGModel(nonlinear_model,
-                           grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty();
+                           grid, Rusanov(), CentralNumericalFluxDiffusive(),
+                           CentralNumericalFluxGradient();
                            auxstate=dg.auxstate)
   end
 

--- a/test/DGmethods/Euler/isentropicvortex-multirate.jl
+++ b/test/DGmethods/Euler/isentropicvortex-multirate.jl
@@ -2,7 +2,7 @@ using CLIMA
 using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
-using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxGradient,
                                        CentralNumericalFluxDiffusive
 using CLIMA.ODESolvers: solve!, gettime
 using CLIMA.MultirateRungeKuttaMethod
@@ -126,12 +126,15 @@ function run(mpicomm, polynomialorder, numelems, setup,
   # The nonlinear model has the slow time scales
   slow_model = RemainderModel(model, (fast_model,))
 
-  dg = DGModel(model, grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty())
+  dg = DGModel(model, grid, Rusanov(), CentralNumericalFluxDiffusive(),
+               CentralNumericalFluxGradient())
   fast_dg = DGModel(fast_model,
-                    grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty();
+                    grid, Rusanov(), CentralNumericalFluxDiffusive(),
+                    CentralNumericalFluxGradient();
                     auxstate=dg.auxstate)
   slow_dg = DGModel(slow_model,
-                    grid, Rusanov(), CentralNumericalFluxDiffusive(), CentralGradPenalty();
+                    grid, Rusanov(), CentralNumericalFluxDiffusive(),
+                    CentralNumericalFluxGradient();
                     auxstate=dg.auxstate)
 
   timeend = FT(2 * setup.domain_halflength / setup.translation_speed)

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -2,7 +2,7 @@ using CLIMA
 using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.DGmethods: DGModel, init_ode_state
-using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralGradPenalty,
+using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxGradient,
                                        CentralNumericalFluxDiffusive,
                                        CentralNumericalFluxNonDiffusive
 using CLIMA.ODESolvers: solve!, gettime
@@ -154,7 +154,7 @@ function run(mpicomm, polynomialorder, numelems,
                      initialcondition!)
 
   dg = DGModel(model, grid, NumericalFlux(),
-               CentralNumericalFluxDiffusive(), CentralGradPenalty())
+               CentralNumericalFluxDiffusive(), CentralNumericalFluxGradient())
 
   timeend = FT(2 * setup.domain_halflength / 10 / setup.translation_speed)
 

--- a/test/DGmethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/DGmethods/advection_diffusion/advection_diffusion_model.jl
@@ -8,7 +8,7 @@ import CLIMA.DGmethods: BalanceLaw,
                         boundary_state!, wavespeed, LocalGeometry
 using CLIMA.DGmethods.NumericalFluxes: NumericalFluxNonDiffusive,
                                        NumericalFluxDiffusive,
-                                       GradNumericalPenalty
+                                       NumericalFluxGradient
 
 abstract type AdvectionDiffusionProblem end
 struct AdvectionDiffusion{dim, P} <: BalanceLaw
@@ -171,7 +171,7 @@ function boundary_state_Dirichlet!(::NumericalFluxNonDiffusive,
   # Set the plus side to the exact boundary data
   init_state!(m, stateP, auxP, auxP.coord, t)
 end
-function boundary_state_Dirichlet!(::GradNumericalPenalty,
+function boundary_state_Dirichlet!(::NumericalFluxGradient,
                                    m::AdvectionDiffusion,
                                    stateP, auxP, nM, stateM, auxM, t)
   # Set the plus side sot that after average the numerical flux is the boundary

--- a/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -84,7 +84,7 @@ function run(mpicomm, dim, topl, N, timeend, FT, direction, dt,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty(),
+               CentralNumericalFluxGradient(),
                direction=direction())
 
   Q = init_ode_state(dg, FT(0))

--- a/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -93,14 +93,14 @@ function run(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty(),
+               CentralNumericalFluxGradient(),
                direction=EveryDirection())
 
   vdg = DGModel(model,
                 grid,
                 Rusanov(),
                 CentralNumericalFluxDiffusive(),
-                CentralGradPenalty(),
+                CentralNumericalFluxGradient(),
                 auxstate=dg.auxstate,
                 direction=VerticalDirection())
 

--- a/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
@@ -119,7 +119,7 @@ function run(mpicomm,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
 

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -129,7 +129,7 @@ function run(mpicomm, dim, topl, warpfun, N, timeend, FT, dt)
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
   Qcpu = init_ode_state(dg, FT(0); forcecpu=true)

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
@@ -38,7 +38,7 @@ function run(mpicomm, dim, topl, warpfun, N, timeend, FT, dt)
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
 

--- a/test/DGmethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_model.jl
@@ -103,7 +103,7 @@ function boundary_state!(::Rusanov, bl::MMSModel, stateP::Vars, auxP::Vars, nM,
 end
 
 # FIXME: This is probably not right....
-boundary_state!(::CentralGradPenalty, bl::MMSModel, _...) = nothing
+boundary_state!(::CentralNumericalFluxGradient, bl::MMSModel, _...) = nothing
 
 function boundary_state!(::CentralNumericalFluxDiffusive, bl::MMSModel,
                          stateP::Vars, diffP::Vars, auxP::Vars, nM,

--- a/test/DGmethods/compressible_Navier_Stokes/rayleigh-benard_model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/rayleigh-benard_model.jl
@@ -88,7 +88,7 @@ function run(mpicomm,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
 

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -58,7 +58,7 @@ function run1(mpicomm, dim, topl, N, timeend, FT, dt)
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
 
@@ -93,7 +93,7 @@ function run2(mpicomm, dim, topl, N, timeend, FT, dt)
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
 

--- a/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model-imex.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model-imex.jl
@@ -115,14 +115,14 @@ function run(mpicomm, LinearType,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   linmodel = LinearType(model)
   lindg = DGModel(linmodel,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty(); auxstate=dg.auxstate)
+               CentralNumericalFluxGradient(); auxstate=dg.auxstate)
 
   Q = init_ode_state(dg, FT(0))
 

--- a/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/rising_bubble-model.jl
@@ -113,7 +113,7 @@ function run(mpicomm,
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
 

--- a/test/DGmethods/integral_test.jl
+++ b/test/DGmethods/integral_test.jl
@@ -85,7 +85,7 @@ function run(mpicomm, dim, Ne, N, FT)
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
   dQdt = similar(Q)

--- a/test/DGmethods/integral_test_sphere.jl
+++ b/test/DGmethods/integral_test_sphere.jl
@@ -81,7 +81,7 @@ function run(mpicomm, topl, ArrayType, N, FT, Rinner, Router)
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
   dQdt = similar(Q)

--- a/test/Diagnostics/dycoms_sin_test.jl
+++ b/test/Diagnostics/dycoms_sin_test.jl
@@ -171,7 +171,7 @@ let
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
   Q = init_ode_state(dg, FT(0))
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 

--- a/test/LinearSolvers/bandedsystem.jl
+++ b/test/LinearSolvers/bandedsystem.jl
@@ -11,7 +11,7 @@ using StaticArrays
 using CLIMA.DGmethods: DGModel, Vars, vars_state, num_state, init_ode_state
 using CLIMA.ColumnwiseLUSolver: banded_matrix, banded_matrix_vector_product!
 using CLIMA.DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxDiffusive,
-                                       CentralGradPenalty
+                                       CentralNumericalFluxGradient
 using CLIMA.MPIStateArrays: MPIStateArray, euclidean_distance
 
 using Test
@@ -108,13 +108,13 @@ let
                         grid,
                         Rusanov(),
                         CentralNumericalFluxDiffusive(),
-                        CentralGradPenalty())
+                        CentralNumericalFluxGradient())
 
           vdg = DGModel(model,
                         grid,
                         Rusanov(),
                         CentralNumericalFluxDiffusive(),
-                        CentralGradPenalty();
+                        CentralNumericalFluxGradient();
                         direction=VerticalDirection(),
                         auxstate=dg.auxstate)
 

--- a/test/LinearSolvers/poisson.jl
+++ b/test/LinearSolvers/poisson.jl
@@ -110,7 +110,7 @@ function run(mpicomm, ArrayType, FT, dim, polynomialorder, brickrange, periodici
                grid,
                CentralNumericalFluxNonDiffusive(),
                PenaltyNumFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
   Qrhs = dg.auxstate

--- a/test/Mesh/interpolation.jl
+++ b/test/Mesh/interpolation.jl
@@ -89,7 +89,7 @@ function run_brick_interpolation_test()
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
     Q = init_ode_state(dg, FT(0))
     #------------------------------
@@ -206,7 +206,7 @@ function run_cubed_sphere_interpolation_test()
                        setup)
 
     dg = DGModel(model, grid, Rusanov(),
-                 CentralNumericalFluxDiffusive(), CentralGradPenalty())
+                 CentralNumericalFluxDiffusive(), CentralNumericalFluxGradient())
 
     Q = init_ode_state(dg, FT(0))
     #------------------------------

--- a/test/Ocean/Hydrostatic_Boussinesq/simple_box.jl
+++ b/test/Ocean/Hydrostatic_Boussinesq/simple_box.jl
@@ -172,7 +172,7 @@ let
                     grid,
                     Rusanov(),
                     CentralNumericalFluxDiffusive(),
-                    CentralGradPenalty())
+                    CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0); forcecpu=true)
   update_aux!(dg, model, Q, FT(0))

--- a/test/Ocean/Hydrostatic_Boussinesq/test_divergence_free.jl
+++ b/test/Ocean/Hydrostatic_Boussinesq/test_divergence_free.jl
@@ -144,7 +144,7 @@ let
                     grid,
                     Rusanov(),
                     CentralNumericalFluxDiffusive(),
-                    CentralGradPenalty())
+                    CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0); forcecpu=true)
   update_aux!(dg, model, Q, FT(0))

--- a/test/Ocean/shallow_water/GyreDriver.jl
+++ b/test/Ocean/shallow_water/GyreDriver.jl
@@ -100,7 +100,7 @@ function run(mpicomm, topl, ArrayType, N, dt, FT, model, test)
                grid,
                Rusanov(),
                CentralNumericalFluxDiffusive(),
-               CentralGradPenalty())
+               CentralNumericalFluxGradient())
 
   Q  = init_ode_state(dg, FT(0))
   Qe = init_ode_state(dg, FT(timeend))


### PR DESCRIPTION
In `faceviscterms!` change from requiring a diffusive penalty function (strong flux)
```
  F^{*} - F^{-}
```
to requiring the (weak) numerical flux
```
   F^{*} 
```
The subtraction of `F^{-}` then happens in the calling kernel.

This unifies `faceviscterms!` with` facevisc!` and should simplify flux
based boundary conditions.