### PR TITLE
Replaces `forcecpu` with `init_on_cpu` for clarity

### DIFF
--- a/examples/Atmos/dry_rayleigh_benard.jl
+++ b/examples/Atmos/dry_rayleigh_benard.jl
@@ -27,11 +27,11 @@ import CLIMA.DGmethods.NumericalFluxes: boundary_flux_diffusive!
 # 3) Domain - 250m[horizontal] x 250m[horizontal] x 500m[vertical]
 # 4) Timeend - 1000s
 # 5) Mesh Aspect Ratio (Effective resolution) 1:1
-# 6) Random seed in initial condition (Requires `forcecpu=true` argument)
+# 6) Random seed in initial condition (Requires `init_on_cpu=true` argument)
 # 7) Overrides defaults for
 #               `C_smag`
 #               `Courant_number`
-#               `forcecpu`
+#               `init_on_cpu`
 #               `ref_state`
 #               `solver_type`
 #               `bc`
@@ -203,7 +203,7 @@ function main()
         resolution = (Δh, Δh, Δv)
         driver_config = config_problem(FT, N, resolution, xmax, ymax, zmax)
         solver_config = CLIMA.setup_solver(t0, timeend, driver_config,
-                                           forcecpu=true, Courant_number=CFLmax)
+                                           init_on_cpu=true, Courant_number=CFLmax)
         # User defined callbacks (TMAR positivity preserving filter)
         cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init=false)
             Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())

--- a/experiments/Atmos_GCM/heldsuarez.jl
+++ b/experiments/Atmos_GCM/heldsuarez.jl
@@ -182,7 +182,7 @@ function main()
     driver_config,
     ode_solver_type=ode_solver_type,
     Courant_number=0.05,
-    forcecpu=true
+    init_on_cpu=true
   )
 
   # Set up user-defined callbacks

--- a/experiments/Atmos_LES/dycoms.jl
+++ b/experiments/Atmos_LES/dycoms.jl
@@ -375,7 +375,7 @@ function main()
     timeend = FT(100)
 
     driver_config = config_dycoms(FT, N, resolution, xmax, ymax, zmax)
-    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, forcecpu=true)
+    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, init_on_cpu=true)
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(2) do (init=false)
         Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())

--- a/experiments/Atmos_LES/risingbubble.jl
+++ b/experiments/Atmos_LES/risingbubble.jl
@@ -19,7 +19,7 @@ using CLIMA.VariableTemplates
 # 4) Timeend - 1000s
 # 5) Mesh Aspect Ratio (Effective resolution) 1:1
 # 7) Overrides defaults for
-#               `forcecpu`
+#               `init_on_cpu`
 #               `solver_type`
 #               `sources`
 #               `C_smag`
@@ -114,7 +114,7 @@ function main()
     CFL = FT(0.8)
 
     driver_config = config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
-    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, forcecpu=true, Courant_number=CFL)
+    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, init_on_cpu=true, Courant_number=CFL)
 
     # User defined filter (TMAR positivity preserving filter)
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init=false)

--- a/experiments/Atmos_LES/surfacebubble.jl
+++ b/experiments/Atmos_LES/surfacebubble.jl
@@ -185,7 +185,7 @@ function main()
   CFL_max = FT(0.4)
 
   driver_config = config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
-  solver_config = CLIMA.setup_solver(t0, timeend, Courant_number=CFL_max, driver_config, forcecpu=true)
+  solver_config = CLIMA.setup_solver(t0, timeend, Courant_number=CFL_max, driver_config, init_on_cpu=true)
 
   cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init=false)
       Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())

--- a/experiments/Ocean_BoxGCM/homogeneous_box.jl
+++ b/experiments/Ocean_BoxGCM/homogeneous_box.jl
@@ -58,7 +58,7 @@ function main(;imex::Bool = false)
   exp_filter  = ExponentialFilter(grid, 1, 8)
   modeldata = (vert_filter = vert_filter, exp_filter=exp_filter)
 
