### PR TITLE
Add balance law to init funcs

### DIFF
--- a/examples/Atmos/dry_rayleigh_benard.jl
+++ b/examples/Atmos/dry_rayleigh_benard.jl
@@ -113,7 +113,7 @@ const T_bot              = 299
 const T_lapse            = grav/cp_d
 const T_top              = T_bot - T_lapse*zmax
 
-function init_problem!(state, aux, (x,y,z), t)
+function init_problem!(bl, state, aux, (x,y,z), t)
   FT            = eltype(state)
   R_gas::FT     = R_d
   c_p::FT       = cp_d

--- a/experiments/Atmos_GCM/heldsuarez.jl
+++ b/experiments/Atmos_GCM/heldsuarez.jl
@@ -16,13 +16,15 @@ const p_ground = MSLP
 const T_initial = 255
 const domain_height = 30e3
 
-function init_heldsuarez!(state, aux, coords, t)
+function init_heldsuarez!(bl, state, aux, coords, t)
     global p_ground, T_initial
 
     FT = eltype(state)
 
+    # TODO: change to altitude function
     r = norm(coords, 2)
     h = r - FT(planet_radius)
+    # h = altitude(bl.orientation, aux)
 
     scale_height = R_d * FT(T_initial) / grav
     p            = FT(p_ground) * exp(-h / scale_height)
@@ -44,7 +46,6 @@ function config_heldsuarez(FT, N, resolution)
                            moisture   = DryModel(),
                            source     = (Gravity(), Coriolis(), held_suarez_forcing!),
                            init_state = init_heldsuarez!)
