### PR TITLE
Test horizontal/vertical splitting and remove skew symmetric

### DIFF
--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -16,6 +16,7 @@ cpu_gpu = [
   { file = "test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods/compressible_Navier_Stokes/density_current-model.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/DGmethods/advection_diffusion/direction_splitting_advection_diffusion.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/RTB_IMEX.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/isentropic_vortex_standalone.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods_old/Euler/isentropic_vortex_standalone_IMEX.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -50,34 +50,20 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
 
   s_F = @shmem FT (3, Nq, Nq, Nqk, nstate)
   s_ω = @shmem FT (Nq, )
-  s_half_D = @shmem FT (Nq, Nq)
+  s_D = @shmem FT (Nq, Nq)
   l_rhs = @scratch FT (nstate, Nq, Nq, Nqk) 3
 
   source! !== nothing && (l_S = MArray{Tuple{nstate}, FT}(undef))
-  l_Q = @scratch FT (nstate, Nq, Nq, Nqk) 3
+  l_Q = MArray{Tuple{nstate}, FT}(undef)
   l_Qvisc = MArray{Tuple{nviscstate}, FT}(undef)
-  l_aux = @scratch FT (nauxstate, Nq, Nq, Nqk) 3
+  l_aux = MArray{Tuple{nauxstate}, FT}(undef)
   l_F = MArray{Tuple{3, nstate}, FT}(undef)
-  l_M = @scratch FT (Nq, Nq, Nqk) 3
-  l_ξ1x1 = @scratch FT (Nq, Nq, Nqk) 3
-  l_ξ1x2 = @scratch FT (Nq, Nq, Nqk) 3
-  l_ξ1x3 = @scratch FT (Nq, Nq, Nqk) 3
-  if dim == 3 || (dim == 2 && direction == EveryDirection)
-    l_ξ2x1 = @scratch FT (Nq, Nq, Nqk) 3
-    l_ξ2x2 = @scratch FT (Nq, Nq, Nqk) 3
-    l_ξ2x3 = @scratch FT (Nq, Nq, Nqk) 3
-  end
-  if dim == 3 && direction == EveryDirection
-    l_ξ3x1 = @scratch FT (Nq, Nq, Nqk) 3
-    l_ξ3x2 = @scratch FT (Nq, Nq, Nqk) 3
-    l_ξ3x3 = @scratch FT (Nq, Nq, Nqk) 3
-  end
 
   @inbounds @loop for k in (1; threadIdx().z)
     @loop for j in (1:Nq; threadIdx().y)
       s_ω[j] = ω[j]
       @loop for i in (1:Nq; threadIdx().x)
-        s_half_D[i, j] = D[i, j] / 2
+        s_D[i, j] = D[i, j]
       end
     end
   end
@@ -87,19 +73,19 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
       @loop for j in (1:Nq; threadIdx().y)
         @loop for i in (1:Nq; threadIdx().x)
           ijk = i + Nq * ((j-1) + Nq * (k-1))
-          l_M[i, j, k] = vgeo[ijk, _M, e]
-          l_ξ1x1[i, j, k] = vgeo[ijk, _ξ1x1, e]
-          l_ξ1x2[i, j, k] = vgeo[ijk, _ξ1x2, e]
-          l_ξ1x3[i, j, k] = vgeo[ijk, _ξ1x3, e]
+          M = vgeo[ijk, _M, e]
+          ξ1x1 = vgeo[ijk, _ξ1x1, e]
+          ξ1x2 = vgeo[ijk, _ξ1x2, e]
+          ξ1x3 = vgeo[ijk, _ξ1x3, e]
           if dim == 3 || (dim == 2 && direction == EveryDirection)
-            l_ξ2x1[i, j, k] = vgeo[ijk, _ξ2x1, e]
-            l_ξ2x2[i, j, k] = vgeo[ijk, _ξ2x2, e]
-            l_ξ2x3[i, j, k] = vgeo[ijk, _ξ2x3, e]
+            ξ2x1 = vgeo[ijk, _ξ2x1, e]
+            ξ2x2 = vgeo[ijk, _ξ2x2, e]
+            ξ2x3 = vgeo[ijk, _ξ2x3, e]
           end
           if dim == 3 && direction == EveryDirection
-            l_ξ3x1[i, j, k] = vgeo[ijk, _ξ3x1, e]
-            l_ξ3x2[i, j, k] = vgeo[ijk, _ξ3x2, e]
-            l_ξ3x3[i, j, k] = vgeo[ijk, _ξ3x3, e]
+            ξ3x1 = vgeo[ijk, _ξ3x1, e]
+            ξ3x2 = vgeo[ijk, _ξ3x2, e]
+            ξ3x3 = vgeo[ijk, _ξ3x3, e]
           end
 
           @unroll for s = 1:nstate
@@ -107,17 +93,21 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
           end
 
           @unroll for s = 1:nstate
-            l_Q[s, i, j, k] = Q[ijk, s, e]
+            l_Q[s] = Q[ijk, s, e]
           end
 
           @unroll for s = 1:nauxstate
-            l_aux[s, i, j, k] = auxstate[ijk, s, e]
+            l_aux[s] = auxstate[ijk, s, e]
+          end
+
+          @unroll for s = 1:nviscstate
+            l_Qvisc[s] = Qvisc[ijk, s, e]
           end
 
           fill!(l_F, -zero(eltype(l_F)))
           flux_nondiffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                             Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                             Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                             Vars{vars_state(bl,FT)}(l_Q),
+                             Vars{vars_aux(bl,FT)}(l_aux), t)
 
           @unroll for s = 1:nstate
             s_F[1,i,j,k,s] = l_F[1,s]
@@ -125,97 +115,39 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
             s_F[3,i,j,k,s] = l_F[3,s]
           end
 
-          # if source! !== nothing
-          fill!(l_S, -zero(eltype(l_S)))
-          source!(bl, Vars{vars_state(bl,FT)}(l_S),
-                  Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
-
-          @unroll for s = 1:nstate
-            l_rhs[s, i, j, k] += l_S[s]
-          end
-        end
-      end
-    end
-    @synchronize
-
-    # Weak "outside metrics" derivative
-    @loop for k in (1:Nqk; threadIdx().z)
-      @loop for j in (1:Nq; threadIdx().y)
-        @loop for i in (1:Nq; threadIdx().x)
-          @unroll for n = 1:Nq
-            @unroll for s = 1:nstate
-              Dni = s_half_D[n, i] * s_ω[n] / s_ω[i]
-              if dim == 3 || (dim == 2 && direction == EveryDirection)
-                Dnj = s_half_D[n, j] * s_ω[n] / s_ω[j]
-              end
-              if dim == 3 && direction == EveryDirection
-                Dnk = s_half_D[n, k] * s_ω[n] / s_ω[k]
-              end
-
-              # ξ1-grid lines
-              l_rhs[s, i, j, k] += l_ξ1x1[i, j, k] * Dni * s_F[1, n, j, k, s]
-              l_rhs[s, i, j, k] += l_ξ1x2[i, j, k] * Dni * s_F[2, n, j, k, s]
-              l_rhs[s, i, j, k] += l_ξ1x3[i, j, k] * Dni * s_F[3, n, j, k, s]
-
-              # ξ2-grid lines
-              if dim == 3 || (dim == 2 && direction == EveryDirection)
-                l_rhs[s, i, j, k] += l_ξ2x1[i, j, k] * Dnj * s_F[1, i, n, k, s]
-                l_rhs[s, i, j, k] += l_ξ2x2[i, j, k] * Dnj * s_F[2, i, n, k, s]
-                l_rhs[s, i, j, k] += l_ξ2x3[i, j, k] * Dnj * s_F[3, i, n, k, s]
-              end
-
-              # ξ3-grid lines
-              if dim == 3 && direction == EveryDirection
-                l_rhs[s, i, j, k] += l_ξ3x1[i, j, k] * Dnk * s_F[1, i, j, n, s]
-                l_rhs[s, i, j, k] += l_ξ3x2[i, j, k] * Dnk * s_F[2, i, j, n, s]
-                l_rhs[s, i, j, k] += l_ξ3x3[i, j, k] * Dnk * s_F[3, i, j, n, s]
-              end
-            end
-          end
-        end
-      end
-    end
-    @synchronize
-
-    # Add in the diffusive flux (multiply by 2 since derivative is halfed)
-    # This allows symmetric treament of the 2nd order derivative terms
-    # as well as build "inside metrics" flux
-    @loop for k in (1:Nqk; threadIdx().z)
-      @loop for j in (1:Nq; threadIdx().y)
-        @loop for i in (1:Nq; threadIdx().x)
-          ijk = i + Nq * ((j-1) + Nq * (k-1))
-
-          @unroll for s = 1:nviscstate
-            l_Qvisc[s] = Qvisc[ijk, s, e]
-          end
-
           fill!(l_F, -zero(eltype(l_F)))
           flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                          Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
+                          Vars{vars_state(bl,FT)}(l_Q),
                           Vars{vars_diffusive(bl,FT)}(l_Qvisc),
-                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                          Vars{vars_aux(bl,FT)}(l_aux), t)
 
+          @unroll for s = 1:nstate
+            s_F[1,i,j,k,s] += l_F[1,s]
+            s_F[2,i,j,k,s] += l_F[2,s]
+            s_F[3,i,j,k,s] += l_F[3,s]
+          end
+
+          # Build "inside metrics" flux
           @unroll for s = 1:nstate
             F1, F2, F3 = s_F[1,i,j,k,s], s_F[2,i,j,k,s], s_F[3,i,j,k,s]
 
-            F1 += 2l_F[1,s]
-            F2 += 2l_F[2,s]
-            F3 += 2l_F[3,s]
-
-            s_F[1,i,j,k,s] = l_M[i, j, k] * (l_ξ1x1[i, j, k] * F1 +
-                                              l_ξ1x2[i, j, k] * F2 +
-                                              l_ξ1x3[i, j, k] * F3)
+            s_F[1,i,j,k,s] = M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
             if dim == 3 || (dim == 2 && direction == EveryDirection)
-              s_F[2,i,j,k,s] = l_M[i, j, k] * (l_ξ2x1[i, j, k] * F1 +
-                                               l_ξ2x2[i, j, k] * F2 +
-                                               l_ξ2x3[i, j, k] * F3)
+              s_F[2,i,j,k,s] = M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
             end
             if dim == 3 && direction == EveryDirection
-              s_F[3,i,j,k,s] = l_M[i, j, k] * (l_ξ3x1[i, j, k] * F1 +
-                                               l_ξ3x2[i, j, k] * F2 +
-                                               l_ξ3x3[i, j, k] * F3)
+              s_F[3,i,j,k,s] = M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
             end
+          end
+
+          # if source! !== nothing
+          fill!(l_S, -zero(eltype(l_S)))
+          source!(bl, Vars{vars_state(bl,FT)}(l_S),
+                  Vars{vars_state(bl,FT)}(l_Q),
+                  Vars{vars_aux(bl,FT)}(l_aux), t)
+
+          @unroll for s = 1:nstate
+            l_rhs[s, i, j, k] += l_S[s]
           end
         end
       end
@@ -231,16 +163,16 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder}, ::direction,
           @unroll for s = 1:nstate
             @unroll for n = 1:Nq
               # ξ1-grid lines
