### PR TITLE
Fix `PhaseEquil` calls

### DIFF
--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -82,7 +82,8 @@ end
 
 function thermo_state(moist::EquilMoist, orientation::Orientation, state::Vars, aux::Vars)
   e_int = internal_energy(moist, orientation, state, aux)
-  PhaseEquil(e_int, state.ρ, state.moisture.ρq_tot/state.ρ, aux.moisture.temperature)
+  FT = eltype(state)
+  return PhaseEquil{FT}(e_int, state.ρ, state.moisture.ρq_tot/state.ρ, aux.moisture.temperature)
 end
 
 function gradvariables!(moist::EquilMoist, transform::Vars, state::Vars, aux::Vars, t::Real)

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -87,7 +87,7 @@ function compute_thermo!(FT, state, k, ijk, ev, e, z, zvals, thermoQ)
 
     e_int = e_tot - 1//2 * (u^2 + v^2 + w^2) - grav * z
 
-    ts = PhaseEquil(convert(FT, e_int), state.ρ, q_tot, FT(1e-2), 3)
+    ts = PhaseEquil(convert(FT, e_int), state.ρ, q_tot)
     Phpart = PhasePartition(ts)
 
     th = thermo_vars(thermoQ[ijk,e])


### PR DESCRIPTION
Just realized that [this](https://github.com/climate-machine/CLIMA/compare/ck/FixPhaseEquilCalls?expand=1#diff-6f6f3c257f7970bd031f46109bd72cceR86) call to `PhaseEquil` is potentially causing havoc, as this may call the new outer constructor of `PhaseEquil` with a tolerance of `aux.moisture.temperature`.

Also, I've removed the `tol` and `maxiter` args from diagnostics, since this should be in sync with the solver.