### PR TITLE
Fix keyword arguments in SolverTypes

### DIFF
--- a/experiments/GCM/heldsuarez.jl
+++ b/experiments/GCM/heldsuarez.jl
@@ -107,7 +107,7 @@ function main()
     timeend = FT(60) # 400day
 
     driver_config = config_heldsuarez(FT, N, resolution)
-    ode_solver_type = CLIMA.ExplicitSolverType(LSRK144NiegemannDiehlBusch)
+    ode_solver_type = CLIMA.ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch)
     solver_config = CLIMA.setup_solver(t0, timeend, driver_config,
                                        ode_solver_type=ode_solver_type)
 

--- a/experiments/LES/dycoms.jl
+++ b/experiments/LES/dycoms.jl
@@ -137,7 +137,7 @@ function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
 
     config = CLIMA.LES_Configuration("DYCOMS", N, resolution, xmax, ymax, zmax,
                                      init_dycoms!,
-                                     solver_type=CLIMA.ExplicitSolverType(LSRK144NiegemannDiehlBusch),
+                                     solver_type=CLIMA.ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch),
                                      ref_state=ref_state,
                                      C_smag=C_smag,
                                      moisture=EquilMoist(5),

--- a/src/Driver/Configurations.jl
+++ b/src/Driver/Configurations.jl
@@ -20,13 +20,13 @@ using ..PlanetParameters
 abstract type AbstractSolverType end
 struct ExplicitSolverType <: AbstractSolverType
     solver_method::Function
-    ExplicitSolverType(solver_method=LSRK54CarpenterKennedy) = new(solver_method)
+    ExplicitSolverType(;solver_method=LSRK54CarpenterKennedy) = new(solver_method)
 end
 struct IMEXSolverType <: AbstractSolverType
     linear_model::Type
     linear_solver::Type
     solver_method::Function
-    function IMEXSolverType(linear_model=AtmosAcousticGravityLinearModel,
+    function IMEXSolverType(;linear_model=AtmosAcousticGravityLinearModel,
                             linear_solver=SingleColumnLU,
                             solver_method=ARK2GiraldoKellyConstantinescu)
         new(linear_model, linear_solver, solver_method)


### PR DESCRIPTION
Otherwise it's impossible to specify time-stepper in IMEX without setting `linear_model` and `linear_solver` first.