### PR TITLE
Unroll loop over sources

### DIFF
--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -9,8 +9,12 @@ end
 function atmos_source!(::Nothing, atmos::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real)
 end
 # sources are applied additively
-function atmos_source!(stuple::Tuple, atmos::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real)
-  map(s -> atmos_source!(s, atmos, source, state, diffusive, aux, t), stuple)
+@generated function atmos_source!(stuple::Tuple, atmos::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+  N = fieldcount(stuple)
+  return quote
+    Base.Cartesian.@nexprs $N i -> atmos_source!(stuple[i], atmos, source, state, diffusive, aux, t)
+    return nothing
+  end
 end
 
 abstract type Source


### PR DESCRIPTION
# Description

Using `map` seemed to cause problems for > 4 sources.

This manually unrolls the loop using the `@nexprs` macro.

cc: @akshaysridhar 

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
