### PR TITLE
User-facing changes to include hyperdiffusion in AtmosModel

### DIFF
--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -89,6 +89,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     model = AtmosModel{FT}(
         AtmosLESConfigType;
         turbulence = SmagorinskyLilly{FT}(C_smag),
+        hyperdiffusion = StandardHyperDiffusion{FT}(60),
         source = (Gravity(),),
         ref_state = ref_state,
         init_state = init_risingbubble!,

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -19,7 +19,9 @@ import CLIMA.DGmethods:
     vars_aux,
     vars_state,
     vars_gradient,
+    vars_gradient_laplacian,
     vars_diffusive,
+    vars_hyperdiffusive,
     flux_nondiffusive!,
     flux_diffusive!,
     source!,
@@ -27,6 +29,7 @@ import CLIMA.DGmethods:
     boundary_state!,
     gradvariables!,
     diffusive!,
+    hyperdiffusive!,
     init_aux!,
     init_state!,
     update_aux!,
@@ -51,7 +54,9 @@ import ..DGmethods.NumericalFluxes:
     normal_boundary_flux_diffusive!,
     NumericalFluxNonDiffusive,
     NumericalFluxGradient,
-    NumericalFluxDiffusive
+    NumericalFluxDiffusive,
+    CentralHyperDiffusiveFlux,
+    CentralDivPenalty
 
 import ..Courant: advective_courant, nondiffusive_courant, diffusive_courant
 
@@ -62,15 +67,16 @@ A `BalanceLaw` for atmosphere modeling.
 
 # Usage
 
-    AtmosModel(orientation, ref_state, turbulence, moisture, radiation, source,
+    AtmosModel(orientation, ref_state, turbulence, hyperdiffusion, moisture, radiation, source,
                boundarycondition, init_state)
 
 """
-struct AtmosModel{FT, PS, O, RS, T, M, P, R, S, BC, IS, DC} <: BalanceLaw
+struct AtmosModel{FT, PS, O, RS, T, HD, M, P, R, S, BC, IS, DC} <: BalanceLaw
     param_set::PS
     orientation::O
     ref_state::RS
     turbulence::T
+    hyperdiffusion::HD
     moisture::M
     precipitation::P
     radiation::R
@@ -89,6 +95,7 @@ function AtmosModel{FT}(
         FT(0),
     ),
     turbulence::T = SmagorinskyLilly{FT}(0.21),
+    hyperdiffusion::HD = NoHyperDiffusion(),
     moisture::M = EquilMoist{FT}(),
     precipitation::P = NoPrecipitation(),
     radiation::R = NoRadiation(),
@@ -98,7 +105,7 @@ function AtmosModel{FT}(
     init_state::IS = nothing,
     data_config::DC = nothing,
     param_set::PS = nothing,
-) where {FT <: AbstractFloat, O, RS, T, M, P, R, S, BC, IS, DC, PS}
+) where {FT <: AbstractFloat, O, RS, T, HD, M, P, R, S, BC, IS, DC, PS}
     @assert param_set ≠ nothing
     @assert init_state ≠ nothing
 
@@ -107,6 +114,7 @@ function AtmosModel{FT}(
         orientation,
         ref_state,
         turbulence,
+        hyperdiffusion,
         moisture,
         precipitation,
         radiation,
@@ -126,6 +134,7 @@ function AtmosModel{FT}(
         FT(0),
     ),
     turbulence::T = SmagorinskyLilly{FT}(0.21),
+    hyperdiffusion::HD = NoHyperDiffusion(),
     moisture::M = EquilMoist{FT}(),
     precipitation::P = NoPrecipitation(),
     radiation::R = NoRadiation(),
@@ -134,7 +143,7 @@ function AtmosModel{FT}(
     init_state::IS = nothing,
     data_config::DC = nothing,
     param_set::PS = nothing,
-) where {FT <: AbstractFloat, O, RS, T, M, P, R, S, BC, IS, DC, PS}
+) where {FT <: AbstractFloat, O, RS, T, HD, M, P, R, S, BC, IS, DC, PS}
     @assert param_set ≠ nothing
     @assert init_state ≠ nothing
     atmos = (
@@ -142,6 +151,7 @@ function AtmosModel{FT}(
         orientation,
         ref_state,
         turbulence,
+        hyperdiffusion,
         moisture,
         precipitation,
         radiation,
@@ -154,13 +164,13 @@ function AtmosModel{FT}(
     return AtmosModel{FT, typeof.(atmos)...}(atmos...)
 end
 
-
 function vars_state(m::AtmosModel, FT)
     @vars begin
         ρ::FT
         ρu::SVector{3, FT}
         ρe::FT
         turbulence::vars_state(m.turbulence, FT)
+        hyperdiffusion::vars_state(m.hyperdiffusion, FT)
         moisture::vars_state(m.moisture, FT)
         radiation::vars_state(m.radiation, FT)
     end
@@ -170,6 +180,7 @@ function vars_gradient(m::AtmosModel, FT)
         u::SVector{3, FT}
         h_tot::FT
         turbulence::vars_gradient(m.turbulence, FT)
+        hyperdiffusion::vars_gradient(m.hyperdiffusion, FT)
         moisture::vars_gradient(m.moisture, FT)
     end
 end
@@ -177,11 +188,20 @@ function vars_diffusive(m::AtmosModel, FT)
     @vars begin
         ∇h_tot::SVector{3, FT}
         turbulence::vars_diffusive(m.turbulence, FT)
+        hyperdiffusion::vars_diffusive(m.hyperdiffusion, FT)
         moisture::vars_diffusive(m.moisture, FT)
     end
 end
-
-
+function vars_gradient_laplacian(m::AtmosModel, FT)
+    @vars begin
+        hyperdiffusion::vars_gradient_laplacian(m.hyperdiffusion, FT)
+    end
+end
+function vars_hyperdiffusive(m::AtmosModel, FT)
+    @vars begin
+        hyperdiffusion::vars_hyperdiffusive(m.hyperdiffusion, FT)
+    end
+end
 function vars_aux(m::AtmosModel, FT)
     @vars begin
         ∫dz::vars_integrals(m, FT)
@@ -190,6 +210,7 @@ function vars_aux(m::AtmosModel, FT)
         orientation::vars_aux(m.orientation, FT)
         ref_state::vars_aux(m.ref_state, FT)
         turbulence::vars_aux(m.turbulence, FT)
+        hyperdiffusion::vars_aux(m.hyperdiffusion, FT)
         moisture::vars_aux(m.moisture, FT)
         radiation::vars_aux(m.radiation, FT)
     end
@@ -208,6 +229,7 @@ end
 include("orientation.jl")
 include("ref_state.jl")
 include("turbulence.jl")
+include("hyperdiffusion.jl")
 include("moisture.jl")
 include("precipitation.jl")
 include("radiation.jl")
@@ -253,7 +275,6 @@ Where
 
     # pressure terms
     p = pressure(m, m.moisture, state, aux)
-
     if m.ref_state isa HydrostaticState
         flux.ρu += (p - aux.ref_state.p) * I
     else
@@ -277,6 +298,7 @@ function gradvariables!(
 
     gradvariables!(atmos.moisture, transform, state, aux, t)
     gradvariables!(atmos.turbulence, transform, state, aux, t)
+    gradvariables!(atmos.hyperdiffusion, transform, state, aux, t)
 end
 
 function diffusive!(
@@ -303,6 +325,24 @@ function diffusive!(
     diffusive!(atmos.moisture, diffusive, ∇transform, state, aux, t)
 end
 
+function hyperdiffusive!(
+    atmos::AtmosModel,
+    hyperdiffusive::Vars,
+    hypertransform::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    hyperdiffusive!(
+        atmos.hyperdiffusion,
+        hyperdiffusive,
+        hypertransform,
+        state,
+        aux,
+        t,
+    )
+end
+
 @inline function flux_diffusive!(
     atmos::AtmosModel,
     flux::Grad,
@@ -317,6 +357,15 @@ end
     d_h_tot = -D_t .* diffusive.∇h_tot
     flux_diffusive!(atmos, flux, state, τ, d_h_tot)
     flux_diffusive!(atmos.moisture, flux, state, diffusive, aux, t, D_t)
+    flux_diffusive!(
+        atmos.hyperdiffusion,
+        flux,
+        state,
+        diffusive,
+        hyperdiffusive,
+        aux,
+        t,
+    )
 end
 
 #TODO: Consider whether to not pass ρ and ρu (not state), foc BCs reasons
@@ -386,6 +435,7 @@ function init_aux!(m::AtmosModel, aux::Vars, geom::LocalGeometry)
     atmos_init_aux!(m.orientation, m, aux, geom)
     atmos_init_aux!(m.ref_state, m, aux, geom)
     atmos_init_aux!(m.turbulence, m, aux, geom)
+    atmos_init_aux!(m.hyperdiffusion, m, aux, geom)
 end
 
 """
@@ -411,5 +461,4 @@ end
 function init_state!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)
     m.init_state(m, state, aux, coords, t, args...)
 end
-
 end # module

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -2,8 +2,6 @@ using ..PlanetParameters
 
 export BoundaryCondition, InitStateBC
 
-export InitStateBC, DYCOMS_BC, RayleighBenardBC
-
 export AtmosBC,
     Impenetrable,
     FreeSlip,
@@ -31,6 +29,15 @@ end
 function boundary_state!(nf, atmos::AtmosModel, args...)
     atmos_boundary_state!(nf, atmos.boundarycondition, atmos, args...)
 end
+
+function boundary_state!(
+    nf::Union{CentralHyperDiffusiveFlux, CentralDivPenalty},
+    m::AtmosModel,
+    x...,
+)
+    nothing
+end
+
 @generated function atmos_boundary_state!(
     nf,
     tup::Tuple,

--- a/src/Atmos/Model/hyperdiffusion.jl
+++ b/src/Atmos/Model/hyperdiffusion.jl
@@ -1,0 +1,134 @@
+#### Hyperdiffusion Model Functions
+using DocStringExtensions
+using LinearAlgebra
+using ..PlanetParameters
+export HyperDiffusion, NoHyperDiffusion, StandardHyperDiffusion
+
+abstract type HyperDiffusion end
+vars_state(::HyperDiffusion, FT) = @vars()
+vars_aux(::HyperDiffusion, FT) = @vars()
+vars_gradient(::HyperDiffusion, FT) = @vars()
+vars_gradient_laplacian(::HyperDiffusion, FT) = @vars()
+vars_diffusive(::HyperDiffusion, FT) = @vars()
+vars_hyperdiffusive(::HyperDiffusion, FT) = @vars()
+function atmos_init_aux!(
+    ::HyperDiffusion,
+    ::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+) end
+function atmos_nodal_update_aux!(
+    ::HyperDiffusion,
+    ::AtmosModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
+function gradvariables!(
+    ::HyperDiffusion,
+    transform::Vars,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
+function hyperdiffusive!(
+    h::HyperDiffusion,
+    hyperdiffusive::Vars,
+    gradvars::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
+function flux_diffusive!(
+    h::HyperDiffusion,
+    flux::Grad,
+    state::Vars,
+    diffusive::Vars,
+    hyperdiffusive::Vars,
+    aux::Vars,
+    t::Real,
+) end
+function diffusive!(
+    h::HyperDiffusion,
+    diffusive::Vars,
+    ∇transform::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
+
+"""
+  NoHyperDiffusion <: HyperDiffusion
+Defines a default hyperdiffusion model with zero diffusive fluxes. 
+"""
+struct NoHyperDiffusion <: HyperDiffusion end
+
+"""
+  StandardHyperDiffusion{FT} <: HyperDiffusion
+Horizontal hyperdiffusion methods for application in GCM and LES settings
+Timescales are prescribed by the user while the diffusion coefficient is 
+computed as a function of the grid lengthscale.
+"""
+struct StandardHyperDiffusion{FT} <: HyperDiffusion
+    τ_timescale::FT
+end
+
+vars_aux(::StandardHyperDiffusion, FT) = @vars(Δ::FT)
+vars_gradient(::StandardHyperDiffusion, FT) =
+    @vars(u::SVector{3, FT}, h_tot::FT)
+vars_gradient_laplacian(::StandardHyperDiffusion, FT) =
+    @vars(u::SVector{3, FT}, h_tot::FT)
+vars_hyperdiffusive(::StandardHyperDiffusion, FT) =
+    @vars(ν∇³u::SMatrix{3, 3, FT, 9}, ν∇³h_tot::SVector{3, FT})
+
+function atmos_init_aux!(
+    ::StandardHyperDiffusion,
+    ::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    aux.hyperdiffusion.Δ = lengthscale(geom)
+end
+
+function gradvariables!(
+    h::StandardHyperDiffusion,
+    transform::Vars,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    ρinv = 1 / state.ρ
+    transform.hyperdiffusion.u = ρinv * state.ρu
+    transform.hyperdiffusion.h_tot = transform.h_tot
+end
+
+function hyperdiffusive!(
+    h::StandardHyperDiffusion,
+    hyperdiffusive::Vars,
+    hypertransform::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    ∇Δu = hypertransform.hyperdiffusion.u
+    ∇Δh_tot = hypertransform.hyperdiffusion.h_tot
+    # Unpack
+    τ_timescale = h.τ_timescale
+    # Compute hyperviscosity coefficient
+    ν₄ = (aux.hyperdiffusion.Δ / 2)^4 / 2 / τ_timescale
+    hyperdiffusive.hyperdiffusion.ν∇³u = ν₄ * ∇Δu
+    hyperdiffusive.hyperdiffusion.ν∇³h_tot = ν₄ * ∇Δh_tot
+end
+
+function flux_diffusive!(
+    h::StandardHyperDiffusion,
+    flux::Grad,
+    state::Vars,
+    diffusive::Vars,
+    hyperdiffusive::Vars,
+    aux::Vars,
+    t::Real,
+)
+    flux.ρu += state.ρ * hyperdiffusive.hyperdiffusion.ν∇³u
+    flux.ρe += state.ρ * hyperdiffusive.hyperdiffusion.ν∇³h_tot
+end

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -139,7 +139,7 @@ EquilMoist{FT}(;
 
 
 vars_state(::EquilMoist, FT) = @vars(ρq_tot::FT)
-vars_gradient(::EquilMoist, FT) = @vars(q_tot::FT, h_tot::FT)
+vars_gradient(::EquilMoist, FT) = @vars(q_tot::FT)
 vars_diffusive(::EquilMoist, FT) = @vars(∇q_tot::SVector{3, FT})
 vars_aux(::EquilMoist, FT) = @vars(temperature::FT, θ_v::FT, q_liq::FT)
 

--- a/src/Atmos/Model/remainder.jl
+++ b/src/Atmos/Model/remainder.jl
@@ -14,6 +14,9 @@ vars_diffusive(rem::RemainderModel, FT) = vars_diffusive(rem.main, FT)
 vars_aux(rem::RemainderModel, FT) = vars_aux(rem.main, FT)
 vars_integrals(rem::RemainderModel, FT) = vars_integrals(rem.main, FT)
 vars_reverse_integrals(rem::RemainderModel, FT) = vars_integrals(rem.main, FT)
+vars_gradient_laplacian(rem::RemainderModel, FT) =
+    vars_gradient_laplacian(rem.main, FT)
+vars_hyperdiffusive(rem::RemainderModel, FT) = vars_hyperdiffusive(rem.main, FT)
 
 update_aux!(dg::DGModel, rem::RemainderModel, Q::MPIStateArray, t::Real) =
     update_aux!(dg, rem.main, Q, t)
@@ -34,6 +37,23 @@ reverse_integral_load_aux!(
 reverse_integral_set_aux!(rem::RemainderModel, aux::Vars, integ::Vars) =
     reverse_integral_set_aux!(rem.main, aux, integ)
 
+function hyperdiffusive!(
+    rem::RemainderModel,
+    hyperdiffusive::Vars,
+    hypertransform::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    hyperdiffusive!(
+        rem.main.hyperdiffusion,
+        hyperdiffusive,
+        hypertransform,
+        state,
+        aux,
+        t,
+    )
+end
 function flux_diffusive!(
     rem::RemainderModel,
     flux::Grad,

--- a/src/DGmethods/NumericalFluxes.jl
+++ b/src/DGmethods/NumericalFluxes.jl
@@ -6,7 +6,9 @@ export NumericalFluxNonDiffusive,
     Rusanov,
     CentralNumericalFluxGradient,
     CentralNumericalFluxDiffusive,
-    CentralNumericalFluxNonDiffusive
+    CentralNumericalFluxNonDiffusive,
+    CentralHyperDiffusiveFlux,
+    CentralDivPenalty
 
 using StaticArrays, LinearAlgebra
 using CLIMA.VariableTemplates


### PR DESCRIPTION
# Code submission
Adds the user-facing component to allow hyperdiffusion (#658) to be used at the AtmosModel level via a subcomponent `hyperdiffusion` within `AtmosModel{}(...)`
## Description
1) Adds `hyperdiffusion.jl`
2) Updates `AtmosLES` experiments (and other existing simulation drivers) to include hyperdiffusion wherever activated. (The sensible default prescribed in `AtmosModel.jl` is the `NoHyperDiffusion` model) 
<!--- Please leave the following section --->

## For review by CLIMA Developers

- [x] There are no open PR's for this already
- [x] The code conforms to the [style guidelines] and has consistent naming conventions 
- [x] This code does what it is technically intended to do. This is demonstrated through its usage in the Atmos_LES experiments. The hyperdiffusion kernels themselves are independently tested in `tests/DGmethods/...`
