### PR TITLE
Small Held-Suarez fix

### DIFF
--- a/src/Driver/Configurations.jl
+++ b/src/Driver/Configurations.jl
@@ -91,11 +91,12 @@ function Atmos_LES_Configuration(
     ) where {FT<:AbstractFloat}
 
     @info @sprintf("""Establishing Atmos LES configuration for %s
+                   precision        = %s
                    polynomial order = %d
                    grid             = %dx%dx%d
                    resolution       = %dx%dx%d
                    MPI ranks        = %d""",
-                   name, N,
+                   name, FT, N,
                    xmax, ymax, zmax,
                    Δx, Δy, Δz,
                    MPI.Comm_size(mpicomm))
@@ -135,12 +136,13 @@ function Atmos_GCM_Configuration(
         gradnumflux        = CentralNumericalFluxGradient()
     ) where {FT<:AbstractFloat}
     @info @sprintf("""Establishing Atmos GCM configuration for %s
+                   precision        = %s
                    polynomial order = %d
                    #horiz elems     = %d
                    #vert_elems      = %d
                    domain height    = %.2e
                    MPI ranks        = %d""",
-                   name, N,
+                   name, FT, N,
                    nelem_horz, nelem_vert, domain_height,
                    MPI.Comm_size(mpicomm))
 


### PR DESCRIPTION
Apply `FT` when using the global constants. Fixes #713.