-              l_rhs[s, i, j, k] += MI * s_half_D[n, i] * s_F[1, n, j, k, s]
+              l_rhs[s, i, j, k] += MI * s_D[n, i] * s_F[1, n, j, k, s]
 
               # ξ2-grid lines
               if dim == 3 || (dim == 2 && direction == EveryDirection)
-                l_rhs[s, i, j, k] += MI * s_half_D[n, j] * s_F[2, i, n, k, s]
+                l_rhs[s, i, j, k] += MI * s_D[n, j] * s_F[2, i, n, k, s]
               end
 
               # ξ3-grid lines
               if dim == 3 && direction == EveryDirection
-                l_rhs[s, i, j, k] += MI * s_half_D[n, k] * s_F[3, i, j, n, s]
+                l_rhs[s, i, j, k] += MI * s_D[n, k] * s_F[3, i, j, n, s]
               end
             end
           end
@@ -277,19 +209,14 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
 
   s_F = @shmem FT (3, Nq, Nq, Nqk, nstate)
   s_ω = @shmem FT (Nq, )
-  s_half_D = @shmem FT (Nq, Nq)
+  s_D = @shmem FT (Nq, Nq)
   l_rhs = @scratch FT (nstate, Nq, Nq, Nqk) 3
 
   source! !== nothing && (l_S = MArray{Tuple{nstate}, FT}(undef))
