### PR TITLE
Simplify using `CLIMA.Atmos` in drivers

### DIFF
--- a/examples/Atmos/heldsuarez.jl
+++ b/examples/Atmos/heldsuarez.jl
@@ -11,13 +11,9 @@ using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
 using CLIMA.PlanetParameters: R_d, grav, MSLP, planet_radius, cp_d, cv_d, day
-using CLIMA.MoistThermodynamics: air_density, total_energy, soundspeed_air, internal_energy, air_temperature
-using CLIMA.Atmos: AtmosModel, SphericalOrientation, NoReferenceState,
-                   DryModel, NoPrecipitation, NoRadiation, NoSubsidence, NoFluxBC,
-                   ConstantViscosityWithDivergence,
-                   vars_state, vars_aux,
-                   Gravity, Coriolis,
-                   HydrostaticState, IsothermalProfile
+using CLIMA.MoistThermodynamics
+using CLIMA.Atmos
+using CLIMA.Atmos: vars_state, vars_aux
 using CLIMA.VariableTemplates: flattenednames
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test

--- a/examples/DGmethods_old/ex_003_acoustic_wave.jl
+++ b/examples/DGmethods_old/ex_003_acoustic_wave.jl
@@ -51,8 +51,7 @@ using CLIMA.GenericCallbacks
 # Though not required, here we are explicit about which values we read out the
 # `PlanetParameters` and `MoistThermodynamics`
 using CLIMA.PlanetParameters: planet_radius, grav, MSLP
-using CLIMA.MoistThermodynamics: air_temperature, air_pressure, internal_energy,
-                                 soundspeed_air, air_density, gas_constant_air
+using CLIMA.MoistThermodynamics
 
 # Specify whether to enforce hydrostatic balance at PDE level or not
 const PDE_level_hydrostatic_balance = true

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -1,16 +1,13 @@
 module Atmos
 
-export AtmosModel,
-       AtmosAcousticLinearModel, AtmosAcousticGravityLinearModel,
-       RemainderModel
+export AtmosModel
 
 using LinearAlgebra, StaticArrays
+using GPUifyLoops
 using ..VariableTemplates
 using ..MoistThermodynamics
 using ..PlanetParameters
-import ..MoistThermodynamics: internal_energy
 using ..SubgridScaleParameters
-using GPUifyLoops
 using ..MPIStateArrays: MPIStateArray
 
 import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -1,3 +1,6 @@
+export AtmosAcousticGravityLinearModel,
+       AtmosAcousticLinearModel
+
 """
     linearized_air_pressure(ρ, ρe_tot, ρe_pot, ρq_tot=0, ρq_liq=0, ρq_ice=0)
 

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -1,4 +1,5 @@
-export DryModel, EquilMoist
+import ..MoistThermodynamics: internal_energy
+export DryModel, EquilMoist, thermo_state
 
 #### Moisture component in atmosphere model
 abstract type MoistureModel end

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -1,6 +1,6 @@
 ### Reference state
 using DocStringExtensions
-export NoReferenceState, HydrostaticState, IsothermalProfile, LinearTemperatureProfile
+export ReferenceState, NoReferenceState, HydrostaticState, IsothermalProfile, LinearTemperatureProfile
 
 """
     ReferenceState

