### PR TITLE
Change default linear solver in IMEXSolverType to ManyColumnLU

### DIFF
--- a/src/Driver/Configurations.jl
+++ b/src/Driver/Configurations.jl
@@ -27,7 +27,7 @@ struct IMEXSolverType <: AbstractSolverType
     linear_solver::Type
     solver_method::Function
     function IMEXSolverType(;linear_model=AtmosAcousticGravityLinearModel,
-                            linear_solver=SingleColumnLU,
+                            linear_solver=ManyColumnLU,
                             solver_method=ARK2GiraldoKellyConstantinescu)
         new(linear_model, linear_solver, solver_method)
     end
@@ -75,7 +75,7 @@ function LES_Configuration(name::String,
                            ymin           = 0,
                            zmin           = 0,
                            array_type     = CLIMA.array_type(),
-                           solver_type    = DefaultSolverType(),
+                           solver_type    = IMEXSolverType(linear_solver=SingleColumnLU),
                            orientation    = FlatOrientation(),
                            T_min          = FT(200),
                            T_surface      = FT(280),

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -248,7 +248,7 @@ function setup_solver(t0::FT, timeend::FT,
                       driver_config.numfluxdiff, driver_config.gradnumflux,
                       auxstate=dg.auxstate, direction=VerticalDirection())
 
-        solver = solver_type.solver_method(dg, vdg, SingleColumnLU(), Q; dt=dt, t0=t0)
+        solver = solver_type.solver_method(dg, vdg, solver_type.linear_solver(), Q; dt=dt, t0=t0)
     end
 
     @toc setup_solver


### PR DESCRIPTION
This PR changes the default linear solver in `IMEXSolverType` to `ManyColumnLU`. This is a better
default since `SingleColumnLU` won't work on the sphere. This also fixes a bug where the linear solver specified in `solver_type` was not used.
