### PR TITLE
Add isentropic temperature profile

### DIFF
--- a/experiments/Atmos_LES/risingbubble.jl
+++ b/experiments/Atmos_LES/risingbubble.jl
@@ -74,9 +74,11 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
 
   # Set up the model
   C_smag = FT(0.23)
+  ref_state = HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0))
   model = AtmosModel{FT}(AtmosLESConfiguration;
                          turbulence=SmagorinskyLilly{FT}(C_smag),
                          source=(Gravity(),),
+                         ref_state=ref_state,
                          init_state=init_risingbubble!)
 
   # Problem configuration

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -1,6 +1,7 @@
 ### Reference state
 using DocStringExtensions
-export NoReferenceState, HydrostaticState, IsothermalProfile, LinearTemperatureProfile
+export NoReferenceState, HydrostaticState, IsothermalProfile, LinearTemperatureProfile,
+       DryAdiabaticProfile
 
 """
     ReferenceState
@@ -88,6 +89,29 @@ end
 function (profile::IsothermalProfile)(orientation::Orientation, aux::Vars)
   p = MSLP * exp(-gravitational_potential(orientation, aux)/(R_d*profile.T))
   return (profile.T, p)
+end
+
+"""
+    DryAdiabaticProfile{F} <: TemperatureProfile
+
+
+A temperature profile that has uniform potential temperature θ until it
+reaches the minimum specified temperature `T_min`
+
+# Fields
+
+$(DocStringExtensions.FIELDS)
+"""
+struct DryAdiabaticProfile{F} <: TemperatureProfile
+  "minimum temperature (K)"
+  T_min::F
+  "potential temperature (K)"
+  θ::F
+end
+
+function (profile::DryAdiabaticProfile)(orientation::Orientation, aux::Vars)
+  FT = eltype(aux)
+  LinearTemperatureProfile(profile.T_min, profile.θ, FT(grav / cp_d))(orientation, aux)
 end
 
 """

--- a/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
@@ -105,7 +105,7 @@ function run(mpicomm, ArrayType,
   # -------------- Define model ---------------------------------- #
   source = Gravity()
   model = AtmosModel{FT}(AtmosLESConfiguration;
-                         ref_state=NoReferenceState(),
+                         ref_state=HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0)),
                         turbulence=AnisoMinDiss{FT}(1),
                             source=source,
                  boundarycondition=NoFluxBC(),


### PR DESCRIPTION
This adds a constant potential temperature profile for visualization of perturbations in the rising thermal bubble and density current test cases. This is also probably a better state for linearization in the IMEX rising thermal bubble test.

@thomasgibson 