-  l_Q = @scratch FT (nstate, Nq, Nq, Nqk) 3
+  l_Q = MArray{Tuple{nstate}, FT}(undef)
   l_Qvisc = MArray{Tuple{nviscstate}, FT}(undef)
-  l_aux = @scratch FT (nauxstate, Nq, Nq, Nqk) 3
+  l_aux = MArray{Tuple{nauxstate}, FT}(undef)
   l_F = MArray{Tuple{3, nstate}, FT}(undef)
-  l_M = @scratch FT (Nq, Nq, Nqk) 3
-
-  l_ζx1 = @scratch FT (Nq, Nq, Nqk) 3
-  l_ζx2 = @scratch FT (Nq, Nq, Nqk) 3
-  l_ζx3 = @scratch FT (Nq, Nq, Nqk) 3
 
   _ζx1 = dim == 2 ? _ξ2x1 : _ξ3x1
   _ζx2 = dim == 2 ? _ξ2x2 : _ξ3x2
@@ -299,7 +226,7 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
     @loop for j in (1:Nq; threadIdx().y)
       s_ω[j] = ω[j]
       @loop for i in (1:Nq; threadIdx().x)
-        s_half_D[i, j] = D[i, j] / 2
+        s_D[i, j] = D[i, j]
       end
     end
   end
