### PR TITLE
Add `maxiter` to `EquilMoist`, reorder (`tol,maxiter`)

### DIFF
--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -63,7 +63,8 @@ thermo_state(moist::DryModel, orientation::Orientation, state::Vars, aux::Vars) 
 
 Assumes the moisture components are computed via thermodynamic equilibrium.
 """
-struct EquilMoist <: MoistureModel
+Base.@kwdef struct EquilMoist <: MoistureModel
+  maxiter::Int = 3
 end
 vars_state(::EquilMoist,FT) = @vars(ρq_tot::FT)
 vars_gradient(::EquilMoist,FT) = @vars(q_tot::FT, h_tot::FT)
@@ -73,7 +74,7 @@ vars_aux(::EquilMoist,FT) = @vars(temperature::FT, θ_v::FT, q_liq::FT)
 @inline function atmos_nodal_update_aux!(moist::EquilMoist, atmos::AtmosModel,
                                          state::Vars, aux::Vars, t::Real)
   e_int = internal_energy(moist, atmos.orientation, state, aux)
-  TS = PhaseEquil(e_int, state.ρ, state.moisture.ρq_tot/state.ρ)
+  TS = PhaseEquil(e_int, state.ρ, state.moisture.ρq_tot/state.ρ, moist.maxiter)
   aux.moisture.temperature = air_temperature(TS)
   aux.moisture.θ_v = virtual_pottemp(TS)
   aux.moisture.q_liq = PhasePartition(TS).liq

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -78,9 +78,10 @@ end
 function PhaseEquil(e_int::FT,
                     ρ::FT,
                     q_tot::FT,
-                    tol::FT=FT(1e-1),
                     maxiter::Int=3,
-                    sat_adjust::F=saturation_adjustment) where {FT<:Real,F}
+                    tol::FT=FT(1e-1),
+                    sat_adjust::F=saturation_adjustment
+                    ) where {FT<:Real,F}
     return PhaseEquil{FT}(e_int, ρ, q_tot, sat_adjust(e_int, ρ, q_tot, tol, maxiter))
 end
 
@@ -118,8 +119,8 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 function LiquidIcePotTempSHumEquil(θ_liq_ice::FT,
                                    ρ::FT,
                                    q_tot::FT,
-                                   tol::FT=FT(1e-1),
-                                   maxiter::Int=30
+                                   maxiter::Int=30,
+                                   tol::FT=FT(1e-1)
                                    ) where {FT<:Real}
     T = saturation_adjustment_q_tot_θ_liq_ice(θ_liq_ice, ρ, q_tot, tol, maxiter)
     q_pt = PhasePartition_equil(T, ρ, q_tot)
@@ -141,8 +142,9 @@ Constructs a [`PhaseEquil`](@ref) thermodynamic state from:
 function LiquidIcePotTempSHumEquil_given_pressure(θ_liq_ice::FT,
                                                   p::FT,
                                                   q_tot::FT,
-                                                  tol::FT=FT(1e-1),
-                                                  maxiter::Int=30) where {FT<:Real}
+                                                  maxiter::Int=30,
+                                                  tol::FT=FT(1e-1)
+                                                  ) where {FT<:Real}
     T = saturation_adjustment_q_tot_θ_liq_ice_given_pressure(θ_liq_ice, p, q_tot, tol, maxiter)
     ρ = air_density(T, p, PhasePartition(q_tot))
     q = PhasePartition_equil(T, ρ, q_tot)
@@ -205,8 +207,8 @@ and, optionally
 function LiquidIcePotTempSHumNonEquil(θ_liq_ice::FT,
                                       ρ::FT,
                                       q_pt::PhasePartition{FT},
-                                      tol::FT=FT(1e-1),
-                                      maxiter::Int=5
+                                      maxiter::Int=5,
+                                      tol::FT=FT(1e-1)
                                       ) where {FT<:Real}
     T = air_temperature_from_liquid_ice_pottemp_non_linear(θ_liq_ice, ρ, tol, maxiter, q_pt)
     e_int = internal_energy(T, q_pt)

--- a/test/Common/MoistThermodynamics/runtests.jl
+++ b/test/Common/MoistThermodynamics/runtests.jl
@@ -135,7 +135,7 @@ end
     e_int, ρ, q_tot, q_pt, T, p, θ_liq_ice = MT.tested_convergence_range(FT, 50)
 
     # PhaseEquil
-    ts_exact = PhaseEquil.(e_int, ρ, q_tot, FT(1e-4), 100)
+    ts_exact = PhaseEquil.(e_int, ρ, q_tot, 100, FT(1e-4))
     ts = PhaseEquil.(e_int, ρ, q_tot)
     # Should be machine accurate (because ts contains `e_int`,`ρ`,`q_tot`):
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(PhasePartition.(ts_exact),:tot))
@@ -146,8 +146,8 @@ end
     @test all(isapprox.(air_temperature.(ts), air_temperature.(ts_exact), rtol=rtol))
 
     # PhaseEquil
-    ts_exact = PhaseEquil.(e_int, ρ, q_tot, FT(1e-4), 100, MT.saturation_adjustment_SecantMethod)
-    ts = PhaseEquil.(e_int, ρ, q_tot, FT(1e-1), 30, MT.saturation_adjustment_SecantMethod) # Needs to be in sync with default
+    ts_exact = PhaseEquil.(e_int, ρ, q_tot, 100, FT(1e-4), MT.saturation_adjustment_SecantMethod)
+    ts = PhaseEquil.(e_int, ρ, q_tot, 30, FT(1e-1), MT.saturation_adjustment_SecantMethod) # Needs to be in sync with default
     # Should be machine accurate (because ts contains `e_int`,`ρ`,`q_tot`):
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(PhasePartition.(ts_exact),:tot))
     @test all(internal_energy.(ts) .≈ internal_energy.(ts_exact))
@@ -157,7 +157,7 @@ end
     @test all(isapprox.(air_temperature.(ts), air_temperature.(ts_exact), rtol=rtol))
 
     # LiquidIcePotTempSHumEquil
-    ts_exact = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot, FT(1e-3), 40)
+    ts_exact = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot, 40, FT(1e-3))
     ts = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot)
     # Should be machine accurate:
     @test all(air_density.(ts) .≈ air_density.(ts_exact))
@@ -168,7 +168,7 @@ end
     @test all(isapprox.(air_temperature.(ts), air_temperature.(ts_exact), rtol=rtol))
 
     # LiquidIcePotTempSHumEquil_given_pressure
-    ts_exact = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot, FT(1e-3), 40)
+    ts_exact = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot, 40, FT(1e-3))
     ts = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot)
     # Should be machine accurate:
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(PhasePartition.(ts_exact),:tot))
@@ -179,7 +179,7 @@ end
     @test all(isapprox.(air_temperature.(ts), air_temperature.(ts_exact), rtol=rtol))
 
     # LiquidIcePotTempSHumNonEquil
-    ts_exact = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, ρ, q_pt, FT(1e-3), 40)
+    ts_exact = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, ρ, q_pt, 40, FT(1e-3))
     ts = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, ρ, q_pt)
     # Should be machine accurate:
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(PhasePartition.(ts_exact),:tot))
@@ -209,7 +209,7 @@ end
     @test all(air_density.(ts) .≈ ρ)
 
     # PhaseEquil
-    ts = PhaseEquil.(e_int, ρ, q_tot, FT(1e-1), 30, Ref(MT.saturation_adjustment_SecantMethod))
+    ts = PhaseEquil.(e_int, ρ, q_tot, 30, FT(1e-1), Ref(MT.saturation_adjustment_SecantMethod))
     @test all(internal_energy.(ts) .≈ e_int)
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ q_tot)
     @test all(air_density.(ts) .≈ ρ)
@@ -245,7 +245,7 @@ end
     @test all(θ_liq_ice .≈ liquid_ice_pottemp.(ts))
 
     # LiquidIcePotTempSHumEquil
-    ts = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot, FT(1e-3), 40)
+    ts = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot, 40, FT(1e-3))
     @test all(isapprox.(liquid_ice_pottemp.(ts), θ_liq_ice, atol=1e-1))
     @test all(isapprox.(air_density.(ts), ρ, rtol=rtol))
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ q_tot)
@@ -256,7 +256,7 @@ end
     # precision for the input pressure.
 
     # LiquidIcePotTempSHumEquil_given_pressure
-    ts = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot, FT(1e-3), 40)
+    ts = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot, 40, FT(1e-3))
     @test all(isapprox.(liquid_ice_pottemp.(ts), θ_liq_ice, atol=1e-1))
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt, :tot))
     @test all(isapprox.(air_pressure.(ts), p, atol=FT(MSLP)*2e-2))
@@ -270,7 +270,7 @@ end
     @test all(getproperty.(PhasePartition.(ts),:ice) .≈ getproperty.(q_pt,:ice))
 
     # LiquidIcePotTempSHumNonEquil
-    ts = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, ρ, q_pt, FT(1e-3))
+    ts = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, ρ, q_pt, 5, FT(1e-3))
     @test all(θ_liq_ice .≈ liquid_ice_pottemp.(ts))
     @test all(air_density.(ts) .≈ ρ)
     @test all(getproperty.(PhasePartition.(ts),:tot) .≈ getproperty.(q_pt,:tot))
@@ -293,11 +293,11 @@ end
   @test typeof.(internal_energy.(ρ, ρ.*e_int, Ref(ρu), Ref(e_pot))) == typeof.(e_int)
 
   ts_dry             = PhaseDry.(e_int, ρ)
-  ts_eq              = PhaseEquil.(e_int, ρ, q_tot, FT(1e-1), 15)
+  ts_eq              = PhaseEquil.(e_int, ρ, q_tot, 15, FT(1e-1))
   ts_T               = TemperatureSHumEquil.(air_temperature.(ts_dry), air_pressure.(ts_dry), q_tot)
   ts_neq             = PhaseNonEquil.(e_int, ρ, q_pt)
-  ts_θ_liq_ice_eq    = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot, FT(1e-3), 40)
-  ts_θ_liq_ice_eq_p  = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot, FT(1e-3), 40)
+  ts_θ_liq_ice_eq    = LiquidIcePotTempSHumEquil.(θ_liq_ice, ρ, q_tot, 40, FT(1e-3))
+  ts_θ_liq_ice_eq_p  = LiquidIcePotTempSHumEquil_given_pressure.(θ_liq_ice, p, q_tot, 40, FT(1e-3))
   ts_θ_liq_ice_neq   = LiquidIcePotTempSHumNonEquil.(θ_liq_ice, ρ, q_pt)
   ts_θ_liq_ice_neq_p = LiquidIcePotTempSHumNonEquil_given_pressure.(θ_liq_ice, p, q_pt)
 


### PR DESCRIPTION
 - Adds `maxiter` to `EquilMoist`
 - Reorders `maxiter` and `tol` to protect against bug fix caught in #632

This was added so that `EquilMoist(5)` can be used for the DYCOMS driver in #597 without changing the default `maxiter` in saturation adjustment, based on discussions in #636.

The `maxiter` in `EquilMoist` should probably be reverted at some point since there will be two default `maxiter`'s (one in `states.jl`, and another in `moisture.jl`), which is not an ideal design.