### PR TITLE
Replace 'M' and 'P' with '⁻' and '+'

### DIFF
--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -72,7 +72,7 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment=false)
     @launch(device, threads=Nfp, blocks=nrealelem,
             faceviscterms!(bl, Val(dim), Val(N), dg.direction,
                            dg.gradnumflux, Q.data, Qvisc.data, auxstate.data,
-                           grid.vgeo, grid.sgeo, t, grid.vmapM, grid.vmapP, grid.elemtobndy,
+                           grid.vgeo, grid.sgeo, t, grid.vmap⁻, grid.vmap⁺, grid.elemtobndy,
                            topology.realelems))
 
     if communicate
@@ -115,7 +115,7 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment=false)
                    dg.numfluxnondiff,
                    dg.numfluxdiff,
                    dQdt.data, Q.data, Qvisc.data,
-                   auxstate.data, grid.vgeo, grid.sgeo, t, grid.vmapM, grid.vmapP, grid.elemtobndy,
+                   auxstate.data, grid.vgeo, grid.sgeo, t, grid.vmap⁻, grid.vmap⁺, grid.elemtobndy,
                    topology.realelems))
 
   # Just to be safe, we wait on the sends we started.

--- a/src/DGmethods/NumericalFluxes.jl
+++ b/src/DGmethods/NumericalFluxes.jl
@@ -18,10 +18,10 @@ import ..DGmethods: BalanceLaw, Grad, Vars, vars_state, vars_diffusive,
 
 Any `P <: NumericalFluxGradient` should define methods for:
 
-   numerical_flux_gradient!(gnf::P, bl::BalanceLaw, diffF, nM, QM, QdiffM, QauxM, QP,
-                            QdiffP, QauxP, t)
-   numerical_boundary_flux_gradient!(gnf::P, bl::BalanceLaw, l_Qvisc, nM, l_GM, l_QM,
-                                     l_auxM, l_GP, l_QP, l_auxP, bctype, t)
+   numerical_flux_gradient!(gnf::P, bl::BalanceLaw, diffF, n⁻, Q⁻, Qdiff⁻, Qaux⁻, Q⁺,
+                            Qdiff⁺, Qaux⁺, t)
+   numerical_boundary_flux_gradient!(gnf::P, bl::BalanceLaw, l_Qvisc, n⁻, l_G⁻, l_Q⁻,
+                                     l_aux⁻, l_G⁺, l_Q⁺, l_aux⁺, bctype, t)
 
 """
 abstract type NumericalFluxGradient end
@@ -68,19 +68,19 @@ end
 
 Any `N <: NumericalFluxNonDiffusive` should define the a method for
 
-    numerical_flux_nondiffusive!(nf::N, bl::BalanceLaw, F, nM, QM, QauxM, QP,
-                                 QauxP, t)
+    numerical_flux_nondiffusive!(nf::N, bl::BalanceLaw, F, n⁻, Q⁻, Qaux⁻, Q⁺,
+                                 Qaux⁺, t)
 
 where
 - `F` is the numerical flux array
-- `nM` is the unit normal
-- `QM`/`QP` are the minus/positive state arrays
+- `n⁻` is the unit normal
+- `Q⁻`/`Q⁺` are the minus/positive state arrays
 - `t` is the time
 
 An optional method can also be defined for
 
-    numerical_boundary_flux_nondiffusive!(nf::N, bl::BalanceLaw, F, nM, QM,
-                                          QauxM, QP, QauxP, bctype, t)
+    numerical_boundary_flux_nondiffusive!(nf::N, bl::BalanceLaw, F, n⁻, Q⁻,
+                                          Qaux⁻, Q⁺, Qaux⁺, bctype, t)
 
 """
 abstract type NumericalFluxNonDiffusive end
@@ -171,21 +171,21 @@ end
 
 Any `N <: NumericalFluxDiffusive` should define the a method for
 