-    
     config = CLIMA.Atmos_GCM_Configuration("HeldSuarez", N, resolution,
                                            FT(domain_height),
                                            init_heldsuarez!;

--- a/experiments/Atmos_LES/dycoms.jl
+++ b/experiments/Atmos_LES/dycoms.jl
@@ -210,7 +210,7 @@ URL = {https://doi.org/10.1175/MWR2930.1},
 eprint = {https://doi.org/10.1175/MWR2930.1}
 }
 """
-function init_dycoms!(state, aux, (x,y,z), t)
+function init_dycoms!(bl, state, aux, (x,y,z), t)
     FT = eltype(state)
 
     z = FT(z)

--- a/experiments/Atmos_LES/risingbubble.jl
+++ b/experiments/Atmos_LES/risingbubble.jl
@@ -26,7 +26,7 @@ using CLIMA.VariableTemplates
 # 8) Default settings can be found in `src/Driver/Configurations.jl`
 # ------------------------ Description ------------------------- #
 
-function init_risingbubble!(state, aux, (x,y,z), t)
+function init_risingbubble!(bl, state, aux, (x,y,z), t)
   FT            = eltype(state)
   R_gas::FT     = R_d
   c_p::FT       = cp_d

--- a/experiments/Atmos_LES/surfacebubble.jl
+++ b/experiments/Atmos_LES/surfacebubble.jl
@@ -16,26 +16,26 @@ using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
 
 import CLIMA.DGmethods: boundary_state!
-import CLIMA.Atmos: atmos_boundary_state!, atmos_boundary_flux_diffusive!, flux_diffusive! 
+import CLIMA.Atmos: atmos_boundary_state!, atmos_boundary_flux_diffusive!, flux_diffusive!
 import CLIMA.DGmethods.NumericalFluxes: boundary_flux_diffusive!
 
 # -------------------- Surface Driven Bubble ----------------- #
-# Rising thermals driven by a prescribed surface heat flux. 
-# 1) Boundary Conditions: 
+# Rising thermals driven by a prescribed surface heat flux.
+# 1) Boundary Conditions:
 #       Laterally periodic with no flow penetration through top
-#       and bottom wall boundaries. 
+#       and bottom wall boundaries.
 #       Momentum: No flow penetration [NoFluxBC()]
 #       Energy:   Spatially varying non-zero heat flux up to time t₁
 # 2) Domain: 1250m × 1250m × 1000m
 # Configuration defaults are in `src/Driver/Configurations.jl`
-  
+
 """
   SurfaceDrivenBubbleBC <: BoundaryCondition
 Y ≡ state vars
 Σ ≡ diffusive vars
 A ≡ auxiliary vars
 X⁺ and X⁻ refer to exterior, interior faces
-X₁ refers to the first interior node 
+X₁ refers to the first interior node
 
 # Fields
 $(DocStringExtensions.FIELDS)
@@ -48,12 +48,12 @@ struct SurfaceDrivenBubbleBC{FT} <: BoundaryCondition
   "Plume wavelength scaling"
   x₀::FT
 end
-function atmos_boundary_state!(nf::Union{NumericalFluxNonDiffusive,NumericalFluxGradient}, 
-                               bc::SurfaceDrivenBubbleBC, 
+function atmos_boundary_state!(nf::Union{NumericalFluxNonDiffusive,NumericalFluxGradient},
+                               bc::SurfaceDrivenBubbleBC,
                                m::AtmosModel,
-                               Y⁺::Vars, A⁺::Vars, 
-                               n⁻, 
-                               Y⁻::Vars, A⁻::Vars, 
+                               Y⁺::Vars, A⁺::Vars,
+                               n⁻,
+                               Y⁻::Vars, A⁻::Vars,
                                bctype, t,_...)
   # Use default NoFluxBC()
   atmos_boundary_state!(nf, NoFluxBC(), m,
@@ -61,35 +61,35 @@ function atmos_boundary_state!(nf::Union{NumericalFluxNonDiffusive,NumericalFlux
                         Y⁻, A⁻,
                         bctype, t)
 end
-function atmos_boundary_flux_diffusive!(nf::CentralNumericalFluxDiffusive, 
+function atmos_boundary_flux_diffusive!(nf::CentralNumericalFluxDiffusive,
                                         bc::SurfaceDrivenBubbleBC,
-                                        m::AtmosModel, 
+                                        m::AtmosModel,
                                         F,
-                                        Y⁺::Vars, Σ⁺::Vars, A⁺::Vars, 
-                                        n⁻, 
-                                        Y⁻::Vars, Σ⁻::Vars, A⁻::Vars, 
-                                        bctype, t, Y₁⁻, Σ₁⁻, A₁⁻) 
+                                        Y⁺::Vars, Σ⁺::Vars, A⁺::Vars,
+                                        n⁻,
+                                        Y⁻::Vars, Σ⁻::Vars, A⁻::Vars,
+                                        bctype, t, Y₁⁻, Σ₁⁻, A₁⁻)
   # Working precision
   FT = eltype(Y⁻)
   # Assign vertical unit vector and coordinates
   k̂  = vertical_unit_vector(m.orientation, A⁻)
   x = A⁻.coord[1]
   y = A⁻.coord[2]
-  # Unpack fields 
+  # Unpack fields
   t₁    = bc.t₁
   x₀    = bc.x₀
   F₀ =  t < t₁ ? bc.F₀ : -zero(FT)
   # Apply boundary condition per face (1 == bottom wall)
-  if bctype != 1 
+  if bctype != 1
     atmos_boundary_flux_diffusive!(nf, NoFluxBC(), m, F,
-                                   Y⁺, Σ⁺, A⁺, 
+                                   Y⁺, Σ⁺, A⁺,
                                    n⁻,
                                    Y⁻, Σ⁻, A⁻,
-                                   bctype, t, 
+                                   bctype, t,
                                    Y₁⁻, Σ₁⁻, A₁⁻)
-  else 
+  else
     atmos_boundary_state!(nf, NoFluxBC(), m,
-                          Y⁺, Σ⁺, A⁺, 
+                          Y⁺, Σ⁺, A⁺,
                           n⁻,
                           Y⁻, Σ⁻, A⁻,
                           bctype, t)
@@ -103,7 +103,7 @@ end
 """
   Surface Driven Thermal Bubble
 """
-function init_surfacebubble!(state, aux, (x,y,z), t)
+function init_surfacebubble!(bl, state, aux, (x,y,z), t)
   FT            = eltype(state)
   R_gas::FT     = R_d
   c_p::FT       = cp_d
@@ -139,24 +139,24 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
   # Boundary conditions
   # Heat Flux Peak Magnitude
   F₀ = FT(100)
-  # Time [s] at which `heater` turns off 
+  # Time [s] at which `heater` turns off
   t₁ = FT(500)
   # Plume wavelength scaling
   x₀ = xmax
   bc = SurfaceDrivenBubbleBC{FT}(F₀, t₁, x₀)
-  
+
   C_smag = FT(0.23)
-  
+
   imex_solver = CLIMA.DefaultSolverType()
   explicit_solver = CLIMA.ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch)
-  
+
   model = AtmosModel{FT}(AtmosLESConfiguration;
                          turbulence=SmagorinskyLilly{FT}(C_smag),
                          source=(Gravity(),),
                          boundarycondition=bc,
                          moisture=EquilMoist(),
                          init_state=init_surfacebubble!)
-  config = CLIMA.Atmos_LES_Configuration("SurfaceDrivenBubble", 
+  config = CLIMA.Atmos_LES_Configuration("SurfaceDrivenBubble",
                                    N, resolution, xmax, ymax, zmax,
                                    init_surfacebubble!,
                                    solver_type=explicit_solver,
@@ -178,7 +178,7 @@ function main()
   zmax = 2000
   t0 = FT(0)
   timeend = FT(2000)
-  
+
   CFL_max = FT(0.4)
 
   driver_config = config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -328,7 +328,7 @@ boundary_state!(nf, m::AtmosModel, x...) =
   atmos_boundary_state!(nf, m.boundarycondition, m, x...)
 
 function init_state!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)
-  m.init_state(state, aux, coords, t, args...)
+  m.init_state(m, state, aux, coords, t, args...)
 end
 
 boundary_flux_diffusive!(nf::NumericalFluxDiffusive,

--- a/test/DGmethods/Euler/acousticwave-1d-imex.jl
+++ b/test/DGmethods/Euler/acousticwave-1d-imex.jl
@@ -181,7 +181,7 @@ Base.@kwdef struct AcousticWaveSetup{FT}
   nv::Int = 1
 end
 
-function (setup::AcousticWaveSetup)(state, aux, coords, t)
+function (setup::AcousticWaveSetup)(bl, state, aux, coords, t)
   # callable to set initial conditions
   FT = eltype(state)
 

--- a/test/DGmethods/Euler/isentropicvortex-imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex-imex.jl
@@ -110,11 +110,6 @@ function run(mpicomm, ArrayType, polynomialorder, numelems, setup,
                                           DeviceArray = ArrayType,
                                           polynomialorder = polynomialorder)
 
-  initialcondition! = function(args...)
-    isentropicvortex_initialcondition!(setup, args...)
-  end
-
-
   model = AtmosModel{FT}(AtmosLESConfiguration;
                          orientation=NoOrientation(),
                            ref_state=IsentropicVortexReferenceState{FT}(setup),
@@ -122,7 +117,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems, setup,
                             moisture=DryModel(),
                               source=nothing,
                    boundarycondition=PeriodicBC(),
-                          init_state=initialcondition!)
+                          init_state=isentropicvortex_initialcondition!)
 
   linear_model = AtmosAcousticLinearModel(model)
   nonlinear_model = RemainderModel(model, (linear_model,))
@@ -249,7 +244,8 @@ function atmos_init_aux!(m::IsentropicVortexReferenceState, atmos::AtmosModel, a
   aux.ref_state.ρe = ρ∞ * internal_energy(T∞)
 end
 
-function isentropicvortex_initialcondition!(setup, state, aux, coords, t)
+function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
+  setup = bl.ref_state.setup
   FT = eltype(state)
   x = MVector(coords)
 

--- a/test/DGmethods/Euler/isentropicvortex-multirate.jl
+++ b/test/DGmethods/Euler/isentropicvortex-multirate.jl
@@ -107,10 +107,6 @@ function run(mpicomm, ArrayType, polynomialorder, numelems, setup,
                                           DeviceArray = ArrayType,
                                           polynomialorder = polynomialorder)
 
-  initialcondition! = function(args...)
-    isentropicvortex_initialcondition!(setup, args...)
-  end
-
   model = AtmosModel{FT}(AtmosLESConfiguration;
                          orientation=NoOrientation(),
                            ref_state=IsentropicVortexReferenceState{FT}(setup),
@@ -118,7 +114,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems, setup,
                             moisture=DryModel(),
                               source=nothing,
                    boundarycondition=PeriodicBC(),
-                          init_state=initialcondition!)
+                          init_state=isentropicvortex_initialcondition!)
   # The linear model has the fast time scales
   fast_model = AtmosAcousticLinearModel(model)
   # The nonlinear model has the slow time scales
@@ -145,7 +141,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems, setup,
   # arbitrary and not needed for stabilty, just for testing
   fast_dt = slow_dt / 3
 
-  Q = init_ode_state(dg, FT(0))
+  Q = init_ode_state(dg, FT(0), setup)
 
   slow_ode_solver = LSRK144NiegemannDiehlBusch(slow_dg, Q; dt = slow_dt)
 
@@ -202,7 +198,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems, setup,
     outputtime = timeend
     cbvtk = EveryXSimulationSteps(floor(outputtime / slow_dt)) do
       vtkstep += 1
-      Qe = init_ode_state(dg, gettime(ode_solver))
+      Qe = init_ode_state(dg, gettime(ode_solver), setup)
       do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model)
     end
     callbacks = (callbacks..., cbvtk)
@@ -211,7 +207,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems, setup,
   solve!(Q, ode_solver; timeend=timeend, callbacks=callbacks)
 
   # final statistics
-  Qe = init_ode_state(dg, timeend)
+  Qe = init_ode_state(dg, timeend, setup)
   engf = norm(Q)
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)
@@ -252,7 +248,7 @@ function atmos_init_aux!(m::IsentropicVortexReferenceState, atmos::AtmosModel, a
   aux.ref_state.ρe = ρ∞ * internal_energy(T∞)
 end
 
-function isentropicvortex_initialcondition!(setup, state, aux, coords, t)
+function isentropicvortex_initialcondition!(bl, state, aux, coords, t, setup)
   FT = eltype(state)
   x = MVector(coords)
 

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -139,9 +139,6 @@ function run(mpicomm, ArrayType, polynomialorder, numelems,
                                           DeviceArray = ArrayType,
                                           polynomialorder = polynomialorder)
 
-  initialcondition! = function(args...)
-    isentropicvortex_initialcondition!(setup, args...)
-  end
   model = AtmosModel{FT}(AtmosLESConfiguration;
                          orientation=NoOrientation(),
                            ref_state=NoReferenceState(),
@@ -149,7 +146,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems,
                             moisture=DryModel(),
                               source=nothing,
                    boundarycondition=PeriodicBC(),
-                          init_state=initialcondition!)
+                          init_state=isentropicvortex_initialcondition!)
 
   dg = DGModel(model, grid, NumericalFlux(),
                CentralNumericalFluxDiffusive(), CentralNumericalFluxGradient())
@@ -162,7 +159,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems,
   nsteps = ceil(Int, timeend / dt)
   dt = timeend / nsteps
 
-  Q = init_ode_state(dg, FT(0))
+  Q = init_ode_state(dg, FT(0), setup)
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 
   eng0 = norm(Q)
@@ -204,7 +201,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems,
     outputtime = timeend
     cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
       vtkstep += 1
-      Qe = init_ode_state(dg, gettime(lsrk))
+      Qe = init_ode_state(dg, gettime(lsrk), setup)
       do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model)
     end
     callbacks = (callbacks..., cbvtk)
@@ -213,7 +210,7 @@ function run(mpicomm, ArrayType, polynomialorder, numelems,
   solve!(Q, lsrk; timeend=timeend, callbacks=callbacks)
 
   # final statistics
-  Qe = init_ode_state(dg, timeend)
+  Qe = init_ode_state(dg, timeend, setup)
   engf = norm(Q)
   engfe = norm(Qe)
   errf = euclidean_distance(Q, Qe)
@@ -238,7 +235,8 @@ Base.@kwdef struct IsentropicVortexSetup{FT}
   domain_halflength::FT = 1 // 20
 end
 
-function isentropicvortex_initialcondition!(setup, state, aux, coords, t)
+function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
+  setup = first(args)
   FT = eltype(state)
   x = MVector(coords)
 

--- a/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
@@ -53,7 +53,7 @@ eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/fld.1650170103},
 year = {1993}
 }
 """
-function Initialise_Density_Current!(state::Vars, aux::Vars, (x1,x2,x3), t)
+function Initialise_Density_Current!(bl, state::Vars, aux::Vars, (x1,x2,x3), t)
   FT                = eltype(state)
   R_gas::FT         = R_d
   c_p::FT           = cp_d

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -54,7 +54,7 @@ function soundspeed(m::MMSDryModel, orientation::Orientation, state::Vars, aux::
   sqrt(ρinv * γ * p)
 end
 
-function mms2_init_state!(state::Vars, aux::Vars, (x1,x2,x3), t)
+function mms2_init_state!(bl, state::Vars, aux::Vars, (x1,x2,x3), t)
   state.ρ = ρ_g(t, x1, x2, x3, Val(2))
   state.ρu = SVector(U_g(t, x1, x2, x3, Val(2)),
                      V_g(t, x1, x2, x3, Val(2)),
@@ -71,7 +71,7 @@ function mms2_source!(source::Vars, state::Vars, aux::Vars, t::Real)
   source.ρe = SE_g(t, x1, x2, x3, Val(2))
 end
 
-function mms3_init_state!(state::Vars, aux::Vars, (x1,x2,x3), t)
+function mms3_init_state!(bl, state::Vars, aux::Vars, (x1,x2,x3), t)
   state.ρ = ρ_g(t, x1, x2, x3, Val(3))
   state.ρu = SVector(U_g(t, x1, x2, x3, Val(3)),
                      V_g(t, x1, x2, x3, Val(3)),

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -26,7 +26,7 @@ using CLIMA.Atmos
 using CLIMA.Atmos: internal_energy, thermo_state
 import CLIMA.Atmos: MoistureModel, temperature, pressure, soundspeed
 
-init_state!(state, aux, coords, t) = nothing
+init_state!(bl, state, aux, coords, t) = nothing
 
 # initial condition
 using CLIMA.Atmos: vars_aux

--- a/test/DGmethods/courant.jl
+++ b/test/DGmethods/courant.jl
@@ -31,7 +31,7 @@ using CLIMA.MoistThermodynamics: air_density, total_energy, internal_energy,
 using CLIMA.VariableTemplates: Vars
 using StaticArrays
 
-function initialcondition!(state, aux, coords, t)
+function initialcondition!(bl, state, aux, coords, t)
     FT = eltype(state)
 
     p∞::FT = 10 ^ 5

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -16,7 +16,7 @@ using CLIMA.ODESolvers
 using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
 
-function init_sin_test!(state, aux, (x,y,z), t)
+function init_sin_test!(bl, state, aux, (x,y,z), t)
     FT = eltype(state)
 
     z = FT(z)

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -8,7 +8,7 @@ using CLIMA.MoistThermodynamics
 using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
 
-function init_test!(state, aux, (x,y,z), t)
+function init_test!(bl, state, aux, (x,y,z), t)
     FT = eltype(state)
 
     z = FT(z)

--- a/test/Mesh/interpolation.jl
+++ b/test/Mesh/interpolation.jl
@@ -34,7 +34,7 @@ const seed = MersenneTwister(0)
 
 const ArrayType = CLIMA.array_type()
 #-------------------------------------
-function Initialize_Brick_Interpolation_Test!(state::Vars, aux::Vars, (x,y,z), t)
+function Initialize_Brick_Interpolation_Test!(bl, state::Vars, aux::Vars, (x,y,z), t)
     FT         = eltype(state)
     # Dummy variables for initial condition function
     state.ρ               = FT(0)
@@ -53,7 +53,7 @@ struct TestSphereSetup{DT}
     end
 end
 #----------------------------------------------------------------------------
-function (setup::TestSphereSetup)(state, aux, coords, t)
+function (setup::TestSphereSetup)(bl, state, aux, coords, t)
     # callable to set initial conditions
     FT = eltype(state)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@ using Test, Pkg
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 ENV["JULIA_LOG_LEVEL"] = "WARN"
 
-for submodule in ["Utilities/TicToc",
+for submodule in [
+                  "Utilities/TicToc",
                   "Utilities/VariableTemplates",
                   "Utilities/ParametersType",
                   "Utilities/RootSolvers",


### PR DESCRIPTION
Adds balance law to initial condition functions, this will allow us to use `orientation` methods, and not re-implement them in all of the drivers.