### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/docs/src/Atmos/SurfaceFluxes.md
+++ b/docs/src/Atmos/SurfaceFluxes.md
@@ -98,7 +98,7 @@ Nishizawa2018.compute_exchange_coefficients
 
 - Byun, Daewon W. "On the analytical solutions of flux-profile relationships for the
   atmospheric surface layer." Journal of Applied Meteorology 29.7 (1990): 652-657.
-  doi: [10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2](http://dx.doi.org/10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2)
+  doi: [10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2](https://doi.org/10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2)
 
 - Wyngaard, John C. "Modeling the planetary boundary layer-Extension to the stable case."
   Boundary-Layer Meteorology 9.4 (1975): 441-460.

--- a/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
+++ b/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
@@ -21,7 +21,7 @@
     - Byun, Daewon W. "On the analytical solutions of flux-profile
       relationships for the atmospheric surface layer." Journal of
       Applied Meteorology 29.7 (1990): 652-657.
-      http://dx.doi.org/10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2
+      https://doi.org/10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2
 
   - Ref. Wyngaard1975:
     - Wyngaard, John C. "Modeling the planetary boundary layer-Extension

--- a/src/Mesh/BrickMesh.jl
+++ b/src/Mesh/BrickMesh.jl
@@ -34,7 +34,7 @@ where the 15-bit Hilbert integer = `A B C D E F G H I J K L M N O` is stored
 in `H`
 
 This function is based on public domain code from John Skilling which can be
-found in <https://dx.doi.org/10.1063/1.1751381>.
+found in <https://doi.org/10.1063/1.1751381>.
 """
 function hilbertcode(Y::AbstractArray{T}; bits=8sizeof(T)) where T
   # Below is Skilling's AxestoTranspose

--- a/src/Mesh/Topologies.jl
+++ b/src/Mesh/Topologies.jl
@@ -779,7 +779,7 @@ end
 
 Given points `(a, b, c)` on the surface of a cube, warp the points out to a
 spherical shell of radius `R` based on the equiangular gnomonic grid proposed by
-Ronchi, Iacono, Paolucci (1996) <https://dx.doi.org/10.1006/jcph.1996.0047>
+Ronchi, Iacono, Paolucci (1996) <https://doi.org/10.1006/jcph.1996.0047>
 
 ```
 @article{RonchiIaconoPaolucci1996,


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!