--- a/src/Atmos/Model/remainder.jl
+++ b/src/Atmos/Model/remainder.jl
@@ -1,3 +1,5 @@
+export RemainderModel
+
 """
     RemainderModel(main::BalanceLaw, subcomponents::Tuple)
 

--- a/src/Atmos/Model/turbulence.jl
+++ b/src/Atmos/Model/turbulence.jl
@@ -2,7 +2,7 @@
 using DocStringExtensions
 using CLIMA.PlanetParameters
 using CLIMA.SubgridScaleParameters
-export ConstantViscosityWithDivergence, SmagorinskyLilly, Vreman, AnisoMinDiss
+export ConstantViscosityWithDivergence, SmagorinskyLilly, Vreman, AnisoMinDiss, turbulence_tensors
 
 abstract type TurbulenceClosure end
 

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -13,7 +13,6 @@ using MPI
 using StaticArrays
 
 using ..Atmos
-using ..Atmos: thermo_state, turbulence_tensors
 using ..SubgridScaleParameters: inv_Pr_turb
 using ..DGmethods: num_state, vars_state, num_aux, vars_aux, vars_diffusive, num_diffusive
 using ..Mesh.Topologies

--- a/test/DGmethods/Euler/acousticwave-1d-imex.jl
+++ b/test/DGmethods/Euler/acousticwave-1d-imex.jl
@@ -12,13 +12,9 @@ using CLIMA.ColumnwiseLUSolver: ManyColumnLU
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.PlanetParameters: planet_radius, day
-using CLIMA.MoistThermodynamics: air_density, soundspeed_air, internal_energy
-using CLIMA.Atmos: AtmosModel, SphericalOrientation,
-                   DryModel, NoPrecipitation, NoRadiation, NoSubsidence, NoFluxBC,
-                   ConstantViscosityWithDivergence,
-                   vars_state, vars_aux,
-                   Gravity, HydrostaticState, IsothermalProfile,
-                   AtmosAcousticGravityLinearModel
+using CLIMA.MoistThermodynamics
+using CLIMA.Atmos: vars_state, vars_aux
+using CLIMA.Atmos
 using CLIMA.VariableTemplates: flattenednames
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test

--- a/test/DGmethods/Euler/isentropicvortex-imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex-imex.jl
@@ -11,14 +11,9 @@ using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
 using CLIMA.PlanetParameters: kappa_d
-using CLIMA.MoistThermodynamics: air_density, total_energy, internal_energy,
-                                 soundspeed_air
-using CLIMA.Atmos: AtmosModel,
-                   AtmosAcousticLinearModel, RemainderModel,
-                   NoOrientation,
-                   NoReferenceState, ReferenceState,
-                   DryModel, NoPrecipitation, NoRadiation, NoSubsidence, PeriodicBC,
-                   ConstantViscosityWithDivergence, vars_state
+using CLIMA.MoistThermodynamics
+using CLIMA.Atmos
+using CLIMA.Atmos: vars_state
 using CLIMA.VariableTemplates: @vars, Vars, flattenednames
 import CLIMA.Atmos: atmos_init_aux!, vars_aux
 

--- a/test/DGmethods/Euler/isentropicvortex-multirate.jl
+++ b/test/DGmethods/Euler/isentropicvortex-multirate.jl
@@ -14,14 +14,9 @@ using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
 using CLIMA.PlanetParameters: kappa_d
-using CLIMA.MoistThermodynamics: air_density, total_energy, internal_energy,
-                                 soundspeed_air
-using CLIMA.Atmos: AtmosModel,
-                   AtmosAcousticLinearModel, RemainderModel,
-                   NoOrientation,
-                   NoReferenceState, ReferenceState,
-                   DryModel, NoPrecipitation, NoRadiation, NoSubsidence, PeriodicBC,
-                   ConstantViscosityWithDivergence, vars_state
+using CLIMA.MoistThermodynamics
+using CLIMA.Atmos: vars_state
+using CLIMA.Atmos
 using CLIMA.VariableTemplates: @vars, Vars, flattenednames
 import CLIMA.Atmos: atmos_init_aux!, vars_aux
 

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -11,10 +11,9 @@ using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
 using CLIMA.PlanetParameters: kappa_d
-using CLIMA.MoistThermodynamics: air_density, total_energy, soundspeed_air
-using CLIMA.Atmos: AtmosModel, NoOrientation, NoReferenceState,
-                   DryModel, NoPrecipitation, NoRadiation, NoSubsidence, PeriodicBC,
-                   ConstantViscosityWithDivergence, vars_state
+using CLIMA.MoistThermodynamics
+using CLIMA.Atmos: vars_state
+using CLIMA.Atmos
 using CLIMA.VariableTemplates: flattenednames
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test


### PR DESCRIPTION
Changing `using CLIMA.Atmos: ...` in all of the drivers is a bit of a pain. This PR exports a few extra things from AtmosModel, and makes drivers just have `using CLIMA.Atmos`.