-    numerical_flux_diffusive!(nf::N, bl::BalanceLaw, F, nM, QM, QdiffM, QauxM, QP,
-                              QdiffP, QauxP, t)
+    numerical_flux_diffusive!(nf::N, bl::BalanceLaw, F, n⁻, Q⁻, Qdiff⁻, Qaux⁻, Q⁺,
+                              Qdiff⁺, Qaux⁺, t)
 
 where
 - `F` is the numerical flux array
-- `nM` is the unit normal
-- `QM`/`QP` are the minus/positive state arrays
-- `QdiffM`/`QdiffP` are the minus/positive diffusive state arrays
-- `QdiffM`/`QdiffP` are the minus/positive auxiliary state arrays
+- `n⁻` is the unit normal
+- `Q⁻`/`Q⁺` are the minus/positive state arrays
+- `Qdiff⁻`/`Qdiff⁺` are the minus/positive diffusive state arrays
+- `Qdiff⁻`/`Qdiff⁺` are the minus/positive auxiliary state arrays
 - `t` is the time
 
 An optional method can also be defined for
 
-    numerical_boundary_flux_diffusive!(nf::N, bl::BalanceLaw, F, nM, QM, QdiffM,
-                                       QauxM, QP, QdiffP, QauxP, bctype, t)
+    numerical_boundary_flux_diffusive!(nf::N, bl::BalanceLaw, F, n⁻, Q⁻, Qdiff⁻,
+                                       Qaux⁻, Q⁺, Qdiff⁺, Qaux⁺, bctype, t)
 
 """
 abstract type NumericalFluxDiffusive end

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -20,10 +20,10 @@ Subtypes `L` should define the following methods:
 - `gradvariables!(::L, transformstate::State, state::State, auxstate::State, t::Real)`
 - `diffusive!(::L, diffstate::State, ∇transform::Grad, auxstate::State, t::Real)`
 - `source!(::L, source::State, state::State, diffusive::Vars, auxstate::State, t::Real)`
-- `wavespeed(::L, nM, state::State, aux::State, t::Real)`
-- `boundary_state!(::NumericalFluxGradient, ::L, stateP::State, auxP::State, normalM, stateM::State, auxM::State, bctype, t)`
-- `boundary_state!(::NumericalFluxNonDiffusive, ::L, stateP::State, auxP::State, normalM, stateM::State, auxM::State, bctype, t)`
-- `boundary_state!(::NumericalFluxDiffusive, ::L, stateP::State, diffP::State, auxP::State, normalM, stateM::State, diffM::State, auxM::State, bctype, t)`
+- `wavespeed(::L, n⁻, state::State, aux::State, t::Real)`
+- `boundary_state!(::NumericalFluxGradient, ::L, state⁺::State, aux⁺::State, normal⁻, state⁻::State, aux⁻::State, bctype, t)`
+- `boundary_state!(::NumericalFluxNonDiffusive, ::L, state⁺::State, aux⁺::State, normal⁻, state⁻::State, aux⁻::State, bctype, t)`
+- `boundary_state!(::NumericalFluxDiffusive, ::L, state⁺::State, diff⁺::State, aux⁺::State, normal⁻, state⁻::State, diff⁻::State, aux⁻::State, bctype, t)`
 - `init_aux!(::L, aux::State, coords, args...)`
 - `init_state!(::L, state::State, aux::State, coords, args...)`
 

--- a/src/DGmethods_old/DGBalanceLawDiscretizations.jl
+++ b/src/DGmethods_old/DGBalanceLawDiscretizations.jl
@@ -206,7 +206,7 @@ where
    `grid.elemtobndy`
 - `t` is the current simulation time
 Note: `QP` and `auxP` are filled with values based on degrees of freedom
-referenced in `grid.vmapP`; `QP` and `auxP` may be modified by the calling
+referenced in `grid.vmap⁺`; `QP` and `auxP` may be modified by the calling
 function.
 
 Warning: Modifications to `nM`, `QM`, or `auxM` may cause side effects and
@@ -565,8 +565,8 @@ function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
   Dmat = grid.D
   vgeo = grid.vgeo
   sgeo = grid.sgeo
-  vmapM = grid.vmapM
-  vmapP = grid.vmapP
+  vmap⁻ = grid.vmap⁻
+  vmap⁺ = grid.vmap⁺
   elemtobndy = grid.elemtobndy
 
   ################################
@@ -596,7 +596,7 @@ function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
                            disc.viscous_penalty!,
                            disc.viscous_boundary_penalty!,
                            disc.gradient_transform!, Q.data, Qvisc.data, auxstate.data,
-                           vgeo, sgeo, t, vmapM, vmapP, elemtobndy,
+                           vgeo, sgeo, t, vmap⁻, vmap⁺, elemtobndy,
                            topology.realelems))
 
     MPIStateArrays.start_ghost_exchange!(Qvisc)
@@ -623,7 +623,7 @@ function SpaceMethods.odefun!(disc::DGBalanceLaw, dQ::MPIStateArray,
           facerhs!(Val(dim), Val(N), Val(nstate), Val(nviscstate),
                    Val(nauxstate), disc.numerical_flux!,
                    disc.numerical_boundary_flux!, dQ.data, Q.data, Qvisc.data,
-                   auxstate.data, vgeo, sgeo, t, vmapM, vmapP, elemtobndy,
+                   auxstate.data, vgeo, sgeo, t, vmap⁻, vmap⁺, elemtobndy,
                    topology.realelems))
 
   # Just to be safe, we wait on the sends we started.

--- a/src/DGmethods_old/DGBalanceLawDiscretizations_kernels.jl
+++ b/src/DGmethods_old/DGBalanceLawDiscretizations_kernels.jl
@@ -217,7 +217,7 @@ end
     facerhs!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{nviscstate},
              ::Val{nauxstate}, numerical_flux!,
              numerical_boundary_flux!, rhs, Q, Qvisc, auxstate,
-             vgeo, sgeo, t, vmapM, vmapP, elemtobndy,
+             vgeo, sgeo, t, vmap⁻, vmap⁺, elemtobndy,
              elems) where {dim, N, nstate, nviscstate, nauxstate}
 
 Computational kernel: Evaluate the surface integrals on right-hand side of a
@@ -227,7 +227,7 @@ See [`odefun!`](@ref) for usage.
 """
 function facerhs!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{nviscstate},
                   ::Val{nauxstate}, numerical_flux!, numerical_boundary_flux!,