-  solver_config = CLIMA.setup_solver(timestart, timeend, driver_config, forcecpu=true,
+  solver_config = CLIMA.setup_solver(timestart, timeend, driver_config, init_on_cpu=true,
                                      ode_solver_type=solver_type, modeldata=modeldata)
 
   result = CLIMA.invoke!(solver_config)

--- a/experiments/Ocean_BoxGCM/ocean_gyre.jl
+++ b/experiments/Ocean_BoxGCM/ocean_gyre.jl
@@ -56,7 +56,7 @@ function main(;imex::Bool = false)
   exp_filter  = ExponentialFilter(grid, 1, 8)
   modeldata = (vert_filter = vert_filter, exp_filter=exp_filter)
 
-  solver_config = CLIMA.setup_solver(timestart, timeend, driver_config, forcecpu=true,
+  solver_config = CLIMA.setup_solver(timestart, timeend, driver_config, init_on_cpu=true,
                                      ode_solver_type=solver_type,  modeldata=modeldata)
 
   result = CLIMA.invoke!(solver_config)

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -195,7 +195,7 @@ function (dg::DGModel)(dQdt, Q, ::Nothing, t; increment=false)
 end
 
 function init_ode_state(dg::DGModel, args...;
-                        forcecpu=false,
+                        init_on_cpu=false,
                         commtag=888)
   device = arraytype(dg.grid) <: Array ? CPU() : CUDA()
 
@@ -212,7 +212,7 @@ function init_ode_state(dg::DGModel, args...;
   N = polynomialorder(grid)
   nrealelem = length(topology.realelems)
 
-  if !forcecpu
+  if !init_on_cpu
     @launch(device, threads=(Np,), blocks=nrealelem,
             initstate!(bl, Val(dim), Val(N), state.data, auxstate.data, grid.vgeo,
                      topology.realelems, args...))

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -196,7 +196,7 @@ struct SolverConfiguration{FT}
     t0::FT
     timeend::FT
     dt::FT
-    forcecpu::Bool
+    init_on_cpu::Bool
     numberofsteps::Int
     init_args
     solver
@@ -222,7 +222,7 @@ Set up the DG model per the specified driver configuration and set up the ODE so
 function setup_solver(t0::FT, timeend::FT,
                       driver_config::DriverConfiguration,
                       init_args...;
-                      forcecpu=false,
+                      init_on_cpu=false,
                       ode_solver_type=nothing,
                       ode_dt=nothing,
                       modeldata=nothing,
@@ -242,7 +242,7 @@ function setup_solver(t0::FT, timeend::FT,
                  modeldata=modeldata,
                  diffusion_direction=diffdir)
     @info @sprintf("Initializing %s", driver_config.name)
-    Q = init_ode_state(dg, FT(0), init_args...; forcecpu=forcecpu)
+    Q = init_ode_state(dg, FT(0), init_args...; init_on_cpu=init_on_cpu)
 
     # TODO: using `update_aux!()` to apply filters to the state variables and
     # `update_aux_diffusive!()` to calculate the vertical component of velocity
@@ -289,7 +289,7 @@ function setup_solver(t0::FT, timeend::FT,
     @toc setup_solver
 
     return SolverConfiguration(driver_config.name, driver_config.mpicomm, dg, Q,
-                               t0, timeend, dt, forcecpu, numberofsteps,
+                               t0, timeend, dt, init_on_cpu, numberofsteps,
                                init_args, solver)
 end
 
@@ -333,7 +333,7 @@ function invoke!(solver_config::SolverConfiguration;
     Q = solver_config.Q
     FT = eltype(Q)
     timeend = solver_config.timeend
-    forcecpu = solver_config.forcecpu
+    init_on_cpu = solver_config.init_on_cpu
     init_args = solver_config.init_args
     solver = solver_config.solver
 
@@ -437,7 +437,7 @@ function invoke!(solver_config::SolverConfiguration;
                    engf-eng0)
 
     if check_euclidean_distance
-        Qe = init_ode_state(dg, timeend, init_args...; forcecpu=forcecpu)
+        Qe = init_ode_state(dg, timeend, init_args...; init_on_cpu=init_on_cpu)
         engfe = norm(Qe)
         errf = euclidean_distance(solver_config.Q, Qe)
         @info @sprintf("""Euclidean distance

--- a/test/DGmethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/DGmethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -84,7 +84,7 @@ function run(adv, diff, topo, mpicomm, ArrayType, FT, polynomialorder, Ne, level
      hdg=create_dg(m, grid, HorizontalDirection()))
   end
 
-  Q = init_ode_state(dgmodels.p.dg, FT(0), forcecpu=true)
+  Q = init_ode_state(dgmodels.p.dg, FT(0), init_on_cpu=true)
 
   # evaluate all combinations
   dQ = map(x->map(dg->(dQ=similar(Q); dg(dQ, Q, nothing, FT(0)); dQ), x), dgmodels)

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -125,7 +125,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
                CentralNumericalFluxGradient())
 
   Q = init_ode_state(dg, FT(0))
-  Qcpu = init_ode_state(dg, FT(0); forcecpu=true)
+  Qcpu = init_ode_state(dg, FT(0); init_on_cpu=true)
   @test euclidean_distance(Q, Qcpu) < sqrt(eps(FT))
 
   lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -107,7 +107,7 @@ function main()
     timeend = dt
 
     driver_config = config_sin_test(FT, N, resolution, xmax, ymax, zmax)
-    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, ode_dt=dt, forcecpu=true)
+    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, ode_dt=dt, init_on_cpu=true)
 
     mpicomm = solver_config.mpicomm
     dg = solver_config.dg

--- a/test/Ocean/Hydrostatic_Boussinesq/simple_box.jl
+++ b/test/Ocean/Hydrostatic_Boussinesq/simple_box.jl
@@ -164,7 +164,7 @@ let
                     CentralNumericalFluxDiffusive(),
                     CentralNumericalFluxGradient())
 
-  Q = init_ode_state(dg, FT(0); forcecpu=true)
+  Q = init_ode_state(dg, FT(0); init_on_cpu=true)
   update_aux!(dg, model, Q, FT(0))
   update_aux_diffusive!(dg, model, Q, FT(0))
 

--- a/test/Ocean/Hydrostatic_Boussinesq/simple_box_IMEX.jl
+++ b/test/Ocean/Hydrostatic_Boussinesq/simple_box_IMEX.jl
@@ -136,7 +136,7 @@ function main()
                      direction=VerticalDirection(),
                      auxstate=dg.auxstate)
 
-  Q = init_ode_state(dg, FT(0); forcecpu=true)
+  Q = init_ode_state(dg, FT(0); init_on_cpu=true)
   update_aux!(dg, model, Q, FT(0))
 
   linearsolver = SingleColumnLU() # ManyColumnLU()

--- a/test/Ocean/Hydrostatic_Boussinesq/test_divergence_free.jl
+++ b/test/Ocean/Hydrostatic_Boussinesq/test_divergence_free.jl
@@ -148,7 +148,7 @@ let
                     CentralNumericalFluxDiffusive(),
                     CentralNumericalFluxGradient())
 
-  Q = init_ode_state(dg, FT(0); forcecpu=true)
+  Q = init_ode_state(dg, FT(0); init_on_cpu=true)
   update_aux!(dg, model, Q, FT(0))
 
   starttime = Ref(now())

--- a/test/Ocean/Hydrostatic_Boussinesq/test_divergence_free_IMEX.jl
+++ b/test/Ocean/Hydrostatic_Boussinesq/test_divergence_free_IMEX.jl
@@ -126,7 +126,7 @@ function main()
                      direction=VerticalDirection(),
                      auxstate=dg.auxstate)
 
-  Q = init_ode_state(dg, FT(0); forcecpu=true)
+  Q = init_ode_state(dg, FT(0); init_on_cpu=true)
   update_aux!(dg, model, Q, FT(0))
 
   linearsolver = SingleColumnLU() # ManyColumnLU()


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

Replaces instances of `forcecpu` keyword with `init_on_cpu` to clarify its functionality. It only enables initialisation on CPU, and does not force the run to be on CPU. (use cases: Currently CPU initialisation needs to be enabled when using random number generators for the initial condition)

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
