### PR TITLE
Add a multirate solver type to driver

### DIFF
--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -31,74 +31,85 @@ include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 # 8) Default settings can be found in `src/Driver/Configurations.jl`
 # ------------------------ Description ------------------------- #
 
-function init_risingbubble!(bl, state, aux, (x,y,z), t)
-  FT            = eltype(state)
-  R_gas::FT     = R_d
-  c_p::FT       = cp_d
-  c_v::FT       = cv_d
-  γ::FT         = c_p / c_v
-  p0::FT        = MSLP
+function init_risingbubble!(bl, state, aux, (x, y, z), t)
+    FT = eltype(state)
+    R_gas::FT = R_d
+    c_p::FT = cp_d
+    c_v::FT = cv_d
+    γ::FT = c_p / c_v
+    p0::FT = MSLP
 
-  xc::FT        = 1250
-  yc::FT        = 1250
-  zc::FT        = 1000
-  r             = sqrt((x-xc)^2+(y-yc)^2+(z-zc)^2)
-  rc::FT        = 500
-  θ_ref::FT     = 300
-  Δθ::FT        = 0
+    xc::FT = 1250
+    yc::FT = 1250
+    zc::FT = 1000
+    r = sqrt((x - xc)^2 + (y - yc)^2 + (z - zc)^2)
+    rc::FT = 500
+    θ_ref::FT = 300
+    Δθ::FT = 0
 
-  if r <= rc
-    Δθ          = FT(5) * cospi(r/rc/2)
-  end
+    if r <= rc
+        Δθ = FT(5) * cospi(r / rc / 2)
+    end
 
-  #Perturbed state:
-  θ            = θ_ref + Δθ # potential temperature
-  π_exner      = FT(1) - grav / (c_p * θ) * z # exner pressure
-  ρ            = p0 / (R_gas * θ) * (π_exner)^ (c_v / R_gas) # density
-  q_tot        = FT(0)
-  ts           = LiquidIcePotTempSHumEquil(θ, ρ, q_tot, bl.param_set)
-  q_pt         = PhasePartition(ts)
+    #Perturbed state:
+    θ = θ_ref + Δθ # potential temperature
+    π_exner = FT(1) - grav / (c_p * θ) * z # exner pressure
+    ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
+    q_tot = FT(0)
+    ts = LiquidIcePotTempSHumEquil(θ, ρ, q_tot, bl.param_set)
+    q_pt = PhasePartition(ts)
 
-  ρu           = SVector(FT(0),FT(0),FT(0))
+    ρu = SVector(FT(0), FT(0), FT(0))
 
-  #State (prognostic) variable assignment
-  e_kin        = FT(0)
-  e_pot        = gravitational_potential(bl.orientation, aux)
-  ρe_tot       = ρ * total_energy(e_kin, e_pot, ts)
-  state.ρ      = ρ
-  state.ρu     = ρu
-  state.ρe     = ρe_tot
-  state.moisture.ρq_tot = ρ*q_pt.tot
+    #State (prognostic) variable assignment
+    e_kin = FT(0)
+    e_pot = gravitational_potential(bl.orientation, aux)
+    ρe_tot = ρ * total_energy(e_kin, e_pot, ts)
+    state.ρ = ρ
+    state.ρu = ρu
+    state.ρe = ρe_tot
+    state.moisture.ρq_tot = ρ * q_pt.tot
 end
 
 function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
 
-  # Boundary conditions
-  bc = NoFluxBC()
+    # Boundary conditions
+    bc = NoFluxBC()
 
-  # Choose explicit solver
-  ode_solver = CLIMA.MultirateSolverType(linear_model=AtmosAcousticGravityLinearModel,
-                                         slow_method=LSRK144NiegemannDiehlBusch,
-                                         fast_method=LSRK144NiegemannDiehlBusch,
-                                         timestep_ratio=10)
+    # Choose explicit solver
+    ode_solver = CLIMA.MultirateSolverType(
+        linear_model = AtmosAcousticGravityLinearModel,
+        slow_method = LSRK144NiegemannDiehlBusch,
+        fast_method = LSRK144NiegemannDiehlBusch,
+        timestep_ratio = 10,
+    )
 
-  # Set up the model
-  C_smag = FT(0.23)
-  ref_state = HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0))
-  model = AtmosModel{FT}(AtmosLESConfigType;
-                         turbulence=SmagorinskyLilly{FT}(C_smag),
-                         source=(Gravity(),),
-                         ref_state=ref_state,
-                         init_state=init_risingbubble!,
-                         param_set=ParameterSet{FT}())
+    # Set up the model
+    C_smag = FT(0.23)
+    ref_state =
+        HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0))
+    model = AtmosModel{FT}(
+        AtmosLESConfigType;
+        turbulence = SmagorinskyLilly{FT}(C_smag),
+        source = (Gravity(),),
+        ref_state = ref_state,
+        init_state = init_risingbubble!,
+        param_set = ParameterSet{FT}(),
+    )
 
