### PR TITLE
[Atmos] Utilize existing functions in atmos init

### DIFF
--- a/examples/Atmos/dry_rayleigh_benard.jl
+++ b/examples/Atmos/dry_rayleigh_benard.jl
@@ -134,11 +134,17 @@ function init_problem!(bl, state, aux, (x,y,z), t)
   T             = dc.T_bot - ΔT
   P             = p0*(T/dc.T_bot)^(grav/R_gas/dc.T_lapse)
   ρ             = P / (R_gas * T)
+
+  q_tot = FT(0)
+  e_pot = gravitational_potential(bl.orientation, aux)
+  ts = TemperatureSHumEquil(T, P, q_tot)
+
   ρu, ρv, ρw    = FT(0) , FT(0) , ρ * δw
-  E_int         = ρ * c_v * (T-T_0)
-  E_pot         = ρ * grav * z
-  E_kin         = ρ * FT(1/2) * δw^2
-  ρe_tot        = E_int + E_pot + E_kin
+
+  e_int         = internal_energy(ts)
+  e_kin         = FT(1/2) * δw^2
+
+  ρe_tot        = ρ * (e_int + e_pot + e_kin)
   state.ρ       = ρ
   state.ρu      = SVector(ρu, ρv, ρw)
   state.ρe      = ρe_tot

--- a/experiments/Atmos_GCM/heldsuarez.jl
+++ b/experiments/Atmos_GCM/heldsuarez.jl
@@ -24,17 +24,19 @@ function init_heldsuarez!(bl, state, aux, coords, t)
 
     FT = eltype(state)
 
-    # TODO: change to altitude function
-    r = norm(coords, 2)
-    h = r - FT(planet_radius)
-    # h = altitude(bl.orientation, aux)
+    z = altitude(bl.orientation, aux)
+    e_pot = gravitational_potential(bl.orientation, aux)
 
-    scale_height = R_d * dc.T_initial / grav
-    p            = dc.p_ground * exp(-h / scale_height)
+    scale_height = FT(R_d) * dc.T_initial / FT(grav)
+    p            = dc.p_ground * exp(-z / scale_height)
 
-    state.ρ  = air_density(dc.T_initial, p)
+    ts = PhaseDry_given_pT(p, dc.T_initial)
+    e_int = internal_energy(ts)
+    ρ = air_density(ts)
+
+    state.ρ  = ρ
     state.ρu = SVector{3, FT}(0, 0, 0)
-    state.ρe = state.ρ * (internal_energy(dc.T_initial) + aux.orientation.Φ)
+    state.ρe = state.ρ * (e_int + e_pot)
 
     return nothing
 end
@@ -69,10 +71,7 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
     ρu    = state.ρu
     ρe    = state.ρe
     coord = aux.coord
-    Φ     = aux.orientation.Φ
-    e     = ρe / ρ
-    u     = ρu / ρ
-    e_int = e - u' * u / 2 - Φ
+    e_int = internal_energy(bl.moisture, bl.orientation, state, aux)
     T     = air_temperature(e_int)
 
     # Held-Suarez constants
@@ -85,12 +84,11 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
     T_min     = FT(200)
 
     σ_b          = FT(7 / 10)
-    r            = norm(coord, 2)
-    @inbounds λ  = atan(coord[2], coord[1])
-    @inbounds φ  = asin(coord[3] / r)
-    h            = r - FT(planet_radius)
-    scale_height = R_d * FT(dc.T_initial) / grav
-    σ            = exp(-h / scale_height)
+    λ            = longitude(bl.orientation, aux)
+    φ            = latitude(bl.orientation, aux)
+    z            = altitude(bl.orientation, aux)
+    scale_height = FT(R_d) * dc.T_initial / FT(grav)
+    σ            = exp(-z / scale_height)
 
     # TODO: use
     #  p = air_pressure(T, ρ)

