### PR TITLE
Make tests flexibly callable

### DIFF
--- a/test/Atmos/Parameterizations/runtests.jl
+++ b/test/Atmos/Parameterizations/runtests.jl
@@ -1,0 +1,20 @@
+using Test, Pkg
+
+@testset "Parameterizations" begin
+    if isempty(ARGS) || "all" in ARGS
+        all_tests = true
+    else
+        all_tests = false
+    end
+    for submodule in [
+                      "Microphysics",
+                      "SurfaceFluxes",
+                      "TurbulenceConvection",
+                     ]
+
+      if all_tests || "$submodule" in ARGS || "Parameterizations" in ARGS || "Atmos" in ARGS
+        include_test(submodule)
+      end
+    end
+
+end

--- a/test/Atmos/runtests.jl
+++ b/test/Atmos/runtests.jl
@@ -1,0 +1,18 @@
+using Test, Pkg
+
+@testset "Atmos" begin
+    if isempty(ARGS) || "all" in ARGS
+        all_tests = true
+    else
+        all_tests = false
+    end
+    for submodule in [
+                      "Parameterizations",
+                     ]
+
+      if all_tests || "$submodule" in ARGS || "Atmos" in ARGS
+        include_test(submodule)
+      end
+    end
+
+end

--- a/test/Common/runtests.jl
+++ b/test/Common/runtests.jl
@@ -1,0 +1,19 @@
+using Test, Pkg
+
+@testset "Common" begin
+    if isempty(ARGS) || "all" in ARGS
+        all_tests = true
+    else
+        all_tests = false
+    end
+    for submodule in [
+                      "MoistThermodynamics",
+                      "PlanetParameters",
+                     ]
+
+      if all_tests || "$submodule" in ARGS || "Common" in ARGS
+        include_test(submodule)
+      end
+    end
+
+end

--- a/test/Utilities/runtests.jl
+++ b/test/Utilities/runtests.jl
@@ -1,0 +1,21 @@
+using Test, Pkg
+
+@testset "Utilities" begin
+    if isempty(ARGS) || "all" in ARGS
+        all_tests = true
+    else
+        all_tests = false
+    end
+    for submodule in [
+                      "TicToc",
+                      "VariableTemplates",
+                      "ParametersType",
+                      "RootSolvers",
+                     ]
+
+      if all_tests || "$submodule" in ARGS || "Utilities" in ARGS
+        include_test(submodule)
+      end
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,27 +3,38 @@ using Test, Pkg
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 ENV["JULIA_LOG_LEVEL"] = "WARN"
 
-for submodule in [
-                  "Utilities/TicToc",
-                  "Utilities/VariableTemplates",
-                  "Utilities/ParametersType",
-                  "Utilities/RootSolvers",
-                  "Common/PlanetParameters",
-                  "Common/MoistThermodynamics",
-                  "Atmos/Parameterizations/SurfaceFluxes",
-                  "Atmos/Parameterizations/TurbulenceConvection",
-                  "Atmos/Parameterizations/Microphysics",
-                  "Mesh",
-                  "DGmethods",
-                  "Diagnostics",
-                  "ODESolvers",
-                  "Ocean",
-                  "Arrays",
-                  "LinearSolvers",
-                  "Driver",
-                 ]
+function include_test(_module)
+  println("Starting tests for $_module")
+  t = @elapsed include(joinpath(_module,"runtests.jl"))
+  println("Completed tests for $_module, $(round(Int, t)) seconds elapsed")
+  return nothing
+end
 
-  println("Starting tests for $submodule")
-  t = @elapsed include(joinpath(submodule,"runtests.jl"))
-  println("Completed tests for $submodule, $(round(Int, t)) seconds elapsed")
+
+@testset "CLIMA" begin
+    if isempty(ARGS) || "all" in ARGS
+        all_tests = true
+    else
+        all_tests = false
+    end
+
+    for submodule in [
+                      "Utilities",
+                      "Common",
+                      "Atmos",
+                      "Mesh",
+                      "DGmethods",
+                      "Diagnostics",
+                      "ODESolvers",
+                      "Ocean",
+                      "Arrays",
+                      "LinearSolvers",
+                      "Driver",
+                     ]
+
+      if all_tests || "$submodule" in ARGS || "CLIMA" in ARGS
+        include_test(submodule)
+      end
+    end
+
 end


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

This adds flexibility to call specific tests, using [command line args](https://github.com/JuliaLang/Pkg.jl/pull/1226).

Now, we can call a specific test as follows

```
julia --project test/runtests.jl Common
Starting tests for Common
Starting tests for MoistThermodynamics
[ Info: CUDAdrv.jl failed to initialize, GPU functionality unavailable (set JULIA_CUDA_SILENT or JULIA_CUDA_VERBOSE to silence or expand this message)
Completed tests for MoistThermodynamics, 30 seconds elapsed
Starting tests for PlanetParameters
Completed tests for PlanetParameters, 0 seconds elapsed
Completed tests for Common, 31 seconds elapsed
Test Summary: | Pass  Total
CLIMA         |  457    457
```

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