-  # Problem configuration
-  config = CLIMA.AtmosLESConfiguration("DryRisingBubble",
-                                       N, resolution, xmax, ymax, zmax,
-                                       init_risingbubble!,
-                                       solver_type=ode_solver,
-                                       model=model)
-  return config
+    # Problem configuration
+    config = CLIMA.AtmosLESConfiguration(
+        "DryRisingBubble",
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        init_risingbubble!,
+        solver_type = ode_solver,
+        model = model,
+    )
+    return config
 end
 
 function main()
@@ -123,20 +134,28 @@ function main()
     CFL = FT(20)
 
     driver_config = config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
-    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, init_on_cpu=true, Courant_number=CFL)
+    solver_config = CLIMA.setup_solver(
+        t0,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        Courant_number = CFL,
+    )
 
     # User defined filter (TMAR positivity preserving filter)
-    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init=false)
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
         Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
         nothing
     end
 
     # Invoke solver (calls solve! function for time-integrator)
-    result = CLIMA.invoke!(solver_config;
-                           user_callbacks=(cbtmarfilter,),
-                           check_euclidean_distance=true)
+    result = CLIMA.invoke!(
+        solver_config;
+        user_callbacks = (cbtmarfilter,),
+        check_euclidean_distance = true,
+    )
 
-    @test isapprox(result,FT(1); atol=1.5e-3)
+    @test isapprox(result, FT(1); atol = 1.5e-3)
 end
 
 main()

--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -77,7 +77,10 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
   bc = NoFluxBC()
 
   # Choose explicit solver
-  ode_solver = CLIMA.ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch)
+  ode_solver = CLIMA.MultirateSolverType(linear_model=AtmosAcousticGravityLinearModel,
+                                         slow_method=LSRK144NiegemannDiehlBusch,
+                                         fast_method=LSRK144NiegemannDiehlBusch,
+                                         timestep_ratio=10)
 
   # Set up the model
   C_smag = FT(0.23)
@@ -117,7 +120,7 @@ function main()
     t0 = FT(0)
     timeend = FT(1000)
     # Courant number
-    CFL = FT(0.8)
+    CFL = FT(20)
 
     driver_config = config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     solver_config = CLIMA.setup_solver(t0, timeend, driver_config, init_on_cpu=true, Courant_number=CFL)
@@ -130,8 +133,8 @@ function main()
 
     # Invoke solver (calls solve! function for time-integrator)
     result = CLIMA.invoke!(solver_config;
-                          user_callbacks=(cbtmarfilter,),
-                          check_euclidean_distance=true)
+                           user_callbacks=(cbtmarfilter,),
+                           check_euclidean_distance=true)
 
     @test isapprox(result,FT(1); atol=1.5e-3)
 end

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -10,6 +10,7 @@ using Requires
 using ..Atmos
 using ..ColumnwiseLUSolver
 using ..ConfigTypes
+using ..Courant
 using ..Diagnostics
 using ..DGmethods
 using ..DGmethods: vars_state, vars_aux, update_aux!

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -14,10 +14,12 @@ const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 
 abstract type AbstractSolverType end
+
 struct ExplicitSolverType <: AbstractSolverType
     solver_method::Function
     ExplicitSolverType(;solver_method=LSRK54CarpenterKennedy) = new(solver_method)
 end
+
 struct IMEXSolverType <: AbstractSolverType
     linear_model::Type
     linear_solver::Type
@@ -29,6 +31,22 @@ struct IMEXSolverType <: AbstractSolverType
         return new(linear_model, linear_solver, solver_method)
     end
 end
+
+struct MultirateSolverType <: AbstractSolverType
+    linear_model::Type
+    solver_method::Type
+    slow_method::Function
+    fast_method::Function
+    timestep_ratio::Int
+    function MultirateSolverType(;linear_model=AtmosAcousticGravityLinearModel,
+                                 solver_method=MultirateRungeKutta,
+                                 slow_method=LSRK54CarpenterKennedy,
+                                 fast_method=LSRK54CarpenterKennedy,
+                                 timestep_ratio=100)
+      return new(linear_model, solver_method, slow_method, fast_method, timestep_ratio)
+    end
+end
+
 DefaultSolverType = IMEXSolverType
 
 abstract type ConfigSpecificInfo end

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -17,7 +17,8 @@ abstract type AbstractSolverType end
 
 struct ExplicitSolverType <: AbstractSolverType
     solver_method::Function
