### PR TITLE
Allow calling DGmethods.courant with SolverConfiguration

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -203,6 +203,18 @@ struct SolverConfiguration{FT}
 end
 
 """
+    DGmethods.courant(local_cfl, solver_config::SolverConfiguration;
+                      Q=solver_config.Q, dt=solver_config.dt)
+
+Returns the maximum of the evaluation of the function `local_courant`
+pointwise throughout the domain with the model defined by `solver_config`. The
+keyword arguments `Q` and `dt` can be used to call the courant method with a
+different state `Q` or time step `dt` than are defined in `solver_config`.
+"""
+DGmethods.courant(f, sc::SolverConfiguration; Q=sc.Q, dt = sc.dt) =
+  DGmethods.courant(f, sc.dg, sc.dg.balancelaw, Q, dt)
+
+"""
     CLIMA.setup_solver(t0, timeend, driver_config)
 
 Set up the DG model per the specified driver configuration and set up the ODE solver.

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -71,9 +71,20 @@ function main()
     t0 = FT(0)
     timeend = FT(10)
 
+    CFL = FT(0.4)
+
     driver_config = CLIMA.Atmos_LES_Configuration("Driver test", N, resolution,
                                                   xmax, ymax, zmax, init_test!)
-    solver_config = CLIMA.setup_solver(t0, timeend, driver_config)
+    solver_config = CLIMA.setup_solver(t0, timeend, driver_config,
+                                       Courant_number = CFL)
+
+
+    # Test the courant wrapper
+    CFL_nondiff = CLIMA.DGmethods.courant(CLIMA.Courant.nondiffusive_courant,
+                                          solver_config)
+    # Since the dt is computed before the initial condition, these might be
+    # difference by a fairly large factor
+    @test isapprox(CFL_nondiff, CFL, rtol=0.03)
 
     result = CLIMA.invoke!(solver_config)
 end

--- a/test/testhelpers.jl
+++ b/test/testhelpers.jl
@@ -3,7 +3,7 @@ using MPI
 function runmpi(tests, file)
   MPI.Initialized() && !MPI.Finalized() &&
   error("runmpi does not work if MPI has been "*
-        "Initialized but not Finalizd")
+        "Initialized but not Finalized")
 
   # The code below was modified from the MPI.jl file runtests.jl
   #


### PR DESCRIPTION
# Description

Add a convenience wrapper of `DGmethods.courant` to be called using an already defined `SolverConfiguration`. This allows the user to write
```julia
CLIMA.DGmethods.courant(CLIMA.Courant.nondiffusive_courant,
                        solver_config)

```
instead of 
```julia
CLIMA.DGmethods.courant(CLIMA.Courant.nondiffusive_courant,
                        solver_config.dg,
                        solver_config.dg.balancelaw,
                        solver_config.Q,
                        solver_config.dt)
```
# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