--- a/experiments/Atmos_LES/dycoms.jl
+++ b/experiments/Atmos_LES/dycoms.jl
@@ -238,7 +238,7 @@ eprint = {https://doi.org/10.1175/MWR2930.1}
 function init_dycoms!(bl, state, aux, (x,y,z), t)
     FT = eltype(state)
 
-    z = FT(z)
+    z = altitude(bl.orientation, aux)
 
     # These constants are those used by Stevens et al. (2005)
     qref       = FT(9.0e-3)
@@ -286,7 +286,7 @@ function init_dycoms!(bl, state, aux, (x,y,z), t)
     ρ     = air_density(ts)
 
     e_kin = FT(1/2) * FT((u^2 + v^2 + w^2))
-    e_pot = grav * z
+    e_pot = gravitational_potential(bl.orientation, aux)
     E     = ρ * total_energy(e_kin, e_pot, ts)
 
     state.ρ               = ρ

--- a/experiments/Atmos_LES/risingbubble.jl
+++ b/experiments/Atmos_LES/risingbubble.jl
@@ -50,18 +50,20 @@ function init_risingbubble!(bl, state, aux, (x,y,z), t)
   θ            = θ_ref + Δθ # potential temperature
   π_exner      = FT(1) - grav / (c_p * θ) * z # exner pressure
   ρ            = p0 / (R_gas * θ) * (π_exner)^ (c_v / R_gas) # density
-  P            = p0 * (R_gas * (ρ * θ) / p0) ^(c_p/c_v) # pressure (absolute)
-  T            = P / (ρ * R_gas) # temperature
+  q_tot        = FT(0)
+  ts           = LiquidIcePotTempSHumEquil(θ, ρ, q_tot)
+  q_pt         = PhasePartition(ts)
+
   ρu           = SVector(FT(0),FT(0),FT(0))
 
   #State (prognostic) variable assignment
   e_kin        = FT(0)
-  e_pot        = grav * z
-  ρe_tot       = ρ * total_energy(e_kin, e_pot, T)
+  e_pot        = gravitational_potential(bl.orientation, aux)
+  ρe_tot       = ρ * total_energy(e_kin, e_pot, ts)
   state.ρ      = ρ
   state.ρu     = ρu
   state.ρe     = ρe_tot
-  state.moisture.ρq_tot = FT(0)
+  state.moisture.ρq_tot = ρ*q_pt.tot
 end
 
 function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)

--- a/experiments/Atmos_LES/surfacebubble.jl
+++ b/experiments/Atmos_LES/surfacebubble.jl
@@ -121,17 +121,20 @@ function init_surfacebubble!(bl, state, aux, (x,y,z), t)
   θ            = θ_ref + Δθ # potential temperature
   π_exner      = FT(1) - grav / (c_p * θ) * z # exner pressure
   ρ            = p0 / (R_gas * θ) * (π_exner)^ (c_v / R_gas) # density
-  P            = p0 * (R_gas * (ρ * θ) / p0) ^(c_p/c_v) # pressure (absolute)
-  T            = P / (ρ * R_gas) # temperature
+
+  q_tot        = FT(0)
+  ts           = LiquidIcePotTempSHumEquil(θ, ρ, q_tot)
+  q_pt         = PhasePartition(ts)
+
   ρu           = SVector(FT(0),FT(0),FT(0))
   # energy definitions
   e_kin        = FT(0)
-  e_pot        = grav * z
-  ρe_tot       = ρ * total_energy(e_kin, e_pot, T)
+  e_pot        = gravitational_potential(bl.orientation, aux)
+  ρe_tot       = ρ * total_energy(e_kin, e_pot, ts)
   state.ρ      = ρ
   state.ρu     = ρu
   state.ρe     = ρe_tot
-  state.moisture.ρq_tot = FT(0)
+  state.moisture.ρq_tot = ρ*q_pt.tot
 end
 
 function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)

--- a/src/Atmos/Model/orientation.jl
+++ b/src/Atmos/Model/orientation.jl
@@ -1,7 +1,7 @@
 # TODO: add Coriolis vectors
 import ..PlanetParameters: grav, planet_radius
 export Orientation, NoOrientation, FlatOrientation, SphericalOrientation
-export vertical_unit_vector
+export vertical_unit_vector, altitude, latitude, longitude, gravitational_potential
 
 abstract type Orientation
 end
