### PR TITLE
More consistent and general Courant calculations

### DIFF
--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -183,7 +183,8 @@ function main()
     driver_config,
     ode_solver_type=ode_solver_type,
     Courant_number=0.05,
-    init_on_cpu=true
+    init_on_cpu=true,
+    CFL_direction=HorizontalDirection()
   )
 
   # Set up user-defined callbacks

--- a/experiments/OceanBoxGCM/homogeneous_box.jl
+++ b/experiments/OceanBoxGCM/homogeneous_box.jl
@@ -47,8 +47,10 @@ function main(;imex::Bool = false)
   if imex
     solver_type = CLIMA.IMEXSolverType(linear_model=LinearHBModel)
     Nᶻ = Int(400)
+    Courant_number = 0.1
   else
     solver_type = CLIMA.ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch)
+    Courant_number = 0.4
   end
 
   driver_config = config_simple_box(FT, N, resolution, dimensions)
@@ -61,7 +63,8 @@ function main(;imex::Bool = false)
   solver_config = CLIMA.setup_solver(timestart, timeend, driver_config,
                                      init_on_cpu=true,
                                      ode_solver_type=solver_type,
-                                     modeldata=modeldata)
+                                     modeldata=modeldata,
+                                     Courant_number=Courant_number)
 
   result = CLIMA.invoke!(solver_config)
 

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -34,6 +34,7 @@ import ..DGmethods.NumericalFluxes: boundary_state!,
                                     NumericalFluxNonDiffusive,
                                     NumericalFluxGradient,
                                     NumericalFluxDiffusive