-                  rhs, Q, Qvisc, auxstate, vgeo, sgeo, t, vmapM, vmapP,
+                  rhs, Q, Qvisc, auxstate, vgeo, sgeo, t, vmap⁻, vmap⁺,
                   elemtobndy, elems) where {dim, N, nstate, nviscstate,
                                             nauxstate}
 
@@ -262,7 +262,7 @@ function facerhs!(::Val{dim}, ::Val{N}, ::Val{nstate}, ::Val{nviscstate},
       @loop for n in (1:Nfp; threadIdx().x)
         nM = (sgeo[_n1, n, f, e], sgeo[_n2, n, f, e], sgeo[_n3, n, f, e])
         sM, vMI = sgeo[_sM, n, f, e], sgeo[_vMI, n, f, e]
-        idM, idP = vmapM[n, f, e], vmapP[n, f, e]
+        idM, idP = vmap⁻[n, f, e], vmap⁺[n, f, e]
 
         eM, eP = e, ((idP - 1) ÷ Np) + 1
         vidM, vidP = ((idM - 1) % Np) + 1,  ((idP - 1) % Np) + 1
@@ -410,7 +410,7 @@ function faceviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate},
                         ::Val{ngradstate}, ::Val{nviscstate},
                         ::Val{nauxstate}, viscous_penalty!,
                         viscous_boundary_penalty!, gradient_transform!,
-                        Q, Qvisc, auxstate, vgeo, sgeo, t, vmapM, vmapP,
+                        Q, Qvisc, auxstate, vgeo, sgeo, t, vmap⁻, vmap⁺,
                         elemtobndy, elems) where {dim, N, ngradstate,
                                                   nviscstate, nstate, nauxstate}
   FT = eltype(Q)
