### PR TITLE
Allow driver to add to the cbinfo invoke! callback

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -287,7 +287,8 @@ Run the simulation.
 function invoke!(solver_config::SolverConfiguration;
                  user_callbacks=(),
                  check_euclidean_distance=false,
-                 adjustfinalstep=false
+                 adjustfinalstep=false,
+                 user_info_callback=(init)->nothing
                 )
     mpicomm = solver_config.mpicomm
     dg = solver_config.dg
@@ -320,7 +321,7 @@ function invoke!(solver_config::SolverConfiguration;
                                runtime,
                                energy)
             end
-            nothing
+            user_info_callback(init)
         end
         callbacks = (callbacks..., cbinfo)
     end

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -280,9 +280,32 @@ function setup_solver(t0::FT, timeend::FT,
 end
 
 """
-    CLIMA.invoke!(solver_config)
+    CLIMA.invoke!(solver_config::SolverConfiguration;
+                  user_callbacks=(),
+                  check_euclidean_distance=false,
+                  adjustfinalstep=false
+                  user_info_callback=(init)->nothing)
 
-Run the simulation.
+Run the simulation defined by the `solver_config`.
+
+Keyword Arguments:
+
+The `user_callbacks` are passed to the ODE solver as callback functions; see
+[`ODESolvers.solve!]@ref().
+
+If `check_euclidean_distance` is `true, then the Euclidean distance between the
+final solution and initial condition function evaluated with
+`solver_config.timeend` is reported.
+
+The value of 'adjustfinalstep` is passed to the ODE solver; see
+[`ODESolvers.solve!]@ref().
+
+The function `user_info_callback` is called after the default info callback
+(which is called every `Settings.update_interval` seconds of wallclock time).
+The single input argument `init` is `true` when the callback is called
+called for initialization before time stepping begins and `false` when called
+during the actual ODE solve; see [`GenericCallbacks`](@ref) and
+[`ODESolvers.solve!]@ref().
 """
 function invoke!(solver_config::SolverConfiguration;
                  user_callbacks=(),

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -75,7 +75,14 @@ function main()
                                                   xmax, ymax, zmax, init_test!)
     solver_config = CLIMA.setup_solver(t0, timeend, driver_config)
 
+    cb_test = 0
     result = CLIMA.invoke!(solver_config)
+    # cb_test should be zero since user_info_callback not specified
+    @test cb_test == 0
+
+    result = CLIMA.invoke!(solver_config, user_info_callback=(init)->cb_test+=1)
+    # cb_test should be greater than one if the user_info_callback got called
+    @test cb_test > 0
 end
 
 main()


### PR DESCRIPTION
# Description

It is likely convenient to allow the driver to inject extra output into the `cbinfo` callback (for instance to write out the current CFL numbers)

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