@@ -309,27 +236,31 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
       @loop for j in (1:Nq; threadIdx().y)
         @loop for i in (1:Nq; threadIdx().x)
           ijk = i + Nq * ((j-1) + Nq * (k-1))
-          l_M[i, j, k] = vgeo[ijk, _M, e]
-          l_ζx1[i, j, k] = vgeo[ijk, _ζx1, e]
-          l_ζx2[i, j, k] = vgeo[ijk, _ζx2, e]
-          l_ζx3[i, j, k] = vgeo[ijk, _ζx3, e]
+          M = vgeo[ijk, _M, e]
+          ζx1 = vgeo[ijk, _ζx1, e]
+          ζx2 = vgeo[ijk, _ζx2, e]
+          ζx3 = vgeo[ijk, _ζx3, e]
 
           @unroll for s = 1:nstate
             l_rhs[s, i, j, k] = increment ? rhs[ijk, s, e] : zero(FT)
           end
 
           @unroll for s = 1:nstate
-            l_Q[s, i, j, k] = Q[ijk, s, e]
+            l_Q[s] = Q[ijk, s, e]
           end
 
           @unroll for s = 1:nauxstate
-            l_aux[s, i, j, k] = auxstate[ijk, s, e]
+            l_aux[s] = auxstate[ijk, s, e]
+          end
+
+          @unroll for s = 1:nviscstate
+            l_Qvisc[s] = Qvisc[ijk, s, e]
           end
 
           fill!(l_F, -zero(eltype(l_F)))
           flux_nondiffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                             Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                             Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                             Vars{vars_state(bl,FT)}(l_Q),
+                             Vars{vars_aux(bl,FT)}(l_aux), t)
 
           @unroll for s = 1:nstate
             s_F[1,i,j,k,s] = l_F[1,s]
@@ -337,70 +268,32 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
             s_F[3,i,j,k,s] = l_F[3,s]
           end
 
+          fill!(l_F, -zero(eltype(l_F)))
+          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
+                          Vars{vars_state(bl,FT)}(l_Q),
+                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
+                          Vars{vars_aux(bl,FT)}(l_aux), t)
+
+          @unroll for s = 1:nstate
+            s_F[1,i,j,k,s] += l_F[1,s]
+            s_F[2,i,j,k,s] += l_F[2,s]
+            s_F[3,i,j,k,s] += l_F[3,s]
+          end
+
+          # Build "inside metrics" flux
+          @unroll for s = 1:nstate
+            F1, F2, F3 = s_F[1,i,j,k,s], s_F[2,i,j,k,s], s_F[3,i,j,k,s]
+            s_F[3,i,j,k,s] = M * (ζx1 * F1 + ζx2 * F2 + ζx3 * F3)
+          end
+
           # if source! !== nothing
           fill!(l_S, -zero(eltype(l_S)))
           source!(bl, Vars{vars_state(bl,FT)}(l_S),
-                  Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                  Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
+                  Vars{vars_state(bl,FT)}(l_Q),
+                  Vars{vars_aux(bl,FT)}(l_aux), t)
 
           @unroll for s = 1:nstate
             l_rhs[s, i, j, k] += l_S[s]