-    ExplicitSolverType(;solver_method=LSRK54CarpenterKennedy) = new(solver_method)
+    ExplicitSolverType(; solver_method = LSRK54CarpenterKennedy) =
+        new(solver_method)
 end
 
 struct IMEXSolverType <: AbstractSolverType
@@ -25,9 +26,11 @@ struct IMEXSolverType <: AbstractSolverType
     linear_solver::Type
     solver_method::Function
     # FIXME: this is Atmos-specific
-    function IMEXSolverType(;linear_model=AtmosAcousticGravityLinearModel,
-                            linear_solver=ManyColumnLU,
-                            solver_method=ARK2GiraldoKellyConstantinescu)
+    function IMEXSolverType(;
+        linear_model = AtmosAcousticGravityLinearModel,
+        linear_solver = ManyColumnLU,
+        solver_method = ARK2GiraldoKellyConstantinescu,
+    )
         return new(linear_model, linear_solver, solver_method)
     end
 end
@@ -38,12 +41,20 @@ struct MultirateSolverType <: AbstractSolverType
     slow_method::Function
     fast_method::Function
     timestep_ratio::Int
-    function MultirateSolverType(;linear_model=AtmosAcousticGravityLinearModel,
-                                 solver_method=MultirateRungeKutta,
-                                 slow_method=LSRK54CarpenterKennedy,
-                                 fast_method=LSRK54CarpenterKennedy,
-                                 timestep_ratio=100)
-      return new(linear_model, solver_method, slow_method, fast_method, timestep_ratio)
+    function MultirateSolverType(;
+        linear_model = AtmosAcousticGravityLinearModel,
+        solver_method = MultirateRungeKutta,
+        slow_method = LSRK54CarpenterKennedy,
+        fast_method = LSRK54CarpenterKennedy,
+        timestep_ratio = 100,
+    )
+        return new(
+            linear_model,
+            solver_method,
+            slow_method,
+            fast_method,
+            timestep_ratio,
+        )
     end
 end
 
@@ -58,8 +69,7 @@ struct AtmosGCMSpecificInfo{FT} <: ConfigSpecificInfo
     nelem_vert::Int
     nelem_horz::Int
 end
