### PR TITLE
Cleanup a few things in multirate codes

### DIFF
--- a/src/ODESolvers/MultirateInfinitesimalStepMethod.jl
+++ b/src/ODESolvers/MultirateInfinitesimalStepMethod.jl
@@ -112,7 +112,7 @@ end
 # TODO almost identical functions seem to be defined for every ode solver,
 # define a common one in ODEsolvers ?
 function dostep!(Q, mis::MultirateInfinitesimalStep, param,
-                      timeend::AbstractFloat, adjustfinalstep::Bool)
+                      timeend::Real, adjustfinalstep::Bool)
   time, dt = mis.t, mis.dt
   @assert dt > 0
   if adjustfinalstep && time + dt > timeend
@@ -131,7 +131,7 @@ function dostep!(Q, mis::MultirateInfinitesimalStep, param,
 end
 
 function dostep!(Q, mis::MultirateInfinitesimalStep, p,
-                      time::AbstractFloat, dt::AbstractFloat)
+                      time::Real, dt::AbstractFloat)
   FT = eltype(dt)
   α = mis.α
   β = mis.β

--- a/src/ODESolvers/MultirateRungeKuttaMethod.jl
+++ b/src/ODESolvers/MultirateRungeKuttaMethod.jl
@@ -78,7 +78,7 @@ function MultirateRungeKutta(solvers::Tuple, Q=nothing;
 end
 
 function dostep!(Q, mrrk::MultirateRungeKutta, param,
-                      timeend::AbstractFloat, adjustfinalstep::Bool)
+                 timeend::Real, adjustfinalstep::Bool)
   time, dt = mrrk.t, mrrk.dt
   @assert dt > 0
   if adjustfinalstep && time + dt > timeend
@@ -96,10 +96,10 @@ function dostep!(Q, mrrk::MultirateRungeKutta, param,
   return mrrk.t
 end
 
-function dostep!(Q, mrrk::MultirateRungeKutta{SS}, param,
-                      time::AbstractFloat, dt::AbstractFloat,
-                      in_slow_δ = nothing, in_slow_rv_dQ = nothing,
-                      in_slow_scaling = nothing) where {SS <: LSRK2N}
+function dostep!(Q, mrrk::MultirateRungeKutta{SS}, param, time::Real,
+                 dt::AbstractFloat, in_slow_δ = nothing,
+                 in_slow_rv_dQ = nothing,
+                 in_slow_scaling = nothing) where {SS <: LSRK2N}
   slow = mrrk.slow_solver
   fast = mrrk.fast_solver
 
@@ -148,7 +148,7 @@ function dostep!(Q, mrrk::MultirateRungeKutta{SS}, param,
       end
       fast_time = slow_stage_time + (substep - 1) * fast_dt
       dostep!(Q, fast, param, fast_time, fast_dt, slow_δ, slow_rv_dQ,
-                   slow_rka)
+              slow_rka)
     end
   end
 end

--- a/src/ODESolvers/MultirateRungeKuttaMethod.jl
+++ b/src/ODESolvers/MultirateRungeKuttaMethod.jl
@@ -4,7 +4,6 @@ include("MultirateRungeKuttaMethod_kernels.jl")
 export MultirateRungeKutta
 
 LSRK2N = LowStorageRungeKutta2N
-SSPRK = StrongStabilityPreservingRungeKutta
 
 """
     MultirateRungeKutta(slow_solver, fast_solver; dt, t0 = 0)
@@ -59,7 +58,6 @@ mutable struct MultirateRungeKutta{SS, FS, RT} <: AbstractODESolver
     new{SS, FS, RT}(slow_solver, fast_solver, RT(dt), RT(t0))
   end
 end
-MRRK = MultirateRungeKutta
 
 function MultirateRungeKutta(solvers::Tuple, Q=nothing;
                              dt=getdt(solvers[1]), t0=solvers[1].t


### PR DESCRIPTION
Make the multirate solvers consistent with the other solvers in dispatching based on time variables being `Real` as opposed to `AbstractFloat`

Mainly this allows the `timeend` to be an integer as opposed to an float.

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
