### PR TITLE
Create JuliaFormatter GitHub Action

### DIFF
--- a/.dev/.gitignore
+++ b/.dev/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/.dev/Project.toml
+++ b/.dev/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+
+[compat]
+JuliaFormatter = "0.3"

--- a/.dev/format.jl
+++ b/.dev/format.jl
@@ -1,0 +1,25 @@
+#!/usr/bin/env julia
+
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+
+using JuliaFormatter
+
+headbranch = get(ARGS, 1, "master")
+
+for filename in
+    readlines(`git diff --name-only --diff-filter=AM $headbranch...`)
+    endswith(filename, ".jl") || continue
+
+    format(
+        filename,
+        verbose = true,
+        indent = 4,
+        margin = 80,
+        always_for_in = true,
+        whitespace_typedefs = true,
+        whitespace_ops_in_indices = true,
+        remove_extra_newlines = false,
+    )
+end

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,5 @@ A clear and concise description of the code with usage.
 
 - [ ] There are no open pull requests for this already
 - [ ] CLIMA developers with relevant expertise have been assigned to review this submission
-- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
+- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
 - [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -1,0 +1,21 @@
+name: JuliaFormatter
+
+on: [pull_request]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: git fetch origin
+    - uses: julia-actions/setup-julia@latest
+      with:
+        version: 1.3
+    - name: Apply JuliaFormatter
+      run: |
+        julia --project=.dev .dev/format.jl origin/master
+    - name: Check formatting diff
+      run: |
+        git diff --color=always --exit-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+CLIMA encourages Pull Requests (PRs) and contributions.
+The easiest way to contribute is by running code and letting us know what's wrong by creating issues.
+In the case that you can specifically pinpoint the issue within the code, please consider submitting a PR with these changes.
+
+To contribute, we assume that you already have a basic understanding of git and version control as all tools are accessible on Github; however, we will discuss the general workflow for submitting code for review to CLIMA.
+
+If you are unfamiliar with git and version control, please consider reading the following guides:
+
+- [Atlassian (bitbucket) git tutorials. A set of tips and tricks for getting started with git](https://www.atlassian.com/git/tutorials)
+- [Github's git tutorials. A set of resources from github to learn git](https://try.github.io/)
+
+There are a bunch of other guides available as well.
+We will try to guide you along the process here, but this is by no means an exhaustive set of everything you will need to know when using git and version control.
+
+## Forks and branches
+
+To start contributing, first create your own fork (version of CLIMA) [on GitHub](https://github.com/climate-machine/CLIMA) and check out your copy:
+
+```
+$ git clone https://github.com/<username>/CLIMA.git
+$ cd CLIMA
+$ git remote add upstream https://github.com/climate-machine/CLIMA.git
+```
+
+This will create two places for you to keep code, one called `origin`, which is your own fork and another called `upstream`, which is CLIMA's main repository.
+
+From there, it is important to create a *feature branch* for your project:
+
+```
+$ git checkout -b <branchname>
+```
+Creating a feature branch allows you to more easily reconcile your code with the master branch on CLIMA.
+
+### Basic git interactions
+
+Firstly, make sure git knows your name and email address:
+
+```
+$ git config --global user.name "A. Climate Developer"
+$ git config --global user.email "j.climate.developer@eg.com"
+```
+
+From there, we need to begin saving different versions of code.
+This is done by creating `commits`, which are save states for all code within the git repository.
+The basic workflow for creating changes to CLIMA is the following:
+
+1. `git status` will show you any changes in your current code from the last commit
+2. `git add <FILE>` will add any files you want to commit into a staging area
+3. `git commit` will store any staged files into a commit.
+4. `git push origin <branchname>` will then push all the changes to `origin`, which is a nickname for your fork on github.
+5. When you are happy with all the code on your branch, go to github and click the button to create a pull request with all the changes against CLIMA's master branch.
+
+### Squash and Rebase
+
+Before merging with CLIMA, use `git rebase` (not `git merge`) to sync your work  with the current master.
+
+```
+$ git fetch upstream
+$ git rebase upstream/master
+```
+
+Once the PR is ready for review (or in the process of review), be sure to [squash your commits](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes).
+This will help us keep the commit history clean on the master branch of CLIMA.
+
+## Formatting and style
+
+For the most part, we follow the [YASGuide](https://github.com/jrevels/YASGuide) for Julia formatting, with small exceptions covered in the [Coding Conventions](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) section of the documentation.
+
+In addition to this, once you are happy with your PR, please apply [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) to all changed files in the repository.
+
+To apply our formatter settings to all changed files, run:
+```
+julia .dev/format.jl
+```
+
+Formatting changes should be done as a separate commit, ideally the last commit of the pull request (you may want to leave it until all other changes have been approved).
+
+## Bors and CI
+
+All commits that end up in the CLIMA repository must pass Continuous Integration (CI).
+When a PR is updated, it will automatically be run on Microsoft Azure for Linux, Windows, and MacOS; however, because CLIMA is heterogeneous and must also run on GPU hardware, we also manually launch CI with Bors.
+
+To test to see if all bors CI will pass, please type `bors try` in a separate comment in the PR.
+After this, if you are a collaborator you can merge the commit with `bors merge`.
+If you are a collaborator and want to test and merge in the same step, use `bors r+`.
+
+### Tests
+
+Most PRs should include tests and these will be reviewed as part of the code review process on github.
+Add your tests in the `test/` directory.


### PR DESCRIPTION
# Description

On each PR, this will run the JuliaFormatter.jl on all modified .jl files, failing if the formatting modifies any of the files.

I originally tried using https://github.com/julia-actions/julia-format, but it wasn't really sufficient for our needs, so it made more sense to use a custom workflow.

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