-          end
-        end
-      end
-    end
-    @synchronize
-
-    # Weak "outside metrics" derivative
-    @loop for k in (1:Nqk; threadIdx().z)
-      @loop for j in (1:Nq; threadIdx().y)
-        @loop for i in (1:Nq; threadIdx().x)
-          @unroll for n = 1:Nq
-            @unroll for s = 1:nstate
-              if dim == 2
-                Dnj = s_half_D[n, j] * s_ω[n] / s_ω[j]
-                l_rhs[s, i, j, k] += l_ζx1[i, j, k] * Dnj * s_F[1, i, n, k, s]
-                l_rhs[s, i, j, k] += l_ζx2[i, j, k] * Dnj * s_F[2, i, n, k, s]
-                l_rhs[s, i, j, k] += l_ζx3[i, j, k] * Dnj * s_F[3, i, n, k, s]
-              else
-                Dnk = s_half_D[n, k] * s_ω[n] / s_ω[k]
-                l_rhs[s, i, j, k] += l_ζx1[i, j, k] * Dnk * s_F[1, i, j, n, s]
-                l_rhs[s, i, j, k] += l_ζx2[i, j, k] * Dnk * s_F[2, i, j, n, s]
-                l_rhs[s, i, j, k] += l_ζx3[i, j, k] * Dnk * s_F[3, i, j, n, s]
-              end
-            end
-          end
-        end
-      end
-    end
-    @synchronize
-
-    # Build "inside metrics" flux
-    @loop for k in (1:Nqk; threadIdx().z)
-      @loop for j in (1:Nq; threadIdx().y)
-        @loop for i in (1:Nq; threadIdx().x)
-          ijk = i + Nq * ((j-1) + Nq * (k-1))
-
-          @unroll for s = 1:nviscstate
-            l_Qvisc[s] = Qvisc[ijk, s, e]
-          end
-
-          fill!(l_F, -zero(eltype(l_F)))
-          flux_diffusive!(bl, Grad{vars_state(bl,FT)}(l_F),
-                          Vars{vars_state(bl,FT)}(l_Q[:, i, j, k]),
-                          Vars{vars_diffusive(bl,FT)}(l_Qvisc),
-                          Vars{vars_aux(bl,FT)}(l_aux[:, i, j, k]), t)
-
-          @unroll for s = 1:nstate
-            F1, F2, F3 = s_F[1,i,j,k,s], s_F[2,i,j,k,s], s_F[3,i,j,k,s]
-
-            F1 += 2l_F[1,s]
-            F2 += 2l_F[2,s]
-            F3 += 2l_F[3,s]
-
-            s_F[3,i,j,k,s] = l_M[i, j, k] * (l_ζx1[i, j, k] * F1 +
-                                             l_ζx2[i, j, k] * F2 +
-                                             l_ζx3[i, j, k] * F3)
           end
         end
       end