-struct OceanBoxGCMSpecificInfo <: ConfigSpecificInfo
-end
+struct OceanBoxGCMSpecificInfo <: ConfigSpecificInfo end
 
 """
     CLIMA.DriverConfiguration
@@ -91,150 +101,241 @@ struct DriverConfiguration{FT}
     # configuration-specific info
     config_info::ConfigSpecificInfo
 
-    function DriverConfiguration(config_type,
-                                 name::String, N::Int, FT, array_type,
-                                 solver_type::AbstractSolverType,
-                                 bl::BalanceLaw,
-                                 mpicomm::MPI.Comm,
-                                 grid::DiscontinuousSpectralElementGrid,
-                                 numfluxnondiff::NumericalFluxNonDiffusive,
-                                 numfluxdiff::NumericalFluxDiffusive,
-                                 gradnumflux::NumericalFluxGradient,
-                                 config_info::ConfigSpecificInfo)
-        return new{FT}(config_type, name, N, array_type, solver_type, bl,
-                       mpicomm, grid, numfluxnondiff, numfluxdiff, gradnumflux,
-                       config_info)
+    function DriverConfiguration(
+        config_type,
+        name::String,
+        N::Int,
+        FT,
+        array_type,
+        solver_type::AbstractSolverType,
+        bl::BalanceLaw,
+        mpicomm::MPI.Comm,
+        grid::DiscontinuousSpectralElementGrid,
+        numfluxnondiff::NumericalFluxNonDiffusive,
+        numfluxdiff::NumericalFluxDiffusive,
+        gradnumflux::NumericalFluxGradient,
+        config_info::ConfigSpecificInfo,
+    )
+        return new{FT}(
+            config_type,
+            name,
+            N,
+            array_type,
+            solver_type,
+            bl,
+            mpicomm,
+            grid,
+            numfluxnondiff,
+            numfluxdiff,
+            gradnumflux,
+            config_info,
+        )
     end
 end
 
 function AtmosLESConfiguration(
-        name::String,
-        N::Int,
-        (Δx, Δy, Δz)::NTuple{3,FT},
-        xmax::Int, ymax::Int, zmax::Int,
-        init_LES!;
-        xmin           = 0,
-        ymin           = 0,
-        zmin           = 0,
-        array_type     = CLIMA.array_type(),
-        solver_type    = IMEXSolverType(linear_solver=SingleColumnLU),
-        model          = AtmosModel{FT}(AtmosLESConfigType;
-                                        init_state=init_LES!,
-                                        param_set=ParameterSet{FT}()),
-        mpicomm        = MPI.COMM_WORLD,
-        boundary       = ((0,0), (0,0), (1,2)),
-        periodicity    = (true, true, false),
-        meshwarp       = (x...)->identity(x),
-        numfluxnondiff = Rusanov(),
-        numfluxdiff    = CentralNumericalFluxDiffusive(),
-        gradnumflux    = CentralNumericalFluxGradient()
-    ) where {FT<:AbstractFloat}
+    name::String,
+    N::Int,
+    (Δx, Δy, Δz)::NTuple{3, FT},
+    xmax::Int,
+    ymax::Int,
+    zmax::Int,
+    init_LES!;
+    xmin = 0,
+    ymin = 0,
+    zmin = 0,
+    array_type = CLIMA.array_type(),
+    solver_type = IMEXSolverType(linear_solver = SingleColumnLU),
+    model = AtmosModel{FT}(
+        AtmosLESConfigType;
+        init_state = init_LES!,
+        param_set = ParameterSet{FT}(),
+    ),
+    mpicomm = MPI.COMM_WORLD,
+    boundary = ((0, 0), (0, 0), (1, 2)),
+    periodicity = (true, true, false),
+    meshwarp = (x...) -> identity(x),
+    numfluxnondiff = Rusanov(),
+    numfluxdiff = CentralNumericalFluxDiffusive(),
+    gradnumflux = CentralNumericalFluxGradient(),
+) where {FT <: AbstractFloat}
 
-    @info @sprintf("""Establishing Atmos LES configuration for %s
-                   precision        = %s
-                   polynomial order = %d
-                   grid             = %dx%dx%d
-                   resolution       = %dx%dx%d
-                   MPI ranks        = %d""",
-                   name, FT, N,
-                   xmax, ymax, zmax,
-                   Δx, Δy, Δz,
-                   MPI.Comm_size(mpicomm))
+    @info @sprintf(
+        """Establishing Atmos LES configuration for %s
+        precision        = %s
+        polynomial order = %d
+        grid             = %dx%dx%d
+        resolution       = %dx%dx%d
+        MPI ranks        = %d""",
+        name,
+        FT,
+        N,
+        xmax,
+        ymax,
+        zmax,
+        Δx,
+        Δy,
+        Δz,
+        MPI.Comm_size(mpicomm)
+    )
 
-    brickrange = (grid1d(xmin, xmax, elemsize=Δx*N),
-                  grid1d(ymin, ymax, elemsize=Δy*N),
-                  grid1d(zmin, zmax, elemsize=Δz*N))
-    topology = StackedBrickTopology(mpicomm, brickrange,
-                                    periodicity=periodicity,
-                                    boundary=boundary)
+    brickrange = (
+        grid1d(xmin, xmax, elemsize = Δx * N),
+        grid1d(ymin, ymax, elemsize = Δy * N),
+        grid1d(zmin, zmax, elemsize = Δz * N),
+    )
+    topology = StackedBrickTopology(
+        mpicomm,
+        brickrange,
+        periodicity = periodicity,
+        boundary = boundary,
+    )
 
-    grid = DiscontinuousSpectralElementGrid(topology,
-                                            FloatType=FT,
-                                            DeviceArray=array_type,
-                                            polynomialorder=N,
-                                            meshwarp=meshwarp)
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = array_type,
+        polynomialorder = N,
+        meshwarp = meshwarp,
+    )
 
-    return DriverConfiguration(AtmosLESConfigType(), name, N, FT, array_type,
-                               solver_type, model, mpicomm, grid,
-                               numfluxnondiff, numfluxdiff, gradnumflux,
-                               AtmosLESSpecificInfo(brickrange))
+    return DriverConfiguration(
+        AtmosLESConfigType(),
+        name,
+        N,
+        FT,
+        array_type,
+        solver_type,
+        model,
+        mpicomm,
+        grid,
+        numfluxnondiff,
+        numfluxdiff,
+        gradnumflux,
+        AtmosLESSpecificInfo(brickrange),
+    )
 end
 
 function AtmosGCMConfiguration(
-        name::String,
-        N::Int,
-        (nelem_horz, nelem_vert)::NTuple{2,Int},
-        domain_height::FT,
-        init_GCM!;
-        array_type         = CLIMA.array_type(),
-        solver_type        = DefaultSolverType(),
-        model              = AtmosModel{FT}(AtmosGCMConfigType;
-                                            init_state=init_GCM!,
-                                            param_set=ParameterSet{FT}()),
-        mpicomm            = MPI.COMM_WORLD,
-        meshwarp::Function = cubedshellwarp,
-        numfluxnondiff     = Rusanov(),
-        numfluxdiff        = CentralNumericalFluxDiffusive(),
-        gradnumflux        = CentralNumericalFluxGradient()
-    ) where {FT<:AbstractFloat}
-    @info @sprintf("""Establishing Atmos GCM configuration for %s
-                   precision        = %s
-                   polynomial order = %d
-                   #horiz elems     = %d
-                   #vert_elems      = %d
-                   domain height    = %.2e
-                   MPI ranks        = %d""",
-                   name, FT, N,
-                   nelem_horz, nelem_vert, domain_height,
-                   MPI.Comm_size(mpicomm))
+    name::String,
+    N::Int,
+    (nelem_horz, nelem_vert)::NTuple{2, Int},
+    domain_height::FT,
+    init_GCM!;
+    array_type = CLIMA.array_type(),
+    solver_type = DefaultSolverType(),
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType;
+        init_state = init_GCM!,
+        param_set = ParameterSet{FT}(),
+    ),
+    mpicomm = MPI.COMM_WORLD,
+    meshwarp::Function = cubedshellwarp,
+    numfluxnondiff = Rusanov(),
+    numfluxdiff = CentralNumericalFluxDiffusive(),
+    gradnumflux = CentralNumericalFluxGradient(),
+) where {FT <: AbstractFloat}
+    @info @sprintf(
+        """Establishing Atmos GCM configuration for %s
+        precision        = %s
+        polynomial order = %d
+        #horiz elems     = %d
+        #vert_elems      = %d
+        domain height    = %.2e
+        MPI ranks        = %d""",
+        name,
+        FT,
+        N,
+        nelem_horz,
+        nelem_vert,
+        domain_height,
+        MPI.Comm_size(mpicomm)
+    )
 
-    vert_range = grid1d(FT(planet_radius), FT(planet_radius+domain_height), nelem=nelem_vert)
+    vert_range = grid1d(
+        FT(planet_radius),
+        FT(planet_radius + domain_height),
+        nelem = nelem_vert,
+    )
 
     topology = StackedCubedSphereTopology(mpicomm, nelem_horz, vert_range)
 
-    grid = DiscontinuousSpectralElementGrid(topology,
-                                            FloatType=FT,
-                                            DeviceArray=array_type,
-                                            polynomialorder=N,
-                                            meshwarp=meshwarp)
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = array_type,
+        polynomialorder = N,
+        meshwarp = meshwarp,
+    )
 
-    return DriverConfiguration(AtmosGCMConfigType(), name, N, FT, array_type,
-                               solver_type, model, mpicomm, grid,
-                               numfluxnondiff, numfluxdiff, gradnumflux,
-                               AtmosGCMSpecificInfo(domain_height, nelem_vert, nelem_horz))
+    return DriverConfiguration(
+        AtmosGCMConfigType(),
+        name,
+        N,
+        FT,
+        array_type,
+        solver_type,
+        model,
+        mpicomm,
+        grid,
+        numfluxnondiff,
+        numfluxdiff,
+        gradnumflux,
+        AtmosGCMSpecificInfo(domain_height, nelem_vert, nelem_horz),
+    )
 end
 
 function OceanBoxGCMConfiguration(
     name::String,
     N::Int,
-    (Nˣ, Nʸ, Nᶻ)::NTuple{3,Int},
+    (Nˣ, Nʸ, Nᶻ)::NTuple{3, Int},
     model::HydrostaticBoussinesqModel;
-    FT             = Float64,
-    array_type     = CLIMA.array_type(),
-    solver_type    = ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch),
-    mpicomm        = MPI.COMM_WORLD,
+    FT = Float64,
+    array_type = CLIMA.array_type(),
+    solver_type = ExplicitSolverType(
+        solver_method = LSRK144NiegemannDiehlBusch,
+    ),
+    mpicomm = MPI.COMM_WORLD,
     numfluxnondiff = Rusanov(),
-    numfluxdiff    = CentralNumericalFluxDiffusive(),
-    gradnumflux    = CentralNumericalFluxGradient(),
-    periodicity    = (false, false, false),
-    boundary       = ((1, 1), (1, 1), (2, 3))
+    numfluxdiff = CentralNumericalFluxDiffusive(),
+    gradnumflux = CentralNumericalFluxGradient(),
+    periodicity = (false, false, false),
+    boundary = ((1, 1), (1, 1), (2, 3)),
+)
+
+    brickrange = (
+        range(FT(0); length = Nˣ + 1, stop = model.problem.Lˣ),
+        range(FT(0); length = Nʸ + 1, stop = model.problem.Lʸ),
+        range(FT(-model.problem.H); length = Nᶻ + 1, stop = 0),
     )
 
-    brickrange = (range(FT(0);  length=Nˣ+1, stop=model.problem.Lˣ),
-                  range(FT(0);  length=Nʸ+1, stop=model.problem.Lʸ),
-                  range(FT(-model.problem.H); length=Nᶻ+1, stop=0))
+    topology = StackedBrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = periodicity,
+        boundary = boundary,
+    )
 
-    topology = StackedBrickTopology(mpicomm, brickrange;
-                                    periodicity = periodicity,
-                                    boundary = boundary)
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = array_type,
+        polynomialorder = N,
+    )
 
-    grid = DiscontinuousSpectralElementGrid(topology,
-                                            FloatType = FT,
-                                            DeviceArray = array_type,
-                                            polynomialorder = N)
-
-    return DriverConfiguration(OceanBoxGCMConfigType(), name, N, FT, array_type,
-                               solver_type, model, mpicomm, grid,
-                               numfluxnondiff, numfluxdiff, gradnumflux,
-                               OceanBoxGCMSpecificInfo())
+    return DriverConfiguration(
+        OceanBoxGCMConfigType(),
+        name,
+        N,
+        FT,
+        array_type,
+        solver_type,
+        model,
+        mpicomm,
+        grid,
+        numfluxnondiff,
+        numfluxdiff,
+        gradnumflux,
+        OceanBoxGCMSpecificInfo(),
+    )
 end

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -31,8 +31,13 @@ pointwise throughout the domain with the model defined by `solver_config`. The
 keyword arguments `Q` and `dt` can be used to call the courant method with a
 different state `Q` or time step `dt` than are defined in `solver_config`.
 """
