### PR TITLE
Revise balance law interface

### DIFF
--- a/examples/Microphysics/ex_2_Kessler.jl
+++ b/examples/Microphysics/ex_2_Kessler.jl
@@ -131,7 +131,7 @@ end
 
 
 # time tendencies
-@inline function source!(S, Q, aux, t)
+@inline function source!(Q, aux, t, S)
   FT = eltype(Q)
   u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
   @inbounds begin

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -40,7 +40,7 @@ function update_aux!(dg::DGModel, lm::AtmosLinearModel, Q::MPIStateArray, t::Rea
   return false
 end
 integrate_aux!(lm::AtmosLinearModel, integ::Vars, state::Vars, aux::Vars) = nothing
-flux_diffusive!(lm::AtmosLinearModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) = nothing
+flux_diffusive!(lm::AtmosLinearModel, state::Vars, aux::Vars, t::Real, flux::Grad, diffusive::Vars) = nothing
 function wavespeed(lm::AtmosLinearModel, nM, state::Vars, aux::Vars, t::Real)
   ref = aux.ref_state
   return soundspeed_air(ref.T)
@@ -66,7 +66,7 @@ struct AtmosAcousticLinearModel{M} <: AtmosLinearModel
   end
 end
 
-function flux_nondiffusive!(lm::AtmosAcousticLinearModel, flux::Grad, state::Vars, aux::Vars, t::Real)
+function flux_nondiffusive!(lm::AtmosAcousticLinearModel, state::Vars, aux::Vars, t::Real, flux::Grad)
   FT = eltype(state)
   ref = aux.ref_state
   e_pot = gravitational_potential(lm.atmos.orientation, aux)
@@ -77,7 +77,7 @@ function flux_nondiffusive!(lm::AtmosAcousticLinearModel, flux::Grad, state::Var
   flux.ρe = ((ref.ρe + ref.p)/ref.ρ - e_pot)*state.ρu
   nothing
 end
-function source!(lm::AtmosAcousticLinearModel, source::Vars, state::Vars, aux::Vars, t::Real)
+function source!(lm::AtmosAcousticLinearModel, state::Vars, aux::Vars, t::Real, source::Vars)
   nothing
 end
 
@@ -90,7 +90,7 @@ struct AtmosAcousticGravityLinearModel{M} <: AtmosLinearModel
     new{M}(atmos)
   end
 end
-function flux_nondiffusive!(lm::AtmosAcousticGravityLinearModel, flux::Grad, state::Vars, aux::Vars, t::Real)
+function flux_nondiffusive!(lm::AtmosAcousticGravityLinearModel, state::Vars, aux::Vars, t::Real, flux::Grad)
   FT = eltype(state)
   ref = aux.ref_state
   e_pot = gravitational_potential(lm.atmos.orientation, aux)
@@ -101,7 +101,7 @@ function flux_nondiffusive!(lm::AtmosAcousticGravityLinearModel, flux::Grad, sta
   flux.ρe = ((ref.ρe + ref.p)/ref.ρ)*state.ρu
   nothing
 end
-function source!(lm::AtmosAcousticGravityLinearModel, source::Vars, state::Vars, aux::Vars, t::Real)
+function source!(lm::AtmosAcousticGravityLinearModel, state::Vars, aux::Vars, t::Real, source::Vars)
   ∇Φ = ∇gravitational_potential(lm.atmos.orientation, aux)
   source.ρu -= state.ρ * ∇Φ
   nothing

--- a/src/Atmos/Model/remainder.jl
+++ b/src/Atmos/Model/remainder.jl
@@ -20,14 +20,14 @@ update_aux!(dg::DGModel, rem::RemainderModel, Q::MPIStateArray, t::Real) =
 integrate_aux!(rem::RemainderModel, integ::Vars, state::Vars, aux::Vars) =
   integrate_aux!(rem.main, integ, state, aux)
 
-flux_diffusive!(rem::RemainderModel, flux::Grad, state::Vars, diffusive::Vars, aux::Vars, t::Real) =
-  flux_diffusive!(rem.main, flux, state, diffusive, aux, t)
+flux_diffusive!(rem::RemainderModel, state::Vars, aux::Vars, t::Real, flux::Grad, diffusive::Vars) =
+  flux_diffusive!(rem.main, state, aux, t, flux, diffusive)
 
-gradvariables!(rem::RemainderModel, transform::Vars, state::Vars, aux::Vars, t::Real) =
-  gradvariables!(rem.main, transform, state, aux, t)
+gradvariables!(rem::RemainderModel, state::Vars, aux::Vars, t::Real, transform::Vars) =
+  gradvariables!(rem.main, state, aux, t, transform)
 
-diffusive!(rem::RemainderModel, diffusive::Vars, ∇transform::Grad, state::Vars, aux::Vars, t::Real) =
-  diffusive!(rem.main, diffusive, ∇transform, state, aux, t)
+diffusive!(rem::RemainderModel, state::Vars, aux::Vars, t::Real, diffusive::Vars, ∇transform::Grad) =
+  diffusive!(rem.main, state, aux, t, diffusive, ∇transform)
 
 function wavespeed(rem::RemainderModel, nM, state::Vars, aux::Vars, t::Real)
   ref = aux.ref_state
@@ -40,31 +40,31 @@ init_aux!(rem::RemainderModel, aux::Vars, geom::LocalGeometry) = nothing
 init_state!(rem::RemainderModel, state::Vars, aux::Vars, coords, t) = nothing
 
 
-function flux_nondiffusive!(rem::RemainderModel, flux::Grad, state::Vars, aux::Vars, t::Real)
+function flux_nondiffusive!(rem::RemainderModel, state::Vars, aux::Vars, t::Real, flux::Grad)
   m = getfield(flux, :array)
-  flux_nondiffusive!(rem.main, flux, state, aux, t)
+  flux_nondiffusive!(rem.main, state, aux, t, flux)
 
   flux_s = similar(flux)
   m_s = getfield(flux_s, :array)
 
   for sub in rem.subs
     fill!(m_s, 0)
-    flux_nondiffusive!(sub, flux_s, state, aux, t)
+    flux_nondiffusive!(sub, state, aux, t, flux_s)
     m .-= m_s
   end
   nothing
 end
 
-function source!(rem::RemainderModel, source::Vars, state::Vars, aux::Vars, t::Real)
+function source!(rem::RemainderModel, state::Vars, aux::Vars, t::Real, source::Vars)
   m = getfield(source, :array)
-  source!(rem.main, source, state, aux, t)
+  source!(rem.main, state, aux, t, source)
 
   source_s = similar(source)
   m_s = getfield(source_s, :array)
 
   for sub in rem.subs
     fill!(m_s, 0)
-    source!(sub, source_s, state, aux, t)
+    source!(sub, state, aux, t, source_s)
     m .-= m_s
   end
   nothing

--- a/src/Atmos/Model/turbulence.jl
+++ b/src/Atmos/Model/turbulence.jl
@@ -15,16 +15,16 @@ function atmos_init_aux!(::TurbulenceClosure, ::AtmosModel, aux::Vars, geom::Loc
 end
 function atmos_nodal_update_aux!(::TurbulenceClosure, ::AtmosModel, state::Vars, aux::Vars, t::Real)
 end
-function diffusive!(::TurbulenceClosure, diffusive, ∇transform, state, aux, t, ν)
+function diffusive!(::TurbulenceClosure, state::Vars, aux::Vars, t::Real, diffusive, ∇transform, ν)
 end
-function gradvariables!(::TurbulenceClosure, transform::Vars, state::Vars, aux::Vars, t::Real)
+function gradvariables!(::TurbulenceClosure, state::Vars, aux::Vars, t::Real, transform::Vars)
 end
 
 """
-  PrincipalInvariants{FT} 
+  PrincipalInvariants{FT}
 
-Calculates principal invariants of a tensor. Returns struct with fields first,second,third 
-referring to each of the invariants. 
+Calculates principal invariants of a tensor. Returns struct with fields first,second,third
+referring to each of the invariants.
 """
 struct PrincipalInvariants{FT}
   first::FT
@@ -51,7 +51,7 @@ struct ConstantViscosityWithDivergence{FT} <: TurbulenceClosure
   "Dynamic Viscosity [kg/m/s]"
   ρν::FT
 end
-function dynamic_viscosity_tensor(m::ConstantViscosityWithDivergence, S, 
+function dynamic_viscosity_tensor(m::ConstantViscosityWithDivergence, S,
   state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real)
   return m.ρν
 end
@@ -63,7 +63,7 @@ end
 """
     SmagorinskyLilly <: TurbulenceClosure
 
-  § 1.3.2 in CliMA documentation 
+  § 1.3.2 in CliMA documentation
 
   article{doi:10.1175/1520-0493(1963)091<0099:GCEWTP>2.3.CO;2,
   author = {Smagorinksy, J.},
@@ -94,7 +94,7 @@ function atmos_init_aux!(::SmagorinskyLilly, ::AtmosModel, aux::Vars, geom::Loca
   aux.turbulence.Δ = lengthscale(geom)
 end
 
-function gradvariables!(m::SmagorinskyLilly, transform::Vars, state::Vars, aux::Vars, t::Real)
+function gradvariables!(m::SmagorinskyLilly, state::Vars, aux::Vars, t::Real, transform::Vars)
   transform.turbulence.θ_v = aux.moisture.θ_v
 end
 
@@ -103,21 +103,21 @@ end
   return buoyancy_factor, scaling coefficient for Standard Smagorinsky Model
   in stratified flows
 
-Compute the buoyancy adjustment coefficient for stratified flows 
-given the strain rate tensor inner product |S| ≡ SijSij ≡ normSij, 
-local virtual potential temperature θᵥ and the vertical potential 
-temperature gradient dθvdz. 
+Compute the buoyancy adjustment coefficient for stratified flows
+given the strain rate tensor inner product |S| ≡ SijSij ≡ normSij,
+local virtual potential temperature θᵥ and the vertical potential
+temperature gradient dθvdz.
 
-Brunt-Vaisala frequency N² defined as in equation (1b) in 
-  Durran, D.R. and J.B. Klemp, 1982: 
-  On the Effects of Moisture on the Brunt-Väisälä Frequency. 
-  J. Atmos. Sci., 39, 2152–2158, 
-  https://doi.org/10.1175/1520-0469(1982)039<2152:OTEOMO>2.0.CO;2 
+Brunt-Vaisala frequency N² defined as in equation (1b) in
+  Durran, D.R. and J.B. Klemp, 1982:
+  On the Effects of Moisture on the Brunt-Väisälä Frequency.
+  J. Atmos. Sci., 39, 2152–2158,
+  https://doi.org/10.1175/1520-0469(1982)039<2152:OTEOMO>2.0.CO;2
 
 Ri = N² / (2*normSij)
 Ri = gravity / θᵥ * ∂θᵥ∂z / 2 |S_{ij}|
 
-§1.3.2 in CliMA documentation. 
+§1.3.2 in CliMA documentation.
 
 article{doi:10.1111/j.2153-3490.1962.tb00128.x,
 author = {LILLY, D. K.},
@@ -159,15 +159,15 @@ end
 
 """
   Vreman{FT} <: TurbulenceClosure
-  
-  §1.3.2 in CLIMA documentation 
+
+  §1.3.2 in CLIMA documentation
 Filter width Δ is the local grid resolution calculated from the mesh metric tensor. A Smagorinsky coefficient
-is specified and used to compute the equivalent Vreman coefficient. 
+is specified and used to compute the equivalent Vreman coefficient.
 
 1) ν_e = √(Bᵦ/(αᵢⱼαᵢⱼ)) where αᵢⱼ = ∂uⱼ∂uᵢ with uᵢ the resolved scale velocity component.
 2) βij = Δ²αₘᵢαₘⱼ
 3) Bᵦ = β₁₁β₂₂ + β₂₂β₃₃ + β₁₁β₃₃ - β₁₂² - β₁₃² - β₂₃²
-βᵢⱼ is symmetric, positive-definite. 
+βᵢⱼ is symmetric, positive-definite.
 If Δᵢ = Δ, then β = Δ²αᵀα
 
 @article{Vreman2004,
@@ -194,7 +194,7 @@ vars_gradient(::Vreman,FT) = @vars(θ_v::FT)
 function atmos_init_aux!(::Vreman, ::AtmosModel, aux::Vars, geom::LocalGeometry)
   aux.turbulence.Δ = lengthscale(geom)
 end
-function gradvariables!(m::Vreman, transform::Vars, state::Vars, aux::Vars, t::Real)
+function gradvariables!(m::Vreman, state::Vars, aux::Vars, t::Real, transform::Vars)
   transform.turbulence.θ_v = aux.moisture.θ_v
 end
 function dynamic_viscosity_tensor(m::Vreman, S, state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real)
@@ -206,7 +206,7 @@ function dynamic_viscosity_tensor(m::Vreman, S, state::Vars, diffusive::Vars, �
   βij = f_b² * (aux.turbulence.Δ)^2 * (∇u' * ∇u)
   Bβinvariants = compute_principal_invariants(βij)
   @inbounds Bβ = Bβinvariants.second
-  return state.ρ * max(0,m.C_smag^2 * 2.5 * sqrt(abs(Bβ/(αijαij+eps(FT))))) 
+  return state.ρ * max(0,m.C_smag^2 * 2.5 * sqrt(abs(Bβ/(αijαij+eps(FT)))))
 end
 function scaled_momentum_flux_tensor(m::Vreman, ρν, S)
   (-2*ρν) * S
@@ -214,11 +214,11 @@ end
 
 """
   AnisoMinDiss{FT} <: TurbulenceClosure
-  
-  §1.3.2 in CLIMA documentation 
+
+  §1.3.2 in CLIMA documentation
 Filter width Δ is the local grid resolution calculated from the mesh metric tensor. A Poincare coefficient
-is specified and used to compute the equivalent AnisoMinDiss coefficient (computed as the solution to the 
-eigenvalue problem for the Laplacian operator). 
+is specified and used to compute the equivalent AnisoMinDiss coefficient (computed as the solution to the
+eigenvalue problem for the Laplacian operator).
 
 @article{doi:10.1063/1.4928700,
 author = {Rozema,Wybe  and Bae,Hyun J.  and Moin,Parviz  and Verstappen,Roel },
@@ -233,7 +233,7 @@ URL = {https://aip.scitation.org/doi/abs/10.1063/1.4928700},
 eprint = {https://aip.scitation.org/doi/pdf/10.1063/1.4928700}
 }
 -------------------------------------------------------------------------------------
-# TODO: Future versions will include modifications of Abkar(2016), Verstappen(2018) 
+# TODO: Future versions will include modifications of Abkar(2016), Verstappen(2018)
 @article{PhysRevFluids.1.041701,
 title = {Minimum-dissipation scalar transport model for large-eddy simulation of turbulent flows},
 author = {Abkar, Mahdi and Bae, Hyun J. and Moin, Parviz},
@@ -258,7 +258,7 @@ vars_gradient(::AnisoMinDiss,T) = @vars(θ_v::T)
 function atmos_init_aux!(::AnisoMinDiss, ::AtmosModel, aux::Vars, geom::LocalGeometry)
   aux.turbulence.Δ = lengthscale(geom)
 end
-function gradvariables!(m::AnisoMinDiss, transform::Vars, state::Vars, aux::Vars, t::Real)
+function gradvariables!(m::AnisoMinDiss, state::Vars, aux::Vars, t::Real, transform::Vars)
   transform.turbulence.θ_v = aux.moisture.θ_v
 end
 function dynamic_viscosity_tensor(m::AnisoMinDiss, S, state::Vars, diffusive::Vars, ∇transform::Grad, aux::Vars, t::Real)

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -115,9 +115,10 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
           end
 
           fill!(l_F, -zero(eltype(l_F)))
-          flux_nondiffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                             Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                             Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+          flux_nondiffusive!(bl, Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                                 Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                                 t,
+                                 Grad{vars_state(bl,FT)}(l_F))
 
           @unroll for s = 1:nstate
             s_F[1,i,j,k,s] = l_F[1,s]
@@ -127,9 +128,11 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
 
           # if source! !== nothing
           fill!(l_S, -zero(eltype(l_S)))
-          source!(bl, Vars{vars_state(bl,FT)}(l_S),
+          source!(bl,
                   Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                  t,
+                  Vars{vars_state(bl,FT)}(l_S))
 
           @unroll for s = 1:nstate
             l_rhs[s, i, j, k] += l_S[s]
@@ -191,10 +194,12 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
           end
 
           fill!(l_F, -zero(eltype(l_F)))
-          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
+          flux_diffusive!(bl,
                           Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
-                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                          t,
+                          Grad{vars_state(bl,FT)}(l_F),
+                          Vars{vars_diffusive(bl,FT)}(l_Qvisc))
 
           @unroll for s = 1:nstate
             F1, F2, F3 = s_F[1,i,j,k,s], s_F[2,i,j,k,s], s_F[3,i,j,k,s]
@@ -327,9 +332,10 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           end
 
           fill!(l_F, -zero(eltype(l_F)))
-          flux_nondiffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                             Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                             Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+          flux_nondiffusive!(bl, Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                                 Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                                 t,
+                                 Grad{vars_state(bl,FT)}(l_F))
 
           @unroll for s = 1:nstate
             s_F[1,i,j,k,s] = l_F[1,s]
@@ -339,9 +345,11 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
 
           # if source! !== nothing
           fill!(l_S, -zero(eltype(l_S)))
-          source!(bl, Vars{vars_state(bl,FT)}(l_S),
+          source!(bl,
                   Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                  t,
+                  Vars{vars_state(bl,FT)}(l_S))
 
           @unroll for s = 1:nstate
             l_rhs[s, i, j, k] += l_S[s]
@@ -386,10 +394,12 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           end
 
           fill!(l_F, -zero(eltype(l_F)))
-          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
+          flux_diffusive!(bl,
                           Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
-                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                          t,
+                          Grad{vars_state(bl,FT)}(l_F),
+                          Vars{vars_diffusive(bl,FT)}(l_Qvisc))
 
           @unroll for s = 1:nstate
             F1, F2, F3 = s_F[1,i,j,k,s], s_F[2,i,j,k,s], s_F[3,i,j,k,s]
@@ -648,8 +658,11 @@ function volumeviscterms!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           end
 
           fill!(l_G, -zero(eltype(l_G)))
-          gradvariables!(bl, Vars{vars_gradient(bl,FT)}(l_G), Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                     Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+          gradvariables!(bl,
+                         Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                         Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                         t,
+                         Vars{vars_gradient(bl,FT)}(l_G))
           @unroll for s = 1:ngradstate
             s_G[i, j, k, s] = l_G[s]
           end
@@ -700,8 +713,12 @@ function volumeviscterms!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           end
 
           fill!(l_Qvisc, -zero(eltype(l_Qvisc)))
-          diffusive!(bl, Vars{vars_diffusive(bl,FT)}(l_Qvisc), Grad{vars_gradient(bl,FT)}(l_gradG),
-                     Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]), Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+          diffusive!(bl,
+                     Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                     Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                     t,
+                     Vars{vars_diffusive(bl,FT)}(l_Qvisc),
+                     Grad{vars_gradient(bl,FT)}(l_gradG))
 
           @unroll for s = 1:nviscstate
             Qvisc[ijk, s, e] = l_Qvisc[s]
@@ -765,9 +782,11 @@ function volumeviscterms!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           end
 
           fill!(l_G, -zero(eltype(l_G)))
-          gradvariables!(bl, Vars{vars_gradient(bl,FT)}(l_G),
+          gradvariables!(bl,
                          Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                         Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                         Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                         t,
+                         Vars{vars_gradient(bl,FT)}(l_G))
           @unroll for s = 1:ngradstate
             s_G[i, j, k, s] = l_G[s]
           end
@@ -800,10 +819,12 @@ function volumeviscterms!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           end
 
           fill!(l_Qvisc, -zero(eltype(l_Qvisc)))
-          diffusive!(bl, Vars{vars_diffusive(bl,FT)}(l_Qvisc),
-                     Grad{vars_gradient(bl,FT)}(l_gradG),
+          diffusive!(bl,
                      Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                     Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                     Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]),
+                     t,
+                     Vars{vars_diffusive(bl,FT)}(l_Qvisc),
+                     Grad{vars_gradient(bl,FT)}(l_gradG))
 
           @unroll for s = 1:nviscstate
             Qvisc[ijk, s, e] = l_Qvisc[s]
@@ -884,9 +905,11 @@ function faceviscterms!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
         end
 
         fill!(l_GM, -zero(eltype(l_GM)))
-        gradvariables!(bl, Vars{vars_gradient(bl,FT)}(l_GM),
+        gradvariables!(bl,
                        Vars{vars_state(bl,FT)}(l_QM),
-                       Vars{vars_aux(bl,FT)}(l_auxM), t)
+                       Vars{vars_aux(bl,FT)}(l_auxM),
+                       t,
+                       Vars{vars_gradient(bl,FT)}(l_GM))
 
         # Load plus side data
         @unroll for s = 1:ngradtransformstate
@@ -898,9 +921,11 @@ function faceviscterms!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
         end
 
         fill!(l_GP, -zero(eltype(l_GP)))
-        gradvariables!(bl, Vars{vars_gradient(bl,FT)}(l_GP),
+        gradvariables!(bl,
                        Vars{vars_state(bl,FT)}(l_QP),
-                       Vars{vars_aux(bl,FT)}(l_auxP), t)
+                       Vars{vars_aux(bl,FT)}(l_auxP),
+                       t,
+                       Vars{vars_gradient(bl,FT)}(l_GP))
 
         bctype = elemtobndy[f, e]
         fill!(l_Qvisc, -zero(eltype(l_Qvisc)))

--- a/src/DGmethods/NumericalFluxes.jl
+++ b/src/DGmethods/NumericalFluxes.jl
@@ -42,7 +42,7 @@ function diffusive_penalty!(::CentralGradPenalty, bl::BalanceLaw,
     t) where {D,T,S,A}
 
   G = n .* (parent(transform⁺) .- parent(transform⁻))' ./ 2
-  diffusive!(bl, diff_penalty, Grad{T}(G), state⁻, aux⁻, t)
+  diffusive!(bl, state⁻, aux⁻, t, diff_penalty, Grad{T}(G))
 end
 
 function diffusive_boundary_penalty!(nf::CentralGradPenalty, bl::BalanceLaw,
@@ -54,7 +54,7 @@ function diffusive_boundary_penalty!(nf::CentralGradPenalty, bl::BalanceLaw,
   boundary_state!(nf, bl, state⁺, aux⁺, n, state⁻, aux⁻,
     bctype, t, state1⁻, aux1⁻)
 
-  gradvariables!(bl, transform⁺, state⁺, aux⁺, t)
+  gradvariables!(bl, state⁺, aux⁺, t, transform⁺)
 
   diffusive_penalty!(nf, bl, diff_penalty, n,
     transform⁻, state⁻, aux⁻,
@@ -157,11 +157,11 @@ function numerical_flux_nondiffusive!(::CentralNumericalFluxNonDiffusive,
 
   F⁻ = similar(Fᵀn, Size(3, nstate))
   fill!(F⁻, -zero(FT))
-  flux_nondiffusive!(bl, Grad{S}(F⁻), state⁻, aux⁻, t)
+  flux_nondiffusive!(bl, state⁻, aux⁻, t, Grad{S}(F⁻))
 
   F⁺ = similar(Fᵀn, Size(3, nstate))
   fill!(F⁺, -zero(FT))
-  flux_nondiffusive!(bl, Grad{S}(F⁺), state⁺, aux⁺, t)
+  flux_nondiffusive!(bl, state⁺, aux⁺, t, Grad{S}(F⁺))
 
   Fᵀn .+= (F⁻ + F⁺)' * (n/2)
 end
@@ -232,11 +232,11 @@ function numerical_flux_diffusive!(::CentralNumericalFluxDiffusive,
 
   F⁻ = similar(Fᵀn, Size(3, nstate))
   fill!(F⁻, -zero(FT))
-  flux_diffusive!(bl, Grad{S}(F⁻), state⁻, diff⁻, aux⁻, t)
+  flux_diffusive!(bl, state⁻, aux⁻, t, Grad{S}(F⁻), diff⁻)
 
   F⁺ = similar(Fᵀn, Size(3, nstate))
   fill!(F⁺, -zero(FT))
-  flux_diffusive!(bl, Grad{S}(F⁺), state⁺, diff⁺, aux⁺, t)
+  flux_diffusive!(bl, state⁺, aux⁺, t, Grad{S}(F⁺), diff⁺)
 
   Fᵀn .+= (F⁻ + F⁺)' * (n/2)
 end

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -15,11 +15,13 @@ Subtypes `L` should define the following methods:
 - `vars_state_for_transform(::L)`: a tuple of symbols containing the state variables which are passed to the `transform!` function.
 - `vars_gradient(::L)`: a tuple of symbols containing the transformed variables of which gradients are computed
 - `vars_diffusive(::L)`: a tuple of symbols containing the diffusive variables
-- `flux_nondiffusive!(::L, flux::Grad, state::State, auxstate::State, t::Real)`
-- `flux_diffusive!(::L, flux::Grad, state::State, diffstate::State, auxstate::State, t::Real)`
-- `gradvariables!(::L, transformstate::State, state::State, auxstate::State, t::Real)`
-- `diffusive!(::L, diffstate::State, ∇transformstate::Grad, auxstate::State, t::Real)`
-- `source!(::L, source::State, state::State, auxstate::State, t::Real)`
+
+- `flux_nondiffusive!(::L, state::State, auxstate::State, t::Real, flux::Grad)`
+- `flux_diffusive!(   ::L, state::State, auxstate::State, t::Real, flux::Grad, diffstate::State)`
+- `gradvariables!(    ::L, state::State, auxstate::State, t::Real, transformstate::State)`
+- `diffusive!(        ::L, state::State, auxstate::State, t::Real, diffstate::State, ∇transformstate::Grad)`
+- `source!(           ::L, state::State, auxstate::State, t::Real, source::State)`
+
 - `wavespeed(::L, nM, state::State, aux::State, t::Real)`
 - `boundary_state!(::GradNumericalPenalty, ::L, stateP::State, auxP::State, normalM, stateM::State, auxM::State, bctype, t)`
 - `boundary_state!(::NumericalFluxNonDiffusive, ::L, stateP::State, auxP::State, normalM, stateM::State, auxM::State, bctype, t)`

--- a/src/Ocean/Model/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/Model/HydrostaticBoussinesqModel.jl
@@ -115,8 +115,8 @@ function vars_integrals(m::HBModel, T)
   end
 end
 
-@inline function flux_nondiffusive!(m::HBModel, F::Grad, Q::Vars,
-                                    A::Vars, t::Real)
+@inline function flux_nondiffusive!(m::HBModel, Q::Vars,
+                                    A::Vars, t::Real, F::Grad)
   @inbounds begin
     u = Q.u # Horizontal components of velocity
     η = Q.η
@@ -189,15 +189,15 @@ end
   return nothing
 end
 
-@inline function gradvariables!(m::HBModel, G::Vars, Q::Vars, A, t)
+@inline function gradvariables!(m::HBModel, Q::Vars, A, t, G::Vars)
   G.u = Q.u
   G.θ = Q.θ
 
   return nothing
 end
 
-@inline function diffusive!(m::HBModel, D::Vars, G::Grad, Q::Vars,
-                            A::Vars, t)
+@inline function diffusive!(m::HBModel, Q::Vars,
+                            A::Vars, t, D::Vars, G::Grad)
   D.∇u = G.u
   D.∇θ = G.θ
 

--- a/src/Ocean/Model/ShallowWaterModel.jl
+++ b/src/Ocean/Model/ShallowWaterModel.jl
@@ -66,8 +66,8 @@ function vars_diffusive(m::SWModel, T)
   end
 end
 
-@inline function flux_nondiffusive!(m::SWModel, F::Grad, q::Vars,
-                                    α::Vars, t::Real)
+@inline function flux_nondiffusive!(m::SWModel, q::Vars,
+                                    α::Vars, t::Real, F::Grad)
   U = q.U
   η = q.η
   H = m.problem.H
@@ -92,21 +92,21 @@ advective_flux!(::SWModel, ::Nothing, _...) = nothing
   return nothing
 end
 
-function gradvariables!(m::SWModel, f::Vars, q::Vars, α::Vars, t::Real)
-  gradvariables!(m.turbulence, f, q, α, t)
+function gradvariables!(m::SWModel, q::Vars, α::Vars, t::Real, f::Vars)
+  gradvariables!(m.turbulence, q, α, t, f)
 end
 
 gradvariables!(::LinearDrag, _...) = nothing
 
-@inline function gradvariables!(T::ConstantViscosity, f::Vars, q::Vars,
-                                α::Vars, t::Real)
+@inline function gradvariables!(T::ConstantViscosity, q::Vars,
+                                α::Vars, t::Real, f::Vars)
   f.U = q.U
 
   return nothing
 end
 
-function diffusive!(m::SWModel, σ::Vars, δ::Grad, q::Vars, α::Vars, t::Real)
-  diffusive!(m.turbulence, σ, δ, q, α, t)
+function diffusive!(m::SWModel, q::Vars, α::Vars, t::Real, σ::Vars, δ::Grad)
+  diffusive!(m.turbulence, q, α, t, σ, δ)
 end
 
 diffusive!(::LinearDrag, _...) = nothing
@@ -121,15 +121,15 @@ diffusive!(::LinearDrag, _...) = nothing
   return nothing
 end
 
-function flux_diffusive!(m::SWModel, G::Grad, q::Vars, σ::Vars,
-                         α::Vars, t::Real)
+function flux_diffusive!(m::SWModel, q::Vars,
+                         α::Vars, t::Real, G::Grad, σ::Vars)
   flux_diffusive!(m.turbulence, G, q, σ, α, t)
 end
 
 flux_diffusive!(::LinearDrag, _...) = nothing
 
-@inline function flux_diffusive!(::ConstantViscosity, G::Grad, q::Vars,
-                                 σ::Vars, α::Vars, t::Real)
+@inline function flux_diffusive!(::ConstantViscosity, q::Vars,
+                                 α::Vars, t::Real, G::Grad, σ::Vars)
   G.U -= σ.ν∇U
 
   return nothing
@@ -137,8 +137,8 @@ end
 
 @inline wavespeed(m::SWModel, n⁻, q::Vars, α::Vars, t::Real) = m.c
 
-@inline function source!(m::SWModel{P}, S::Vars, q::Vars, α::Vars,
-                         t::Real) where P
+@inline function source!(m::SWModel{P}, q::Vars, α::Vars,
+                         t::Real, S::Vars) where P
   τ = α.τ
   f = α.f
   U = q.U

--- a/test/DGmethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/DGmethods/advection_diffusion/advection_diffusion_model.jl
@@ -36,8 +36,8 @@ vars_gradient(::AdvectionDiffusion, FT) = @vars(ρ::FT)
 vars_diffusive(::AdvectionDiffusion, FT) = @vars(σ::SVector{3,FT})
 
 """
-    flux_nondiffusive!(m::AdvectionDiffusion, flux::Grad, state::Vars,
-                       aux::Vars, t::Real)
+    flux_nondiffusive!(m::AdvectionDiffusion, state::Vars,
+                       aux::Vars, t::Real, flux::Grad)
 
 Computes non-diffusive flux `F` in:
 
@@ -52,16 +52,16 @@ Where
  - `ρ` is the advected quantity
  - `σ` is DG auxiliary variable (`σ = D ∇ ρ` with D being the diffusion tensor)
 """
-function flux_nondiffusive!(m::AdvectionDiffusion, flux::Grad, state::Vars,
-                            aux::Vars, t::Real)
+function flux_nondiffusive!(m::AdvectionDiffusion, state::Vars,
+                            aux::Vars, t::Real, flux::Grad)
   ρ = state.ρ
   u = aux.u
   flux.ρ += u * ρ
 end
 
 """
-    flux_diffusive!(m::AdvectionDiffusion, flux::Grad, state::Vars,
-                     auxDG::Vars, aux::Vars, t::Real)
+    flux_diffusive!(m::AdvectionDiffusion, state::Vars,
+                     aux::Vars, t::Real, flux::Grad, auxDG::Vars)
 
 Computes diffusive flux `F` in:
 
@@ -76,31 +76,31 @@ Where
  - `ρ` is the advected quantity
  - `σ` is DG auxiliary variable (`σ = D ∇ ρ` with D being the diffusion tensor)
 """
-function flux_diffusive!(m::AdvectionDiffusion, flux::Grad, state::Vars,
-                         auxDG::Vars, aux::Vars, t::Real)
+function flux_diffusive!(m::AdvectionDiffusion, state::Vars,
+                         aux::Vars, t::Real, flux::Grad, auxDG::Vars)
   σ = auxDG.σ
   flux.ρ += -σ
 end
 
 """
-    gradvariables!(m::AdvectionDiffusion, transform::Vars, state::Vars,
-                   aux::Vars, t::Real)
+    gradvariables!(m::AdvectionDiffusion, state::Vars,
+                   aux::Vars, t::Real, transform::Vars)
 
 Set the variable to take the gradient of (`ρ` in this case)
 """
-function gradvariables!(m::AdvectionDiffusion, transform::Vars, state::Vars,
-                        aux::Vars, t::Real)
+function gradvariables!(m::AdvectionDiffusion, state::Vars,
+                        aux::Vars, t::Real, transform::Vars)
   transform.ρ = state.ρ
 end
 
 """
-    diffusive!(m::AdvectionDiffusion, transform::Vars, state::Vars, aux::Vars,
-               t::Real)
+    diffusive!(m::AdvectionDiffusion, state::Vars, aux::Vars, t::Real,
+               auxDG::Vars, gradvars::Grad)
 
 Set the variable to take the gradient of (`ρ` in this case)
 """
-function diffusive!(m::AdvectionDiffusion, auxDG::Vars, gradvars::Grad,
-                    state::Vars, aux::Vars, t::Real)
+function diffusive!(m::AdvectionDiffusion, state::Vars, aux::Vars, t::Real,
+                    auxDG::Vars, gradvars::Grad)
   ∇ρ = gradvars.ρ
   D = aux.D
   auxDG.σ = D * ∇ρ

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -64,7 +64,7 @@ function mms2_init_state!(state::Vars, aux::Vars, (x1,x2,x3), t)
   state.ρe = E_g(t, x1, x2, x3, Val(2))
 end
 
-function mms2_source!(source::Vars, state::Vars, aux::Vars, t::Real)
+function mms2_source!(state::Vars, aux::Vars, t::Real, source::Vars)
   x1,x2,x3 = aux.coord
   source.ρ  = Sρ_g(t, x1, x2, x3, Val(2))
   source.ρu = SVector(SU_g(t, x1, x2, x3, Val(2)),
@@ -81,7 +81,7 @@ function mms3_init_state!(state::Vars, aux::Vars, (x1,x2,x3), t)
   state.ρe = E_g(t, x1, x2, x3, Val(3))
 end
 
-function mms3_source!(source::Vars, state::Vars, aux::Vars, t::Real)
+function mms3_source!(state::Vars, aux::Vars, t::Real, source::Vars)
   x1,x2,x3 = aux.coord
   source.ρ  = Sρ_g(t, x1, x2, x3, Val(3))
   source.ρu = SVector(SU_g(t, x1, x2, x3, Val(3)),

--- a/test/DGmethods_old/Euler/RTB_IMEX.jl
+++ b/test/DGmethods_old/Euler/RTB_IMEX.jl
@@ -114,14 +114,14 @@ end
   end
 end
 
-@inline function source!(S, Q, aux, t)
+@inline function source!(Q, aux, t, S)
   # Initialise the final block source term
   S .= -zero(eltype(Q))
 
-  source_geopotential!(S, Q, aux, t)
+  source_geopotential!(Q, aux, t, S)
 end
 
-@inline function source_geopotential!(S, Q, aux, t)
+@inline function source_geopotential!(Q, aux, t, S)
   @inbounds begin
     δρ = Q[_δρ]
     ρ0 = aux[_a_ρ0]
@@ -240,11 +240,11 @@ end
   end
 end
 
-@inline function lin_source!(S, Q, aux, t)
+@inline function lin_source!(Q, aux, t, S)
   S .= 0
-  lin_source_geopotential!(S, Q, aux, t)
+  lin_source_geopotential!(Q, aux, t, S)
 end
-@inline function lin_source_geopotential!(S, Q, aux, t)
+@inline function lin_source_geopotential!(Q, aux, t, S)
   @inbounds begin
     δρ = Q[_δρ]
     ∇ϕ = SVector(aux[_a_ϕ_x], aux[_a_ϕ_y], aux[_a_ϕ_z])

--- a/test/DGmethods_old/Euler/isentropic_vortex_standalone_source.jl
+++ b/test/DGmethods_old/Euler/isentropic_vortex_standalone_source.jl
@@ -70,7 +70,7 @@ const _a_ϕ, _a_ϕx, _a_ϕy, _a_ϕz, _a_x, _a_y, _a_z = 1:_nauxstate
   end
 end
 
-@inline function almost_no_source!(S, Q, aux, t)
+@inline function almost_no_source!(Q, aux, t, S)
   @inbounds begin
     x,y,z = aux[_a_x], aux[_a_y], aux[_a_z]
     isentropicvortex!(S, t, x, y, z)

--- a/test/DGmethods_old/compressible_Navier_Stokes/MWE_grid_stretching.jl
+++ b/test/DGmethods_old/compressible_Navier_Stokes/MWE_grid_stretching.jl
@@ -405,7 +405,7 @@ end
 end
 # -------------------------------------------------------------------------
 
-@inline function source!(S,Q,aux,t)
+@inline function source!(Q,aux,t,S)
   # Initialise the final block source term
   S .= 0
 


### PR DESCRIPTION
This PR revises the balance law function arguments to be a bit more structured:

### Old interface

```
- `flux_nondiffusive!(::L, flux::Grad, state::State, auxstate::State, t::Real)`
- `flux_diffusive!(   ::L, flux::Grad, state::State, diffstate::State, auxstate::State, t::Real)`
- `gradvariables!(    ::L, transformstate::State, state::State, auxstate::State, t::Real)`
- `diffusive!(        ::L, diffstate::State, ∇transformstate::Grad, auxstate::State, t::Real)`
- `source!(           ::L, source::State, state::State, auxstate::State, t::Real)`
```

### New interface
```
- `flux_nondiffusive!(::L, state::State, auxstate::State, t::Real, flux::Grad)`
- `flux_diffusive!(   ::L, state::State, auxstate::State, t::Real, flux::Grad, diffstate::State)`
- `gradvariables!(    ::L, state::State, auxstate::State, t::Real, transformstate::State)`
- `diffusive!(        ::L, state::State, auxstate::State, t::Real, diffstate::State, ∇transformstate::Grad)`
- `source!(           ::L, state::State, auxstate::State, t::Real, source::State)`
```