@@ -48,6 +48,10 @@ function atmos_init_aux!(::SphericalOrientation, ::AtmosModel, aux::Vars, geom::
   aux.orientation.Φ = grav * (normcoord - planet_radius)
   aux.orientation.∇Φ = grav / normcoord .* aux.coord
 end
+# TODO: should we define these for non-spherical orientations?
+latitude(orientation::SphericalOrientation, aux::Vars) = @inbounds asin(aux.coord[3] / norm(aux.coord, 2))
+longitude(orientation::SphericalOrientation, aux::Vars) = @inbounds atan(aux.coord[2], aux.coord[1])
+
 
 """
     FlatOrientation <: Orientation

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -2,6 +2,7 @@ export PhasePartition
 # Thermodynamic states
 export ThermodynamicState,
        PhaseDry,
+       PhaseDry_given_pT,
        PhaseEquil,
        PhaseNonEquil,
        TemperatureSHumEquil,
@@ -107,6 +108,20 @@ struct PhaseDry{FT} <: ThermodynamicState{FT}
   e_int::FT
   "density of dry air"
   ρ::FT
+end
+
+"""
+    PhaseDry_given_pT(p, T)
+
+Constructs a [`PhaseDry`](@ref) thermodynamic state from:
+
+ - `p` pressure
+ - `T` temperature
+"""
+function PhaseDry_given_pT(p::FT, T::FT) where {FT<:Real}
+  e_int = internal_energy(T)
+  ρ = air_density(T, p)
+  return PhaseDry{FT}(e_int, ρ)
 end
 
 """

--- a/test/Common/MoistThermodynamics/runtests.jl
+++ b/test/Common/MoistThermodynamics/runtests.jl
@@ -240,6 +240,10 @@ end
     @test all(internal_energy.(ts) .≈ e_int)
     @test all(air_density.(ts) .≈ ρ)
 
+    ts = PhaseDry_given_pT.(p, T)
+    @test all(internal_energy.(ts) .≈ internal_energy.(T))
+    @test all(air_density.(ts) .≈ ρ)
+
     # PhaseEquil
     ts = PhaseEquil.(e_int, ρ, q_tot, 30, FT(1e-1), Ref(MT.saturation_adjustment_SecantMethod))
     @test all(internal_energy.(ts) .≈ e_int)
@@ -325,6 +329,7 @@ end
   @test typeof.(internal_energy.(ρ, ρ.*e_int, Ref(ρu), Ref(e_pot))) == typeof.(e_int)
 
   ts_dry             = PhaseDry.(e_int, ρ)
+  ts_dry_pT          = PhaseDry_given_pT.(p, T)
   ts_eq              = PhaseEquil.(e_int, ρ, q_tot, 15, FT(1e-1))
   ts_T               = TemperatureSHumEquil.(air_temperature.(ts_dry), air_pressure.(ts_dry), q_tot)
   ts_neq             = PhaseNonEquil.(e_int, ρ, q_pt)
@@ -336,6 +341,7 @@ end
   for ts in (
     ts_eq,
     ts_dry,
+    ts_dry_pT,
     ts_T,
     ts_neq,
     ts_θ_liq_ice_eq,

--- a/test/DGmethods/Euler/acousticwave-1d-imex.jl
+++ b/test/DGmethods/Euler/acousticwave-1d-imex.jl
@@ -11,13 +11,14 @@ using CLIMA.ColumnwiseLUSolver: ManyColumnLU
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.PlanetParameters: planet_radius, day
-using CLIMA.MoistThermodynamics: air_density, soundspeed_air, internal_energy
+using CLIMA.MoistThermodynamics: air_density, soundspeed_air, internal_energy, PhaseDry_given_pT, PhasePartition
 using CLIMA.Atmos: AtmosModel, SphericalOrientation,
                    DryModel, NoPrecipitation, NoRadiation, NoFluxBC,
                    ConstantViscosityWithDivergence,
                    vars_state, vars_aux,
                    Gravity, HydrostaticState, IsothermalProfile,
-                   AtmosAcousticGravityLinearModel, AtmosLESConfiguration
+                   AtmosAcousticGravityLinearModel, AtmosLESConfiguration,
+                   altitude, latitude, longitude, gravitational_potential
 using CLIMA.VariableTemplates: flattenednames
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
@@ -184,20 +185,24 @@ function (setup::AcousticWaveSetup)(bl, state, aux, coords, t)
   # callable to set initial conditions
   FT = eltype(state)
 
-  r = norm(coords, 2)
-  @inbounds λ = atan(coords[2], coords[1])
-  @inbounds φ = asin(coords[3] / r)
-  h = r - FT(planet_radius)
+  λ = longitude(bl.orientation, aux)
+  φ = latitude(bl.orientation, aux)
+  z = altitude(bl.orientation, aux)
 
   β = min(FT(1), setup.α * acos(cos(φ) * cos(λ)))
   f = (1 + cos(FT(π) * β)) / 2
-  g = sin(setup.nv * FT(π) * h / setup.domain_height)
+  g = sin(setup.nv * FT(π) * z / setup.domain_height)
   Δp = setup.γ * f * g
   p = aux.ref_state.p + Δp
 
-  state.ρ = air_density(setup.T_ref, p)
+  ts       = PhaseDry_given_pT(p, setup.T_ref)
+  q_pt     = PhasePartition(ts)
+  e_pot    = gravitational_potential(bl.orientation, aux)
+  e_int    = internal_energy(ts)
+
+  state.ρ  = air_density(ts)
   state.ρu = SVector{3, FT}(0, 0, 0)
-  state.ρe = state.ρ * (internal_energy(setup.T_ref) + aux.orientation.Φ)
+  state.ρe = state.ρ * (e_int + e_pot)
   nothing
 end
 

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -10,7 +10,7 @@ using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
 using CLIMA.PlanetParameters: kappa_d
-using CLIMA.MoistThermodynamics: air_density, total_energy, soundspeed_air
+using CLIMA.MoistThermodynamics: air_density, total_energy, soundspeed_air, PhaseDry_given_pT
 using CLIMA.Atmos: AtmosModel, NoOrientation, NoReferenceState,
                    DryModel, NoPrecipitation, NoRadiation, PeriodicBC,
                    ConstantViscosityWithDivergence, vars_state,
@@ -264,12 +264,14 @@ function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
   T = T∞ * (1 - kappa_d * vortex_speed ^ 2 / 2 * ρ∞ / p∞ * exp(-(r / R) ^ 2))
   # adiabatic/isentropic relation
   p = p∞ * (T / T∞) ^ (FT(1) / kappa_d)
-  ρ = air_density(T, p)
+  ts = PhaseDry_given_pT(p, T)
+  ρ = air_density(ts)
 
+  e_pot = FT(0)
   state.ρ = ρ
   state.ρu = ρ * u
   e_kin = u' * u / 2
-  state.ρe = ρ * total_energy(e_kin, FT(0), T)
+  state.ρe = ρ * total_energy(e_kin, e_pot, ts)
 end
 
 function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname = "isentropicvortex")

--- a/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current-model.jl
@@ -79,18 +79,19 @@ function Initialise_Density_Current!(bl, state::Vars, aux::Vars, (x1,x2,x3), t)
   π_exner           = FT(1) - grav / (c_p * θ) * x3 # exner pressure
   ρ                 = p0 / (R_gas * θ) * (π_exner)^ (c_v / R_gas) # density
 
-  P                 = p0 * (R_gas * (ρ * θ) / p0) ^(c_p/c_v) # pressure (absolute)
-  T                 = P / (ρ * R_gas) # temperature
+  ts                = LiquidIcePotTempSHumEquil(θ, ρ, q_tot)
+  q_pt              = PhasePartition(ts)
+
   U, V, W           = FT(0) , FT(0) , FT(0)  # momentum components
   # energy definitions
   e_kin             = (U^2 + V^2 + W^2) / (2*ρ)/ ρ
-  e_pot             = grav * x3
-  e_int             = internal_energy(T, qvar)
+  e_pot             = gravitational_potential(bl.orientation, aux)
+  e_int             = internal_energy(ts)
   E                 = ρ * (e_int + e_kin + e_pot)  #* total_energy(e_kin, e_pot, T, q_tot, q_liq, q_ice)
   state.ρ      = ρ
   state.ρu     = SVector(U, V, W)
   state.ρe     = E
-  state.moisture.ρq_tot = FT(0)
+  state.moisture.ρq_tot = ρ*q_pt.tot
 end
 # --------------- Driver definition ------------------ #
 function run(mpicomm, ArrayType,


### PR DESCRIPTION
Now that the `init_state` methods are aware of the balance law, we should utilize the following methods in the `init_state` methods:

 - `altitude`
 - `gravitational_potential`
 - `internal_energy(::ThermodynamicState)`
 - `total_energy(..., ::ThermodynamicState)`

Since several `DryPhase` models use `p` and `T` for initialization, I've also added a constructor to moist thermo that accepts these args:
 - Adds a `PhaseDry_given_pT` constructor in moist thermo.
I’ve also added 
 - A `latitude` function for `SphericalOrientation`
 - A `longitude` function for `SphericalOrientation`