@@ -416,10 +309,10 @@ function volumerhs!(bl::BalanceLaw, ::Val{dim}, ::Val{polyorder},
           @unroll for s = 1:nstate
             @unroll for n = 1:Nq
               if dim == 2
-                Dnj = s_half_D[n, j]
+                Dnj = s_D[n, j]
                 l_rhs[s, i, j, k] += MI * Dnj * s_F[3, i, n, k, s]
               else
-                Dnk = s_half_D[n, k]
+                Dnk = s_D[n, k]
                 l_rhs[s, i, j, k] += MI * Dnk * s_F[3, i, j, n, s]
               end
             end

--- a/test/DGmethods/Euler/isentropicvortex-imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex-imex.jl
@@ -57,9 +57,9 @@ function main()
   expected_error[Float64, false, 4] = 2.8660813871243937e-03
 
   expected_error[Float64, true, 1] = 2.3225467618783981e+01
-  expected_error[Float64, true, 2] = 5.2663710765946341e+00
-  expected_error[Float64, true, 3] = 1.2183771242881866e-01
-  expected_error[Float64, true, 4] = 2.8660023410820249e-03
+  expected_error[Float64, true, 2] = 5.2663709730207771e+00
+  expected_error[Float64, true, 3] = 1.2183770891083319e-01
+  expected_error[Float64, true, 4] = 2.8660813810759854e-03
 
   @testset "$(@__FILE__)" begin
     for FT in (Float64,), dims in 2

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -70,23 +70,23 @@ function main()
 
   expected_error[Float32, 2, Rusanov, 1] = 1.1990854263305664e+01
   expected_error[Float32, 2, Rusanov, 2] = 2.0812149047851563e+00
-  expected_error[Float32, 2, Rusanov, 3] = 6.7652329802513123e-02
-  expected_error[Float32, 2, Rusanov, 4] = 3.6849677562713623e-02
+  expected_error[Float32, 2, Rusanov, 3] = 6.6969044506549835e-02
+  expected_error[Float32, 2, Rusanov, 4] = 5.2888177335262299e-02
 
   expected_error[Float32, 2, Central, 1] = 2.0840496063232422e+01
   expected_error[Float32, 2, Central, 2] = 2.9250388145446777e+00
   expected_error[Float32, 2, Central, 3] = 3.7026408314704895e-01
-  expected_error[Float32, 2, Central, 4] = 6.7625500261783600e-02
+  expected_error[Float32, 2, Central, 4] = 1.1543836444616318e-01
 
   expected_error[Float32, 3, Rusanov, 1] = 3.7918324470520020e+00
   expected_error[Float32, 3, Rusanov, 2] = 6.5811443328857422e-01
-  expected_error[Float32, 3, Rusanov, 3] = 2.1280560642480850e-02
-  expected_error[Float32, 3, Rusanov, 4] = 9.8376255482435226e-03
+  expected_error[Float32, 3, Rusanov, 3] = 2.0889002829790115e-02
+  expected_error[Float32, 3, Rusanov, 4] = 1.1552370153367519e-02
 
   expected_error[Float32, 3, Central, 1] = 6.5902600288391113e+00
   expected_error[Float32, 3, Central, 2] = 9.2505264282226563e-01
   expected_error[Float32, 3, Central, 3] = 1.1701638251543045e-01
-  expected_error[Float32, 3, Central, 4] = 1.2930640019476414e-02
+  expected_error[Float32, 3, Central, 4] = 2.1023442968726158e-02
 
   @testset "$(@__FILE__)" begin
     for FT in (Float64, Float32), dims in (2, 3)

--- a/test/DGmethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/DGmethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -1,0 +1,143 @@
+using Test
+using MPI
+using CLIMA
+using CLIMA.Mesh.Topologies
+using CLIMA.Mesh.Grids
+using CLIMA.DGmethods
+using CLIMA.DGmethods.NumericalFluxes
+using CLIMA.MPIStateArrays
+using LinearAlgebra
+using Random
+using CLIMA.Mesh.Grids: EveryDirection, HorizontalDirection, VerticalDirection
+
+include("advection_diffusion_model.jl")
+
+struct Box{dim} end
+struct Sphere end
+
+vertical_unit_vector(::Box{2}, ::SVector{3}) = SVector(0, 1, 0)
+vertical_unit_vector(::Box{3}, ::SVector{3}) = SVector(0, 0, 1)
+vertical_unit_vector(::Sphere, coord::SVector{3}) = coord / norm(coord)
+
+projection(::EveryDirection, ::SVector{3}) = I
+projection(::VerticalDirection, k::SVector{3}) = k * k'
+projection(::HorizontalDirection, k::SVector{3}) = I - k * k'
+
+struct Advection end
+struct Diffusion end
+
+struct TestProblem{adv, diff, dir, topo} <: AdvectionDiffusionProblem end
+
+function init_velocity_diffusion!(::TestProblem{adv, diff, dir, topo}, aux::Vars,
+                                  geom::LocalGeometry) where {adv, diff, dir, topo}
+  k = vertical_unit_vector(topo, geom.coord)
+  P = projection(dir, k)
+  aux.u = !isnothing(adv) ? P * sin.(geom.coord) : zeros(SVector{3})
+  aux.D = !isnothing(diff) ? SMatrix{3, 3}(P) / 200 : zeros(SMatrix{3, 3})
+end
+
+function initial_condition!(::AdvectionDiffusionProblem, state, aux, x, t)
+  # random perturbation to trigger numerical fluxes
+  state.ρ = prod(sin.(x)) + rand() / 10
+end
+
+function create_topology(::Box{dim}, mpicomm, Ne, FT) where {dim}
+  brickrange = ntuple(j->range(FT(0); length=Ne+1, stop=1), dim)
+  periodicity = ntuple(j->false, dim)
+  bc = ntuple(j->(3, 3), dim)
+  StackedBrickTopology(mpicomm, brickrange;
+                       periodicity=periodicity,
+                       boundary=bc)
+end
+
+function create_topology(::Sphere, mpicomm, Ne, FT)
+  vert_range = grid1d(FT(1), FT(2), nelem=Ne)
+  StackedCubedSphereTopology(mpicomm, Ne, vert_range, boundary=(3, 3))
+end
+
+create_dg(model, grid, direction) =
+  DGModel(model,
+          grid,
+          Rusanov(),
+          CentralNumericalFluxDiffusive(),
+          CentralNumericalFluxGradient(),
+          direction=direction)
+
+function run(adv, diff, topo, mpicomm, ArrayType, FT, polynomialorder, Ne, level)
+  topology = create_topology(topo(), mpicomm, Ne, FT)
+  grid = DiscontinuousSpectralElementGrid(topology,
+                                          FloatType = FT,
+                                          DeviceArray = ArrayType,
+                                          polynomialorder = polynomialorder,
+                                          meshwarp = topo == Sphere ?
+                                            cubedshellwarp : (x...)->identity(x)
+                                         )
+
+  problems = (p=TestProblem{adv, diff, EveryDirection(), topo()}(),
+              vp=TestProblem{adv, diff, VerticalDirection(), topo()}(),
+              hp=TestProblem{adv, diff, HorizontalDirection(), topo()}())
+
+  models = map(AdvectionDiffusion{3, false}, problems)
+
+  dgmodels = map(models) do m
+    (dg=create_dg(m, grid, EveryDirection()),
+     vdg=create_dg(m, grid, VerticalDirection()), 
+     hdg=create_dg(m, grid, HorizontalDirection()))
+  end
+
+  Q = init_ode_state(dgmodels.p.dg, FT(0), forcecpu=true)
+
+  # evaluate all combinations
+  dQ = map(x->map(dg->(dQ=similar(Q); dg(dQ, Q, nothing, FT(0)); dQ), x), dgmodels)
+
+  # set up tolerances
+  atolm = 6e-13
+  atolv = 5e-5 / 5 ^ (level - 1)
+  atolh = 0.0002 / 5 ^ (level - 1)
+
+  @testset "total" begin
+    atol = topo <: Box || diff == nothing ? atolm : atolh
+    @test isapprox(norm(dQ.p.dg  .- dQ.p.vdg  .- dQ.p.hdg ), 0, atol = atol)
+    @test isapprox(norm(dQ.vp.dg .- dQ.vp.vdg .- dQ.vp.hdg), 0, atol = atol)
+    @test isapprox(norm(dQ.hp.dg .- dQ.hp.vdg .- dQ.hp.hdg), 0, atol = atol)
+  end
+
+  @testset "vertical" begin
+    atol = topo <: Box ? atolm : atolv
+    @test isapprox(norm(dQ.vp.dg .- dQ.vp.vdg), 0, atol = atol)
+    @test isapprox(norm(dQ.vp.hdg), 0, atol = atol)
+    @test isapprox(norm(dQ.vp.dg .- dQ.p.vdg), 0, atol = atol)
+  end
+
+  @testset "horizontal" begin
+    atol = topo <: Box ? atolm : atolh
+    @test isapprox(norm(dQ.hp.dg .- dQ.hp.hdg), 0, atol = atol)
+    @test isapprox(norm(dQ.hp.vdg), 0, atol = atol)
+    @test isapprox(norm(dQ.hp.dg - dQ.p.hdg), 0, atol = atol)
+  end
+end
+
+let
+  Random.seed!(44)
+  CLIMA.init()
+  ArrayType = CLIMA.array_type()
+  mpicomm = MPI.COMM_WORLD
+  FT = Float64
+  numlevels = 2
+  polynomialorder = 4
+  base_num_elem = 4
+
+  @testset "$(@__FILE__)" begin
+    @testset for topo in (Box{2}, Box{3}, Sphere)
+      @testset for (adv, diff) in
+          ((Advection, nothing), (nothing, Diffusion), (Advection, Diffusion))
+        @testset for level = 1:numlevels
+          Ne = 2 ^ (level - 1) * base_num_elem
+          run(adv, diff, topo, mpicomm, ArrayType, FT,
+              polynomialorder, Ne, level)
+        end
+      end
+    end
+  end
+end
+nothing

--- a/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl
+++ b/test/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl
@@ -197,22 +197,22 @@ let
   expected_result[3, 4, Float64, VerticalDirection]   = 5.6257417070312578e-07
   expected_result[2, 1, Float32, EveryDirection]      = 1.2357043102383614e-02
   expected_result[2, 2, Float32, EveryDirection]      = 8.8409741874784231e-04
-  expected_result[2, 3, Float32, EveryDirection]      = 4.9384900194127113e-05
+  expected_result[2, 3, Float32, EveryDirection]      = 4.9193818995263427e-05
   expected_result[2, 1, Float32, HorizontalDirection] = 4.6783901751041412e-02
   expected_result[2, 2, Float32, HorizontalDirection] = 4.0663350373506546e-03
-  expected_result[2, 3, Float32, HorizontalDirection] = 5.3100597142474726e-05
+  expected_result[2, 3, Float32, HorizontalDirection] = 5.3044739615870640e-05
   expected_result[2, 1, Float32, VerticalDirection]   = 4.6783857047557831e-02
   expected_result[2, 2, Float32, VerticalDirection]   = 4.0663424879312515e-03
-  expected_result[2, 3, Float32, VerticalDirection]   = 5.3196803492028266e-05
+  expected_result[2, 3, Float32, VerticalDirection]   = 5.3172039770288393e-05
   expected_result[3, 1, Float32, EveryDirection]      = 9.6252141520380974e-03
   expected_result[3, 2, Float32, EveryDirection]      = 6.0162233421579003e-04
   expected_result[3, 3, Float32, EveryDirection]      = 4.0522103518014774e-05
   expected_result[3, 1, Float32, HorizontalDirection] = 1.7475549131631851e-02
   expected_result[3, 2, Float32, HorizontalDirection] = 1.2503013713285327e-03
-  expected_result[3, 3, Float32, HorizontalDirection] = 7.0818001404404640e-05
+  expected_result[3, 3, Float32, HorizontalDirection] = 7.2867427661549300e-05
   expected_result[3, 1, Float32, VerticalDirection]   = 6.6162362694740295e-02
   expected_result[3, 2, Float32, VerticalDirection]   = 5.7506239973008633e-03
-  expected_result[3, 3, Float32, VerticalDirection]   = 8.6561900388915092e-05
+  expected_result[3, 3, Float32, VerticalDirection]   = 1.0193029447691515e-04
 
   @testset "$(@__FILE__)" begin
     for FT in (Float64, Float32)

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -188,8 +188,8 @@ let
   polynomialorder = 4
   base_num_elem = 4
 
-  expected_result = [1.5834569096502649e-01 5.3705043093160857e-03 2.2780398026991879e-04;
-                     2.6050771352440709e-02 1.1953830539519587e-03 6.2139835471113376e-05]
+  expected_result = [1.6931876910307017e-01 5.4603193051929394e-03 2.3307776694542282e-04;
+                     3.3983777728925593e-02 1.7808380837573065e-03 9.176181458773599e-5]
   lvls = integration_testing ? size(expected_result, 2) : 1
 
   @testset "mms_bc_atmos" begin

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl
@@ -101,8 +101,8 @@ let
   polynomialorder = 4
   base_num_elem = 4
 
-  expected_result = [1.5606168354833677e-01 5.3315302122591991e-03 2.2572667801637464e-04;
-                     2.5754447602174043e-02 1.1781237053129381e-03 6.1753004835330110e-05]
+  expected_result = [1.6694721292986181e-01 5.4178750150416337e-03 2.3066867400713085e-04;
+                     3.3672443923201158e-02 1.7603832251132654e-03 9.1108401774885506e-05]
   lvls = integration_testing ? size(expected_result, 2) : 1
 
   @testset "mms_bc_dgmodel" begin


### PR DESCRIPTION
This adds a test for horizontal/vertical splitting in the box and on the sphere using advection-diffusion
equation. It also removes split treatment of metric terms in `volumerhs`, which caused some small inconsistencies in the splitting that could become important as we move towards actually solving equations in the horizontal/vertical (as opposed to only using it for 1D IMEX where this didn't seem to matter).