### PR TITLE
Fixing runtests for systems with OpenMPI and less than 5 physical cores

### DIFF
--- a/test/testhelpers.jl
+++ b/test/testhelpers.jl
@@ -18,8 +18,14 @@ function runmpi(tests, file)
   coverage_opt = coverage_opts[Base.JLOptions().code_coverage]
   testdir = dirname(file)
 
+  if !Sys.iswindows() && occursin( "OpenRTE", read(`mpiexec --version`, String))
+    oversubscribe = `--oversubscribe`
+  else
+    oversubscribe = ``
+  end
+
   for (n, f) in tests
-    cmd = `mpiexec --oversubscribe -n $n $(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) --code-coverage=$coverage_opt $(joinpath(testdir, f))`
+    cmd = `mpiexec $oversubscribe -n $n $(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) --code-coverage=$coverage_opt $(joinpath(testdir, f))`
 
     @info "Running MPI test..." n f cmd
     # Running this way prevents:

--- a/test/testhelpers.jl
+++ b/test/testhelpers.jl
@@ -18,14 +18,8 @@ function runmpi(tests, file)
   coverage_opt = coverage_opts[Base.JLOptions().code_coverage]
   testdir = dirname(file)
 
-  if haskey(ENV, "SLURM_JOB_ID")
-    oversubscribe = `--oversubscribe`
-  else
-    oversubscribe = ``
-  end
-
   for (n, f) in tests
-    cmd = `mpiexec $oversubscribe -n $n $(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) --code-coverage=$coverage_opt $(joinpath(testdir, f))`
+    cmd = `mpiexec --oversubscribe -n $n $(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) --code-coverage=$coverage_opt $(joinpath(testdir, f))`
 
     @info "Running MPI test..." n f cmd
     # Running this way prevents:


### PR DESCRIPTION
# Fixing CLIMA tests for systems with low processor number

CLIMA tests fail on systems with fewer processors without the `--oversubscribe` option. We could add another exception for these cases or make the `--oversubscribe` option default.

## Description

The following error will appear on systems with fewer processors:

```
--------------------------------------------------------------------------
There are not enough slots available in the system to satisfy the 4
slots that were requested by the application:

  /usr/bin/julia

Either request fewer slots for your application, or make more slots
available for use.

A "slot" is the Open MPI term for an allocatable unit where we can
launch a process.  The number of slots available are defined by the
environment in which Open MPI processes are run:

  1. Hostfile, via "slots=N" clauses (N defaults to number of
     processor cores if not provided)
  2. The --host command line parameter, via a ":N" suffix on the
     hostname (N defaults to 1 if not provided)
  3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
  4. If none of a hostfile, the --host command line parameter, or an
     RM is present, Open MPI defaults to the number of processor cores

In all the above cases, if you want Open MPI to default to the number
of hardware threads instead of the number of processor cores, use the
--use-hwthread-cpus option.

Alternatively, you can use the --oversubscribe option to ignore the
number of available slots when deciding the number of processes to
launch.
--------------------------------------------------------------------------
```

<!--- Please leave the following section --->

## For review by CLIMA Developers

- [x] There are no open PR's for this already
- [ ] The code conforms to the [style guidelines](We should have this) and has consistent naming conventions
- [ ] This code does what it is technically intended to do (All numerics make sense either physically or computationally)