-DGmethods.courant(f, sc::SolverConfiguration; Q=sc.Q, dt = sc.dt, direction = EveryDirection()) =
-  DGmethods.courant(f, sc.dg, sc.dg.balancelaw, Q, dt, direction)
+DGmethods.courant(
+    f,
+    sc::SolverConfiguration;
+    Q = sc.Q,
+    dt = sc.dt,
+    direction = EveryDirection(),
+) = DGmethods.courant(f, sc.dg, sc.dg.balancelaw, Q, dt, direction)
 
 """
     CLIMA.setup_solver(t0::FT,
@@ -64,18 +69,20 @@ the ODE solver, and return a `SolverConfiguration` to be used with
 # - `timeend_dt_adjust=true`: should `dt` be adjusted to hit `timeend` exactly
 # - `CFL_direction=EveryDirection()`: direction for `calculate_dt`
 """
-function setup_solver(t0::FT, timeend::FT,
-                      driver_config::DriverConfiguration,
-                      init_args...;
-                      init_on_cpu=false,
-                      ode_solver_type=driver_config.solver_type,
-                      ode_dt=nothing,
-                      modeldata=nothing,
-                      Courant_number=0.4,
-                      diffdir=EveryDirection(),
-                      timeend_dt_adjust=true,
-                      CFL_direction=EveryDirection()
-                     ) where {FT<:AbstractFloat}
+function setup_solver(
+    t0::FT,
+    timeend::FT,
+    driver_config::DriverConfiguration,
+    init_args...;
+    init_on_cpu = false,
+    ode_solver_type = driver_config.solver_type,
+    ode_dt = nothing,
+    modeldata = nothing,
+    Courant_number = 0.4,
+    diffdir = EveryDirection(),
+    timeend_dt_adjust = true,
+    CFL_direction = EveryDirection(),
+) where {FT <: AbstractFloat}
     @tic setup_solver
 
     bl = driver_config.bl