@@ -444,7 +444,7 @@ function faceviscterms!(::Val{dim}, ::Val{N}, ::Val{nstate},
       @loop for n in (1:Nfp; threadIdx().x)
         nM = (sgeo[_n1, n, f, e], sgeo[_n2, n, f, e], sgeo[_n3, n, f, e])
         sM, vMI = sgeo[_sM, n, f, e], sgeo[_vMI, n, f, e]
-        idM, idP = vmapM[n, f, e], vmapP[n, f, e]
+        idM, idP = vmap⁻[n, f, e], vmap⁺[n, f, e]
 
         eM, eP = e, ((idP - 1) ÷ Np) + 1
         vidM, vidP = ((idM - 1) % Np) + 1,  ((idP - 1) % Np) + 1

--- a/src/Mesh/BrickMesh.jl
+++ b/src/Mesh/BrickMesh.jl
@@ -1025,12 +1025,12 @@ This function takes in a polynomial order `N` and parts of a mesh (as returned
 from `connectmesh`) and returns index mappings for the element surface flux
 computation.  The returned `Tuple` contains:
 
- - `vmapM` an array of linear indices into the volume degrees of freedom where
-   `vmapM[:,f,e]` are the degrees of freedom indices for face `f` of element
+ - `vmap⁻` an array of linear indices into the volume degrees of freedom where
+   `vmap⁻[:,f,e]` are the degrees of freedom indices for face `f` of element
     `e`.
 
- - `vmapP` an array of linear indices into the volume degrees of freedom where
-   `vmapP[:,f,e]` are the degrees of freedom indices for the face neighboring
+ - `vmap⁺` an array of linear indices into the volume degrees of freedom where
+   `vmap⁺[:,f,e]` are the degrees of freedom indices for the face neighboring
    face `f` of element `e`.
 """
 function mappings(N, elemtoelem, elemtoface, elemtoordr)
@@ -1045,8 +1045,8 @@ function mappings(N, elemtoelem, elemtoface, elemtoordr)
   fmask = hcat((p[ntuple(j->(j==fd(f)) ? (fe(f):fe(f)) : (:), d)...][:]
                 for f=1:nface)...)
 
-  vmapM = similar(elemtoelem, Nfp, nface, nelem)
-  vmapP = similar(elemtoelem, Nfp, nface, nelem)
+  vmap⁻ = similar(elemtoelem, Nfp, nface, nelem)
+  vmap⁺ = similar(elemtoelem, Nfp, nface, nelem)
 
   for e1 = 1:nelem, f1 = 1:nface
     e2 = elemtoelem[f1,e1]
@@ -1056,11 +1056,11 @@ function mappings(N, elemtoelem, elemtoface, elemtoordr)
     # TODO support different orientations
     @assert o2 == 1
 
-    vmapM[:,f1,e1] .= Np*(e1-1) .+ fmask[:,f1]
-    vmapP[:,f1,e1] .= Np*(e2-1) .+ fmask[:,f2]
+    vmap⁻[:,f1,e1] .= Np*(e1-1) .+ fmask[:,f1]
+    vmap⁺[:,f1,e1] .= Np*(e2-1) .+ fmask[:,f2]
   end
 
-  (vmapM, vmapP)
+  (vmap⁻, vmap⁺)
 end
 
 """

--- a/test/Mesh/BrickMesh.jl
+++ b/test/Mesh/BrickMesh.jl
@@ -352,11 +352,11 @@ end
     nface = 2d
     Nfp = (N+1)^(d-1)
 
-    vmapM, vmapP = mappings(N, mesh[:elemtoelem], mesh[:elemtoface],
+    vmap⁻, vmap⁺ = mappings(N, mesh[:elemtoelem], mesh[:elemtoface],
                             mesh[:elemtoordr])
 
-    @test vmapM == reshape([1,4,5,8,9,12,13,16], Nfp, nface, nelem)
-    @test vmapP == reshape([16,5,4,9,8,13,12,1], Nfp, nface, nelem)
+    @test vmap⁻ == reshape([1,4,5,8,9,12,13,16], Nfp, nface, nelem)
+    @test vmap⁺ == reshape([16,5,4,9,8,13,12,1], Nfp, nface, nelem)
   end
 
   let
@@ -371,10 +371,10 @@ end
     nface = 2d
     Nfp = (N+1)^(d-1)
 
-    vmapM, vmapP = mappings(N, mesh[:elemtoelem], mesh[:elemtoface],
+    vmap⁻, vmap⁺ = mappings(N, mesh[:elemtoelem], mesh[:elemtoface],
                             mesh[:elemtoordr])
 
-    @test vmapM == reshape([ 1, 4, 7,  # f=1 e=1
+    @test vmap⁻ == reshape([ 1, 4, 7,  # f=1 e=1
                              3, 6, 9,  # f=2 e=1
                              1, 2, 3,  # f=3 e=1
                              7, 8, 9,  # f=4 e=1
@@ -384,7 +384,7 @@ end
                             16,17,18], # f=4 e=2
                            Nfp, nface, nelem)
 
-    @test vmapP == reshape([ 1, 4, 7,  # f=1 e=1
+    @test vmap⁺ == reshape([ 1, 4, 7,  # f=1 e=1
                             10,13,16,  # f=1 e=2
                              7, 8, 9,  # f=4 e=1
                              1, 2, 3,  # f=3 e=1
@@ -408,7 +408,7 @@ end
     Np = (N+1)^d
     Nfp = (N+1)^(d-1)
 
-    vmapM, vmapP = mappings(N, mesh[:elemtoelem], mesh[:elemtoface],
+    vmap⁻, vmap⁺ = mappings(N, mesh[:elemtoelem], mesh[:elemtoface],
                             mesh[:elemtoordr])
 
     fmask = [ 1  3  1  7 1 19
@@ -422,10 +422,10 @@ end
              25 27 21 27 9 27]
 
 
-    @test vmapM == reshape([fmask[:]; fmask[:].+Np],
+    @test vmap⁻ == reshape([fmask[:]; fmask[:].+Np],
                            Nfp, nface, nelem)
 
-    @test vmapP == reshape([fmask[:,1];
+    @test vmap⁺ == reshape([fmask[:,1];
                             fmask[:,2];
                             fmask[:,4];
                             fmask[:,3];

--- a/test/Mesh/mpi_connect_sphere.jl
+++ b/test/Mesh/mpi_connect_sphere.jl
@@ -44,9 +44,9 @@ function main()
   x2 = @view grid.vgeo[:, Grids._x2, :]
   x3 = @view grid.vgeo[:, Grids._x3, :]
 
-  @test x1[grid.vmapM] ≈ x1[grid.vmapP]
-  @test x2[grid.vmapM] ≈ x2[grid.vmapP]
-  @test x3[grid.vmapM] ≈ x3[grid.vmapP]
+  @test x1[grid.vmap⁻] ≈ x1[grid.vmap⁺]
+  @test x2[grid.vmap⁻] ≈ x2[grid.vmap⁺]
+  @test x3[grid.vmap⁻] ≈ x3[grid.vmap⁺]
 
   Np = (N+1)^3
   x1x2x3 = MPIStateArray{FT}(topology.mpicomm, DA, Np, 3,
@@ -68,9 +68,9 @@ function main()
   x2 = @view x1x2x3.data[:, 2, :]
   x3 = @view x1x2x3.data[:, 3, :]
 
-  @test x1[grid.vmapM] ≈ x1[grid.vmapP]
-  @test x2[grid.vmapM] ≈ x2[grid.vmapP]
-  @test x3[grid.vmapM] ≈ x3[grid.vmapP]
+  @test x1[grid.vmap⁻] ≈ x1[grid.vmap⁺]
+  @test x2[grid.vmap⁻] ≈ x2[grid.vmap⁺]
+  @test x3[grid.vmap⁻] ≈ x3[grid.vmap⁺]
 
   nothing
 end


### PR DESCRIPTION
Marking things that come from the interior/minus side and exterior/plus side with minus/plus signs instead of M/P. 

This should make the variable names easier to read and make their intent clearer. 

This PR only affects the DG Kernels.