### PR TITLE
Remove some random perturbations for DYCOMS

### DIFF
--- a/experiments/Atmos_LES/dycoms.jl
+++ b/experiments/Atmos_LES/dycoms.jl
@@ -267,14 +267,8 @@ function init_dycoms!(bl, state, aux, (x,y,z), t)
 
     # Perturb initial state to break symmetry and trigger turbulent convection
     r1 = FT(rand(Uniform(-0.002, 0.002)))
-    r2 = FT(rand(Uniform(-0.00001, 0.00001)))
-    r3 = FT(rand(Uniform(-0.001, 0.001)))
-    r4 = FT(rand(Uniform(-0.001, 0.001)))
-    if z <= 400.0
+    if z <= 200.0
         θ_liq += r1 * θ_liq
-        q_tot += r2 * q_tot
-        u     += r3 * u
-        v     += r4 * v
     end
 
     # Pressure


### PR DESCRIPTION
# Description

This removes some of the random perturbations that were being applied to the initial state of DYCOMS, leaving behind only one for `θ_liq`.

Submitted on behalf of @smarras79.

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
