### PR TITLE
improve formatting of simtime and endtime in logging

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -348,10 +348,11 @@ function invoke!(solver_config::SolverConfiguration;
                                        Dates.dateformat"HH:MM:SS")
                 energy = norm(solver_config.Q)
                 @info @sprintf("""Update
-                               simtime = %.16e
+                               simtime = %8.2f / %8.2f
                                runtime = %s
                                norm(Q) = %.16e""",
                                ODESolvers.gettime(solver),
+                               solver_config.timeend,
                                runtime,
                                energy)
             end
@@ -407,7 +408,7 @@ function invoke!(solver_config::SolverConfiguration;
     eng0 = norm(Q)
     @info @sprintf("""Starting %s
                    dt              = %.5e
-                   timeend         = %.5e
+                   timeend         = %8.2f
                    number of steps = %d
                    norm(Q)         = %.16e""",
                    solver_config.name,


### PR DESCRIPTION
# Description

Switches to using a fixed format for printing simtime and endtime, and print denominator in callback.

Old:
```
┌ Info: Update
│ simtime = 2.6159163716067161e+02
│ runtime = 00:01:59
└ norm(Q) = 3.0116687421160989e+09
```

New:
```
┌ Info: Update
│ simtime =    15.34 /  1000.00
│ runtime = 00:28:31
└ norm(Q) = 3.0115880375677762e+09
```
<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
