### PR TITLE
`using LinearAlgebra` in AtmosDiagnostics

### DIFF
--- a/src/Diagnostics/AtmosDiagnostics.jl
+++ b/src/Diagnostics/AtmosDiagnostics.jl
@@ -3,6 +3,7 @@ using ..Atmos: thermo_state, turbulence_tensors
 using ..SubgridScaleParameters: inv_Pr_turb
 using ..PlanetParameters
 using ..MoistThermodynamics
+using LinearAlgebra
 
 Base.@kwdef mutable struct AtmosCollectedDiagnostics
     zvals::Union{Nothing,Matrix} = nothing


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

https://github.com/climate-machine/CLIMA/blob/466709c28b525850789f448873b192d7b1ac23de/src/Diagnostics/AtmosDiagnostics.jl#L132 Line 132 requires the LinearAlgebra package. This PR adds a statement to use it. 

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
