### PR TITLE
Split RootSolvers CPU/GPU tests

### DIFF
--- a/test/Utilities/RootSolvers/runtests.jl
+++ b/test/Utilities/RootSolvers/runtests.jl
@@ -2,8 +2,6 @@ using Test
 using CLIMA
 using CLIMA.RootSolvers
 
-CLIMA.init()
-
 @testset "RootSolvers - compact solution correctness" begin
   f(x) = x^2 - 100^2
   f′(x) = 2x
@@ -65,43 +63,5 @@ end
     @test sol.err < 1e-3
     @test sol.iter_performed < 20
     @test sol.iter_performed+1 == length(sol.root_history) == length(sol.err_history)
-  end
-end
-
-if CLIMA.array_type() != Array
-  CLIMA.gpu_allowscalar(false)
-
-  @testset "RootSolvers CUDA - compact solution " begin
-    for FT in [Float32, Float64]
-      X0 = cu(rand(FT, 5,5))
-      X1 = cu(rand(FT, 5,5)) .+ 1000
-      f(x) = x^2 - 100^2
-
-      sol = RootSolvers.find_zero.(f, X0, X1, SecantMethod(), CompactSolution())
-      converged = map(x->x.converged, sol)
-      X_roots = map(x->x.root, sol)
-      @test all(converged)
-      @test eltype(X_roots) == eltype(X0)
-      @test all(X_roots .≈ 100)
-    end
-  end
-
-  @testset "RootSolvers CUDA - verbose solution " begin
-    for FT in [Float32, Float64]
-      X0 = cu(rand(FT, 5,5))
-      X1 = cu(rand(FT, 5,5)) .+ 1000
-      f(x) = x^2 - 100^2
-
-      sol = RootSolvers.find_zero.(f, X0, X1, SecantMethod(), VerboseSolution())
-      converged = map(x->x.converged, sol)
-      X_roots = map(x->x.root, sol)
-      err = map(x->x.err, sol)
-      iter_performed = map(x->x.iter_performed, sol)
-      @test all(converged)
-      @test eltype(X_roots) == eltype(X0)
-      @test all(X_roots .≈ 100)
-      @test all(err .< 1e-2)
-      @test all(iter_performed .< 20)
-    end
   end
 end

--- a/test/Utilities/RootSolvers/runtests_gpu.jl
+++ b/test/Utilities/RootSolvers/runtests_gpu.jl
@@ -1,0 +1,43 @@
+using Test
+using CLIMA
+using CLIMA.RootSolvers
+
+CLIMA.init()
+
+if CLIMA.array_type() != Array
+  CLIMA.gpu_allowscalar(false)
+
+  @testset "RootSolvers CUDA - compact solution " begin
+    for FT in [Float32, Float64]
+      X0 = cu(rand(FT, 5,5))
+      X1 = cu(rand(FT, 5,5)) .+ 1000
+      f(x) = x^2 - 100^2
+
+      sol = RootSolvers.find_zero.(f, X0, X1, SecantMethod(), CompactSolution())
+      converged = map(x->x.converged, sol)
+      X_roots = map(x->x.root, sol)
+      @test all(converged)
+      @test eltype(X_roots) == eltype(X0)
+      @test all(X_roots .≈ 100)
+    end
+  end
+
+  @testset "RootSolvers CUDA - verbose solution " begin
+    for FT in [Float32, Float64]
+      X0 = cu(rand(FT, 5,5))
+      X1 = cu(rand(FT, 5,5)) .+ 1000
+      f(x) = x^2 - 100^2
+
+      sol = RootSolvers.find_zero.(f, X0, X1, SecantMethod(), VerboseSolution())
+      converged = map(x->x.converged, sol)
+      X_roots = map(x->x.root, sol)
+      err = map(x->x.err, sol)
+      iter_performed = map(x->x.iter_performed, sol)
+      @test all(converged)
+      @test eltype(X_roots) == eltype(X0)
+      @test all(X_roots .≈ 100)
+      @test all(err .< 1e-2)
+      @test all(iter_performed .< 20)
+    end
+  end
+end


### PR DESCRIPTION
The RootSolvers runtests include CPU and GPU tests, but they should be split. I'm not adding this to the GPU test just yet (it wasn't ever running anyway), but I don't want to discard the code since I've run it locally in the past.

Closes #698 