+import ..Courant: advective_courant, nondiffusive_courant, diffusive_courant
 
 """
     AtmosModel <: BalanceLaw
@@ -193,6 +194,7 @@ include("source.jl")
 include("boundaryconditions.jl")
 include("linear.jl")
 include("remainder.jl")
+include("courant.jl")
 
 """
     flux_nondiffusive!(m::AtmosModel, flux::Grad, state::Vars, aux::Vars,

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -20,7 +20,7 @@ import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
                         flux_diffusive!, source!, wavespeed, boundary_state!,
                         gradvariables!, diffusive!, init_aux!, init_state!,
                         update_aux!, LocalGeometry, lengthscale,
-                        resolutionmetric, DGModel, calculate_dt,
+                        resolutionmetric, DGModel,
                         nodal_update_aux!, num_state,
                         num_integrals,
                         vars_integrals, vars_reverse_integrals,
@@ -59,11 +59,6 @@ struct AtmosModel{FT,O,RS,T,M,P,R,S,BC,IS,DC} <: BalanceLaw
   boundarycondition::BC
   init_state::IS
   data_config::DC
-end
-
-function calculate_dt(grid, model::AtmosModel, Courant_number)
-    T = 290.0
-    return Courant_number * min_node_distance(grid, VerticalDirection()) / soundspeed_air(T)
 end
 
 function AtmosModel{FT}(::Type{AtmosLESConfigType};

--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -40,12 +40,12 @@ function diffusive_courant(m::AtmosModel, state::Vars, aux::Vars,
         return Δt * ν / (Δx*Δx)
     else
         k̂ = vertical_unit_vector(m.orientation, aux)
-        ν_vert = dot(ν, k)
+        ν_vert = dot(ν, k̂)
 
         if direction isa VerticalDirection
             return Δt * ν_vert / (Δx*Δx)
         elseif direction isa HorizontalDirection
-            ν_horz = ν - ν_vert * k
+            ν_horz = ν - ν_vert * k̂
             return Δt * norm(ν_horz) / (Δx*Δx)
         else
             return Δt * norm(ν) / (Δx*Δx)

--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -11,7 +11,7 @@ function advective_courant(m::AtmosModel, state::Vars, aux::Vars,
     if direction isa VerticalDirection
         norm_u =  abs(dot(state.ρu, k̂))/state.ρ
     elseif direction isa HorizontalDirection
-        norm_u = norm( (state.ρu .- dot(state.ρu, k̂).*k̂) / state.ρ )
+        norm_u = norm( (state.ρu - dot(state.ρu, k̂)*k̂) / state.ρ )
     else
         norm_u = norm(state.ρu/state.ρ)
     end
@@ -24,7 +24,7 @@ function nondiffusive_courant(m::AtmosModel, state::Vars, aux::Vars,
     if direction isa VerticalDirection
         norm_u =  abs(dot(state.ρu, k̂))/state.ρ
     elseif direction isa HorizontalDirection
-        norm_u = norm( (state.ρu .- dot(state.ρu, k̂)*k̂) / state.ρ )
+        norm_u = norm( (state.ρu - dot(state.ρu, k̂)*k̂) / state.ρ )
     else
         norm_u = norm(state.ρu/state.ρ)
     end
@@ -45,7 +45,7 @@ function diffusive_courant(m::AtmosModel, state::Vars, aux::Vars,
         if direction isa VerticalDirection
             return Δt * ν_vert / (Δx*Δx)
         elseif direction isa HorizontalDirection
-            ν_horz = ν - ν_vert .* k
+            ν_horz = ν - ν_vert * k
             return Δt * norm(ν_horz) / (Δx*Δx)
         else
             return Δt * norm(ν) / (Δx*Δx)

--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -1,15 +1,12 @@
-advective_courant(m::AtmosLinearModel, a...; k...) =
-advective_courant(m.atmos, a...; k...)
+advective_courant(m::AtmosLinearModel, a...) = advective_courant(m.atmos, a...)
 
-nondiffusive_courant(m::AtmosLinearModel, a...; k...) =
-nondiffusive_courant(m.atmos, a...; k...)
+nondiffusive_courant(m::AtmosLinearModel, a...) = nondiffusive_courant(m.atmos,
+                                                                       a...)
 
-diffusive_courant(m::AtmosLinearModel, a...; k...) =
-diffusive_courant(m.atmos, a...; k...)
+diffusive_courant(m::AtmosLinearModel, a...) = diffusive_courant(m.atmos, a...)
 
 function advective_courant(m::AtmosModel, state::Vars, aux::Vars,
-                           diffusive::Vars, Δx, Δt,
-                           direction=VerticalDirection())
+                           diffusive::Vars, Δx, Δt, direction)
     k̂ = vertical_unit_vector(m.orientation, aux)
     if direction isa VerticalDirection
         norm_u =  abs(dot(state.ρu, k̂))/state.ρ
@@ -22,8 +19,7 @@ function advective_courant(m::AtmosModel, state::Vars, aux::Vars,
 end
 
 function nondiffusive_courant(m::AtmosModel, state::Vars, aux::Vars,
-                              diffusive::Vars, Δx, Δt,
-                              direction=VerticalDirection())
+                              diffusive::Vars, Δx, Δt, direction)
     k̂ = vertical_unit_vector(m.orientation, aux)
     if direction isa VerticalDirection
         norm_u =  abs(dot(state.ρu, k̂))/state.ρ
@@ -36,8 +32,7 @@ function nondiffusive_courant(m::AtmosModel, state::Vars, aux::Vars,
 end
 
 function diffusive_courant(m::AtmosModel, state::Vars, aux::Vars,
-                           diffusive::Vars, Δx, Δt,
-                           direction=VerticalDirection())
+                           diffusive::Vars, Δx, Δt, direction)
     ν, τ = turbulence_tensors(m.turbulence, state, diffusive, aux, 0)
     FT = eltype(state)
 

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -29,11 +29,6 @@ end
 abstract type AtmosLinearModel <: BalanceLaw
 end
 
-function calculate_dt(grid, model::AtmosLinearModel, Courant_number)
-    T = 290.0
-    return Courant_number * min_node_distance(grid, HorizontalDirection()) / soundspeed_air(T)
-end
-
 vars_state(lm::AtmosLinearModel, FT) = vars_state(lm.atmos,FT)
 vars_gradient(lm::AtmosLinearModel, FT) = @vars()
 vars_diffusive(lm::AtmosLinearModel, FT) = @vars()

--- a/src/CLIMA.jl
+++ b/src/CLIMA.jl
@@ -17,6 +17,7 @@ include(joinpath("Atmos", "Parameterizations", "TurbulenceConvection", "Turbulen
 include(joinpath("Atmos", "Parameterizations", "SubgridScaleTurbulence", "SubgridScaleParameters.jl"))
 include(joinpath("Arrays", "MPIStateArrays.jl"))
 include(joinpath("Mesh", "Mesh.jl"))
+include(joinpath("DGmethods", "Courant.jl"))
 include(joinpath("DGmethods", "SpaceMethods.jl"))
 include(joinpath("DGmethods", "DGmethods.jl"))
 include(joinpath("Ocean", "ShallowWater", "ShallowWaterModel.jl"))
@@ -33,6 +34,5 @@ include(joinpath("Atmos", "Model", "AtmosModel.jl"))
 include(joinpath("InputOutput", "VTK", "VTK.jl"))
 include(joinpath("Diagnostics", "Diagnostics.jl"))
 include(joinpath("Driver", "Driver.jl"))
-include(joinpath("Atmos", "Model", "courant.jl"))
 
 end

--- a/src/DGmethods/Courant.jl
+++ b/src/DGmethods/Courant.jl
@@ -13,4 +13,6 @@ function nondiffusive_courant end
 
 function diffusive_courant end
 
+function viscous_courant end
+
 end

--- a/src/DGmethods/Courant.jl
+++ b/src/DGmethods/Courant.jl
@@ -1,0 +1,16 @@
+"""
+Contains stubs for advective, diffusive, and nondiffusive courant number
+calculations to be used in [`DGmethods.courant`](@ref). Models should provide
+concrete implementations if they wish to use these functions.
+"""
+module Courant
+
+export advective_courant, diffusive_courant, nondiffusive_courant
+
+function advective_courant end
+
+function nondiffusive_courant end
+
+function diffusive_courant end
+
+end

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -67,7 +67,19 @@ function boundary_state! end
 function init_aux! end
 function init_state! end
 
-function calculate_dt end
+using ..Courant
+"""
+    calculate_dt(dg, model, Q, Courant_number, direction)
+
+For a given model, compute a time step satisying the nondiffusive Courant number
+`Courant_number`
+"""
+function calculate_dt(dg, model, Q, Courant_number, direction)
+    Δt = one(eltype(Q))
+    CFL = courant(nondiffusive_courant, dg, model, Q, Δt, direction)
+    return Courant_number / CFL
+end
+
 
 function create_state(bl::BalanceLaw, grid, commtag)
   topology = grid.topology

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -31,8 +31,8 @@ pointwise throughout the domain with the model defined by `solver_config`. The
 keyword arguments `Q` and `dt` can be used to call the courant method with a
 different state `Q` or time step `dt` than are defined in `solver_config`.
 """
-DGmethods.courant(f, sc::SolverConfiguration; Q=sc.Q, dt = sc.dt) =
-  DGmethods.courant(f, sc.dg, sc.dg.balancelaw, Q, dt)
+DGmethods.courant(f, sc::SolverConfiguration; Q=sc.Q, dt = sc.dt, direction = EveryDirection()) =
+  DGmethods.courant(f, sc.dg, sc.dg.balancelaw, Q, dt, direction)
 
 """
     CLIMA.setup_solver(t0::FT,

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -61,6 +61,8 @@ the ODE solver, and return a `SolverConfiguration` to be used with
 # - `modeldata=nothing`: passed through to `DGModel`.
 # - `Courant_number=0.4`: for the simulation.
 # - `diffdir=EveryDirection()`: restrict diffusivity direction.
+# - `timeend_dt_adjust=true`: should `dt` be adjusted to hit `timeend` exactly
+# - `CFL_direction=EveryDirection()`: direction for `calculate_dt`
 """
 function setup_solver(t0::FT, timeend::FT,
                       driver_config::DriverConfiguration,
@@ -71,6 +73,8 @@ function setup_solver(t0::FT, timeend::FT,
                       modeldata=nothing,
                       Courant_number=0.4,
                       diffdir=EveryDirection(),
+                      timeend_dt_adjust=true,
+                      CFL_direction=EveryDirection()
                      ) where {FT<:AbstractFloat}
     @tic setup_solver
 
@@ -99,10 +103,10 @@ function setup_solver(t0::FT, timeend::FT,
 
     # initial Δt specified or computed
     if ode_dt === nothing
-        ode_dt = calculate_dt(grid, dtmodel, Courant_number)
+        ode_dt = calculate_dt(dg, dtmodel, Q, Courant_number, CFL_direction)
     end
     numberofsteps = convert(Int, cld(timeend, ode_dt))
-    ode_dt = timeend / numberofsteps
+    timeend_dt_adjust && (ode_dt = timeend / numberofsteps)
 
     # create the solver
     if isa(ode_solver_type, ExplicitSolverType)

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -74,14 +74,16 @@ end
 HBModel = HydrostaticBoussinesqModel
 
 """
-    calculate_dt(grid, model::HBModel)
+    calculate_dt(dg, model::HBModel, _, Courant_number)
 
 calculates the time step based on grid spacing and model parameters
 takes minimum of gravity wave, diffusive, and viscous CFL
 factor of 1000 in the diffusive CFL is to handle the convective adjustment
 
 """
-function calculate_dt(grid, model::HBModel, Courant_number)
+function calculate_dt(dg, model::HBModel, _, Courant_number)
+    grid = dg.grid
+
     minΔx = min_node_distance(grid, HorizontalDirection())
     minΔz = min_node_distance(grid, VerticalDirection())
 

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -20,13 +20,14 @@ struct LinearHBModel{M} <: BalanceLaw
 end
 
 """
-    calculate_dt(grid, model::HBModel)
+     calculate_dt(dg, bl::LinearHBModel, Q, Courant_number)
 
 calculates the time step based on grid spacing and model parameters
 takes minimum of gravity wave, diffusive, and viscous CFL
 
 """
-function calculate_dt(grid, model::LinearHBModel, Courant_number)
+function calculate_dt(dg, model::LinearHBModel, _, Courant_number)
+    grid = dg.grid
     minΔx = min_node_distance(grid, HorizontalDirection())
 
     CFL_gravity = minΔx / model.ocean.cʰ

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -20,23 +20,28 @@ struct LinearHBModel{M} <: BalanceLaw
 end
 
 """
-     calculate_dt(dg, bl::LinearHBModel, Q, Courant_number)
+    calculate_dt(dg, bl::LinearHBModel, Q, Courant_number,
+                 direction::EveryDirection)
 
 calculates the time step based on grid spacing and model parameters
 takes minimum of gravity wave, diffusive, and viscous CFL
 
 """
-function calculate_dt(dg, model::LinearHBModel, _, Courant_number)
-    grid = dg.grid
-    minΔx = min_node_distance(grid, HorizontalDirection())
 
-    CFL_gravity = minΔx / model.ocean.cʰ
-    CFL_diffusive = minΔx^2 / model.ocean.κʰ
-    CFL_viscous = minΔx^2 / model.ocean.νʰ
+function calculate_dt(dg, model::LinearHBModel, Q, Courant_number,
+                      ::EveryDirection)
+  Δt = one(eltype(Q))
+  ocean = model.ocean
 
-    dt = 1//10 * minimum([CFL_gravity, CFL_diffusive, CFL_viscous])
+  CFL_advective = courant(advective_courant, dg, ocean, Q, Δt, VerticalDirection())
+  CFL_gravity = courant(nondiffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
+  CFL_viscous = courant(viscous_courant, dg, ocean, Q, Δt, HorizontalDirection())
+  CFL_diffusive = courant(diffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
 
-    return dt
+  CFL = maximum([CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive])
+  dt = Courant_number / CFL
+
+  return dt
 end
 
 """

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -79,11 +79,10 @@ function main()
                                        Courant_number = CFL)
 
     # Test the courant wrapper
+    # by default the CFL should be less than what asked for
     CFL_nondiff = CLIMA.DGmethods.courant(CLIMA.Courant.nondiffusive_courant,
                                           solver_config)
-    # Since the dt is computed before the initial condition, these might be
-    # difference by a fairly large factor
-    @test isapprox(CFL_nondiff, CFL, rtol=0.03)
+    @test CFL_nondiff < CFL
 
     cb_test = 0
     result = CLIMA.invoke!(solver_config)
@@ -93,6 +92,15 @@ function main()
     result = CLIMA.invoke!(solver_config, user_info_callback=(init)->cb_test+=1)
     # cb_test should be greater than one if the user_info_callback got called
     @test cb_test > 0
+
+    # Test that if dt is not adjusted based on final time the CFL is correct
+    solver_config = CLIMA.setup_solver(t0, timeend, driver_config,
+                                       Courant_number=CFL,
+                                       timeend_dt_adjust=false)
+
+    CFL_nondiff = CLIMA.DGmethods.courant(CLIMA.Courant.nondiffusive_courant,
+                                          solver_config)
+    @test CFL_nondiff ≈ CFL
 end
 
 main()


### PR DESCRIPTION
# Description

- The courant functions were atmos specific. This adds a stub module `Courant` then lets `AtmosModel` override them.
- The `calculate_dt` function did not use the initial condition, thus the courant number may be larger for the given initial condition (this lead to a [weird test in `driver_test.jl`](https://github.com/climate-machine/CLIMA/blob/b7515251d1aeec89e69c8997c31ddb09991025c7/test/Driver/driver_test.jl#L82-L87). Since the initial condition is known before the time step is calculated, this can be used to calculate a consistent dt

The new `calculate_dt` is only used for the atmos model and the ocean model remains unchanged (cc @blallen)

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
