### PR TITLE
Add `vapor_specific_humidity`

### DIFF
--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -40,6 +40,7 @@ export dry_pottemp, dry_pottemp_given_pressure, virtual_pottemp, exner, exner_gi
 export liquid_ice_pottemp, liquid_ice_pottemp_given_pressure, liquid_ice_pottemp_sat, relative_humidity
 export air_temperature_from_liquid_ice_pottemp, air_temperature_from_liquid_ice_pottemp_given_pressure
 export air_temperature_from_liquid_ice_pottemp_non_linear
+export vapor_specific_humidity
 
 include("states.jl")
 
@@ -65,6 +66,13 @@ gas_constant_air(ts::ThermodynamicState) =
   gas_constant_air(PhasePartition(ts))
 gas_constant_air(ts::PhaseDry{FT}) where {FT<:Real} = FT(R_d)
 
+"""
+    vapor_specific_humidity(q::PhasePartition{FT})
+
+The vapor specific humidity, given a `PhasePartition` `q`.
+"""
+vapor_specific_humidity(q::PhasePartition) = q.tot - q.liq - q.ice
+vapor_specific_humidity(ts::ThermodynamicState) = vapor_specific_humidity(PhasePartition(ts))
 
 """
     air_pressure(T, ρ[, q::PhasePartition])

--- a/test/Common/MoistThermodynamics/runtests.jl
+++ b/test/Common/MoistThermodynamics/runtests.jl
@@ -100,7 +100,7 @@ float_types = [Float32, Float64]
   @test MT.saturation_adjustment_SecantMethod(internal_energy_sat(200.0, ρ, q_tot), ρ, q_tot, 1e-2, 10) ≈ 200.0
   @test abs(MT.saturation_adjustment(internal_energy_sat(200.0, ρ, q_tot), ρ, q_tot, 1e-2, 10) - 200.0) < tol_T
   q = PhasePartition_equil(T, ρ, q_tot)
-  @test q.tot - q.liq - q.ice ≈ q_vap_saturation(T, ρ)
+  @test q.tot - q.liq - q.ice ≈ vapor_specific_humidity(q) ≈ q_vap_saturation(T, ρ)
 
   ρ = FT(1)
   ρu = FT[1,2,3]
@@ -313,6 +313,7 @@ end
     )
     @test typeof.(soundspeed_air.(ts))          == typeof.(e_int)
     @test typeof.(gas_constant_air.(ts))        == typeof.(e_int)
+    @test typeof.(vapor_specific_humidity.(ts)) == typeof.(e_int)
     @test typeof.(relative_humidity.(ts))       == typeof.(e_int)
     @test typeof.(air_pressure.(ts))            == typeof.(e_int)
     @test typeof.(air_density.(ts))             == typeof.(e_int)


### PR DESCRIPTION
I noticed that this equation is being manually implemented, and assuming `ice` is zero in some places, so I'm adding a function to replace existing implementation.