@@ -85,11 +92,17 @@ function setup_solver(t0::FT, timeend::FT,
     gradnumflux = driver_config.gradnumflux
 
     # create DG model, initialize ODE state
-    dg = DGModel(bl, grid, numfluxnondiff, numfluxdiff, gradnumflux,
-                 modeldata=modeldata,
-                 diffusion_direction=diffdir)
+    dg = DGModel(
+        bl,
+        grid,
+        numfluxnondiff,
+        numfluxdiff,
+        gradnumflux,
+        modeldata = modeldata,
+        diffusion_direction = diffdir,
+    )
     @info @sprintf("Initializing %s", driver_config.name)
-    Q = init_ode_state(dg, FT(0), init_args...; init_on_cpu=init_on_cpu)
+    Q = init_ode_state(dg, FT(0), init_args...; init_on_cpu = init_on_cpu)
     update_aux!(dg, bl, Q, FT(0))
 
     # create the linear model for IMEX solvers
@@ -110,32 +123,62 @@ function setup_solver(t0::FT, timeend::FT,
 
     # create the solver
     if isa(ode_solver_type, ExplicitSolverType)
-        solver = ode_solver_type.solver_method(dg, Q; dt=ode_dt, t0=t0)
+        solver = ode_solver_type.solver_method(dg, Q; dt = ode_dt, t0 = t0)
     elseif isa(ode_solver_type, MultirateSolverType)
-        fast_dg = DGModel(linmodel, grid,
-                          numfluxnondiff, numfluxdiff, gradnumflux,
-                          auxstate=dg.auxstate)
+        fast_dg = DGModel(
+            linmodel,
+            grid,
+            numfluxnondiff,
+            numfluxdiff,
+            gradnumflux,
+            auxstate = dg.auxstate,
+        )
         slow_model = RemainderModel(bl, (linmodel,))
-        slow_dg = DGModel(slow_model, grid,
-                          numfluxnondiff, numfluxdiff, gradnumflux,
-                          auxstate=dg.auxstate)
-        slow_solver = ode_solver_type.slow_method(slow_dg, Q; dt=ode_dt)
+        slow_dg = DGModel(
+            slow_model,
+            grid,
+            numfluxnondiff,
+            numfluxdiff,
+            gradnumflux,
+            auxstate = dg.auxstate,
+        )
+        slow_solver = ode_solver_type.slow_method(slow_dg, Q; dt = ode_dt)
         fast_dt = ode_dt / ode_solver_type.timestep_ratio
-        fast_solver = ode_solver_type.fast_method(fast_dg, Q; dt=fast_dt)
+        fast_solver = ode_solver_type.fast_method(fast_dg, Q; dt = fast_dt)
         solver = ode_solver_type.solver_method((slow_solver, fast_solver))
     else # solver_type === IMEXSolverType
-        vdg = DGModel(linmodel, grid,
-                      numfluxnondiff, numfluxdiff, gradnumflux,
-                      auxstate=dg.auxstate,
-                      direction=VerticalDirection())
-        solver = ode_solver_type.solver_method(dg, vdg,
-                                               ode_solver_type.linear_solver(), Q;
-                                               dt=ode_dt, t0=t0)
+        vdg = DGModel(
+            linmodel,
+            grid,
+            numfluxnondiff,
+            numfluxdiff,
+            gradnumflux,
+            auxstate = dg.auxstate,
+            direction = VerticalDirection(),
+        )
+        solver = ode_solver_type.solver_method(
+            dg,
+            vdg,
+            ode_solver_type.linear_solver(),
+            Q;
+            dt = ode_dt,
+            t0 = t0,
+        )
     end
 
     @toc setup_solver
 
-    return SolverConfiguration(driver_config.name, driver_config.mpicomm, dg, Q,
-                               t0, timeend, ode_dt, init_on_cpu, numberofsteps,
-                               init_args, solver)
+    return SolverConfiguration(
+        driver_config.name,
+        driver_config.mpicomm,
+        dg,
+        Q,
+        t0,
+        timeend,
+        ode_dt,
+        init_on_cpu,
+        numberofsteps,
+        init_args,
+        solver,
+    )
 end

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -1,0 +1,109 @@
+using StaticArrays
+using Test
+
+using CLIMA
+using CLIMA.Atmos
+using CLIMA.ConfigTypes
+using CLIMA.PlanetParameters
+using CLIMA.MoistThermodynamics
+using CLIMA.PlanetParameters
+using CLIMA.VariableTemplates
+using CLIMA.Grids
+using CLIMA.ODESolvers
+using CLIMA.GenericCallbacks: EveryXSimulationSteps
+using CLIMA.Mesh.Filters
+
+Base.@kwdef struct AcousticWaveSetup{FT}
+    domain_height::FT = 10e3
+    T_ref::FT = 300
+    α::FT = 3
+    γ::FT = 100
+    nv::Int = 1
+end
+
+function (setup::AcousticWaveSetup)(bl, state, aux, coords, t)
+    # callable to set initial conditions
+    FT = eltype(state)
+
+    λ = longitude(bl.orientation, aux)
+    φ = latitude(bl.orientation, aux)
+    z = altitude(bl.orientation, aux)
+
+    β = min(FT(1), setup.α * acos(cos(φ) * cos(λ)))
+    f = (1 + cos(FT(π) * β)) / 2
+    g = sin(setup.nv * FT(π) * z / setup.domain_height)
+    Δp = setup.γ * f * g
+    p = aux.ref_state.p + Δp
+
+    ts       = PhaseDry_given_pT(p, setup.T_ref)
+    q_pt     = PhasePartition(ts)
+    e_pot    = gravitational_potential(bl.orientation, aux)
+    e_int    = internal_energy(ts)
+
+    state.ρ  = air_density(ts)
+    state.ρu = SVector{3, FT}(0, 0, 0)
+    state.ρe = state.ρ * (e_int + e_pot)
+    return nothing
+end
+
+function main()
+    CLIMA.init()
+
+    FT = Float64
+
+    # DG polynomial order
+    N = 4
+
+    # Domain resolution
+    nelem_horz = 4
+    nelem_vert = 6
+    resolution = (nelem_horz, nelem_vert)
+
+    t0 = FT(0)
+    timeend = FT(1800)
+    # Timestep size (s)
+    dt = FT(600)
+
+    setup = AcousticWaveSetup{FT}()
+    orientation = SphericalOrientation()
+    ref_state = HydrostaticState(IsothermalProfile(setup.T_ref), FT(0))
+    turbulence = ConstantViscosityWithDivergence(FT(0))
+    model = AtmosModel{FT}(AtmosGCMConfigType;
+                           orientation = orientation,
+                           ref_state   = ref_state,
+                           turbulence  = turbulence,
+                           moisture    = DryModel(),
+                           source      = Gravity(),
+                           init_state  = setup,
+                           param_set   = CLIMA.ParameterSet{FT}())
+
+    ode_solver = CLIMA.MultirateSolverType(linear_model   = AtmosAcousticGravityLinearModel,
+                                           slow_method    = LSRK144NiegemannDiehlBusch,
+                                           fast_method    = LSRK144NiegemannDiehlBusch,
+                                           timestep_ratio = 180)
+    driver_config = CLIMA.AtmosGCMConfiguration("GCM Driver test", N, resolution,
+                                                setup.domain_height,
+                                                setup;
+                                                solver_type = ode_solver,
+                                                model = model)
+    solver_config = CLIMA.setup_solver(t0, timeend, driver_config,
+                                       ode_dt = dt)
+
+    # Set up the filter callback
+    filterorder = 18
+    filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
+    cbfilter = EveryXSimulationSteps(1) do
+        Filters.apply!(solver_config.Q, 1:size(solver_config.Q, 2),
+                       solver_config.dg.grid, filter, VerticalDirection())
+        return nothing
+    end
+
+    cb_test = 0
+    result = CLIMA.invoke!(solver_config;
+                           user_callbacks=(cbfilter,),
+                           user_info_callback=(init)->cb_test+=1,
+                           check_euclidean_distance=true)
+    @test cb_test > 0
+end
+
+main()

--- a/test/Driver/runtests.jl
+++ b/test/Driver/runtests.jl
@@ -2,10 +2,7 @@ using MPI, Test
 include("../testhelpers.jl")
 
 @testset "Driver" begin
-  tests = [
-    (1,"driver_test.jl"),
-    (1,"gcm_driver_test.jl")
-   ]
+    tests = [(1, "driver_test.jl"), (1, "gcm_driver_test.jl")]
 
-  runmpi(tests, @__FILE__)
+    runmpi(tests, @__FILE__)
 end

--- a/test/Driver/runtests.jl
+++ b/test/Driver/runtests.jl
@@ -3,7 +3,8 @@ include("../testhelpers.jl")
 
 @testset "Driver" begin
   tests = [
-    (1,"driver_test.jl")
+    (1,"driver_test.jl"),
+    (1,"gcm_driver_test.jl")
    ]
 
   runmpi(tests, @__FILE__)


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

This PR simply adds a multirate solver type that executes a 2-rate method. The idea is that slow (advection & diffusion) processes are evaluated using a slow method (some explicit RK method) and the fast (acoustic waves, gravity waves) processes using a fast method with a smaller time-step size.

I tried to not modify the current interface too much, but I am not really happy with the handling of these solver types. I think it can be done in a far more clean way, but I want to save that for another PR. I tried to keep the changes in the PR fairly minimal.

This PR just adds a quick multirate solver to be used in the LES experiments. An example is shown for the risingbubble test in `Atmos_LES`.

[UPDATE]: I've added a gcm driver test (acoustic wave) using the multirate solver. This also demonstrates that multirate actually deals with the acoustic modes properly.

Feel free to leave comments and add any suggestions.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
