### PR TITLE
Update DYCOMS subsidence parameter to reflect 14400s offline simulations

### DIFF
--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -20,16 +20,21 @@ using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 
-import CLIMA.DGmethods: vars_state, vars_aux,
-                        vars_integrals, vars_reverse_integrals,
-                        indefinite_stack_integral!,
-                        reverse_indefinite_stack_integral!,
-                        integral_load_aux!, integral_set_aux!,
-                        reverse_integral_load_aux!,
-                        reverse_integral_set_aux!
+import CLIMA.DGmethods:
+    vars_state,
+    vars_aux,
+    vars_integrals,
+    vars_reverse_integrals,
+    indefinite_stack_integral!,
+    reverse_indefinite_stack_integral!,
+    integral_load_aux!,
+    integral_set_aux!,
+    reverse_integral_load_aux!,
+    reverse_integral_set_aux!
 
 import CLIMA.DGmethods: boundary_state!
-import CLIMA.Atmos: atmos_boundary_state!, atmos_boundary_flux_diffusive!, flux_diffusive!
+import CLIMA.Atmos:
+    atmos_boundary_state!, atmos_boundary_flux_diffusive!, flux_diffusive!
 import CLIMA.DGmethods.NumericalFluxes: boundary_flux_diffusive!
 
 # -------------------- Radiation Model -------------------------- #
@@ -38,13 +43,35 @@ vars_aux(::RadiationModel, FT) = @vars()
 vars_integrals(::RadiationModel, FT) = @vars()
 vars_reverse_integrals(::RadiationModel, FT) = @vars()
 
-function atmos_nodal_update_aux!(::RadiationModel, ::AtmosModel, state::Vars, aux::Vars, t::Real) end
+function atmos_nodal_update_aux!(
+    ::RadiationModel,
+    ::AtmosModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
 function preodefun!(::RadiationModel, aux::Vars, state::Vars, t::Real) end
-function integral_load_aux!(::RadiationModel, integ::Vars, state::Vars, aux::Vars) end
+function integral_load_aux!(
+    ::RadiationModel,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+) end
 function integral_set_aux!(::RadiationModel, aux::Vars, integ::Vars) end
-function reverse_integral_load_aux!(::RadiationModel, integ::Vars, state::Vars, aux::Vars) end
+function reverse_integral_load_aux!(
+    ::RadiationModel,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+) end
 function reverse_integral_set_aux!(::RadiationModel, aux::Vars, integ::Vars) end
-function flux_radiation!(::RadiationModel, flux::Grad, state::Vars, aux::Vars, t::Real) end
+function flux_radiation!(
+    ::RadiationModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
 
 
 # ---------------------------- Begin Boundary Conditions ----------------- #
@@ -55,12 +82,12 @@ function flux_radiation!(::RadiationModel, flux::Grad, state::Vars, aux::Vars, t
 $(DocStringExtensions.FIELDS)
 """
 struct DYCOMS_BC{FT} <: BoundaryCondition
-  "Drag coefficient"
-  C_drag::FT
-  "Latent Heat Flux"
-  LHF::FT
-  "Sensible Heat Flux"
-  SHF::FT
+    "Drag coefficient"
+    C_drag::FT
+    "Latent Heat Flux"
+    LHF::FT
+    "Sensible Heat Flux"
+    SHF::FT
 end
 
 """
@@ -69,9 +96,11 @@ end
 
 For the non-diffussive and gradient terms we just use the `NoFluxBC`
 """
-atmos_boundary_state!(nf::Union{NumericalFluxNonDiffusive, NumericalFluxGradient},
-                      bc::DYCOMS_BC,
-                      args...) = atmos_boundary_state!(nf, NoFluxBC(), args...)
+atmos_boundary_state!(
+    nf::Union{NumericalFluxNonDiffusive, NumericalFluxGradient},
+    bc::DYCOMS_BC,
+    args...,
+) = atmos_boundary_state!(nf, NoFluxBC(), args...)
 
 """
     atmos_boundary_flux_diffusive!(nf::NumericalFluxDiffusive,
@@ -84,74 +113,109 @@ atmos_boundary_state!(nf::Union{NumericalFluxNonDiffusive, NumericalFluxGradient
 
 When `bctype == 1` the `NoFluxBC` otherwise the specialized DYCOMS BC is used
 """
-function atmos_boundary_flux_diffusive!(nf::CentralNumericalFluxDiffusive,
-                                        bc::DYCOMS_BC,
-                                        atmos::AtmosModel, F,
-                                        state⁺, diff⁺, hyperdiff⁺, aux⁺,
-                                        n⁻,
-                                        state⁻, diff⁻, hyperdiff⁻, aux⁻,
-                                        bctype, t,
-                                        state1⁻, diff1⁻, aux1⁻)
-  if bctype != 1
-    atmos_boundary_flux_diffusive!(nf, NoFluxBC(), atmos, F,
-                                   state⁺, diff⁺, hyperdiff⁺, aux⁺, n⁻,
-                                   state⁻, diff⁻, hyperdiff⁻, aux⁻,
-                                   bctype, t,
-                                   state1⁻, diff1⁻, aux1⁻)
-  else
-    # Start with the noflux BC and then build custom flux from there
-    atmos_boundary_state!(nf, NoFluxBC(), atmos,
-                          state⁺, diff⁺, aux⁺, n⁻,
-                          state⁻, diff⁻, aux⁻,
-                          bctype, t)
+function atmos_boundary_flux_diffusive!(
+    nf::CentralNumericalFluxDiffusive,
+    bc::DYCOMS_BC,
+    atmos::AtmosModel,
+    F,
+    state⁺,
+    diff⁺,
+    hyperdiff⁺,
+    aux⁺,
+    n⁻,
+    state⁻,
+    diff⁻,
+    hyperdiff⁻,
+    aux⁻,
+    bctype,
+    t,
+    state1⁻,
+    diff1⁻,
+    aux1⁻,
+)
+    if bctype != 1
+        atmos_boundary_flux_diffusive!(
+            nf,
+            NoFluxBC(),
+            atmos,
+            F,
+            state⁺,
+            diff⁺,
+            hyperdiff⁺,
+            aux⁺,
+            n⁻,
+            state⁻,
+            diff⁻,
+            hyperdiff⁻,
+            aux⁻,
+            bctype,
+            t,
+            state1⁻,
+            diff1⁻,
+            aux1⁻,
+        )
+    else
+        # Start with the noflux BC and then build custom flux from there
+        atmos_boundary_state!(
+            nf,
+            NoFluxBC(),
+            atmos,
+            state⁺,
+            diff⁺,
+            aux⁺,
+            n⁻,
+            state⁻,
+            diff⁻,
+            aux⁻,
+            bctype,
+            t,
+        )
 
-    # ------------------------------------------------------------------------
-    # (<var>_FN) First node values (First interior node from bottom wall)
-    # ------------------------------------------------------------------------
-    u_FN = state1⁻.ρu / state1⁻.ρ
-    windspeed_FN = norm(u_FN)
+        # ------------------------------------------------------------------------
+        # (<var>_FN) First node values (First interior node from bottom wall)
+        # ------------------------------------------------------------------------
+        u_FN = state1⁻.ρu / state1⁻.ρ
+        windspeed_FN = norm(u_FN)
 
-    # ----------------------------------------------------------
-    # Extract components of diffusive momentum flux (minus-side)
-    # ----------------------------------------------------------
-    _, τ⁻ = turbulence_tensors(atmos.turbulence, state⁻, diff⁻, aux⁻, t)
+        # ----------------------------------------------------------
+        # Extract components of diffusive momentum flux (minus-side)
+        # ----------------------------------------------------------
+        _, τ⁻ = turbulence_tensors(atmos.turbulence, state⁻, diff⁻, aux⁻, t)
 
-    # ----------------------------------------------------------
-    # Boundary momentum fluxes
-    # ----------------------------------------------------------
-    # Case specific for flat bottom topography, normal vector is n⃗ = k⃗ = [0, 0, 1]ᵀ
-    # A more general implementation requires (n⃗ ⋅ ∇A) to be defined where A is
-    # replaced by the appropriate flux terms
-    C_drag = bc.C_drag
-    @inbounds begin
-      τ13⁺ = - C_drag * windspeed_FN * u_FN[1]
-      τ23⁺ = - C_drag * windspeed_FN * u_FN[2]
-      τ21⁺ = τ⁻[2,1]
+        # ----------------------------------------------------------
+        # Boundary momentum fluxes
+        # ----------------------------------------------------------
+        # Case specific for flat bottom topography, normal vector is n⃗ = k⃗ = [0, 0, 1]ᵀ
+        # A more general implementation requires (n⃗ ⋅ ∇A) to be defined where A is
+        # replaced by the appropriate flux terms
+        C_drag = bc.C_drag
+        @inbounds begin
+            τ13⁺ = -C_drag * windspeed_FN * u_FN[1]
+            τ23⁺ = -C_drag * windspeed_FN * u_FN[2]
+            τ21⁺ = τ⁻[2, 1]
+        end
+
+        # Assign diffusive momentum and moisture fluxes
+        # (i.e. ρ𝛕 terms)
+        FT = eltype(state⁺)
+        τ⁺ = SHermitianCompact{3, FT, 6}(SVector(0, τ21⁺, τ13⁺, 0, τ23⁺, 0))
+
+        # ----------------------------------------------------------
+        # Boundary moisture fluxes
+        # ----------------------------------------------------------
+        # really ∇q_tot is being used to store d_q_tot
+        d_q_tot⁺ = SVector(0, 0, bc.LHF / (LH_v0))
+
+        # ----------------------------------------------------------
+        # Boundary energy fluxes
+        # ----------------------------------------------------------
+        # Assign diffusive enthalpy flux (i.e. ρ(J+D) terms)
+        d_h_tot⁺ = SVector(0, 0, bc.LHF + bc.SHF)
+
+        # Set the flux using the now defined plus-side data
+        flux_diffusive!(atmos, F, state⁺, τ⁺, d_h_tot⁺)
+        flux_diffusive!(atmos.moisture, F, state⁺, d_q_tot⁺)
     end
-
-    # Assign diffusive momentum and moisture fluxes
-    # (i.e. ρ𝛕 terms)
-    FT = eltype(state⁺)
-    τ⁺ = SHermitianCompact{3, FT, 6}(SVector(0   ,
-                                             τ21⁺, τ13⁺,
-                                             0   , τ23⁺, 0))
-
-    # ----------------------------------------------------------
-    # Boundary moisture fluxes
-    # ----------------------------------------------------------
-    # really ∇q_tot is being used to store d_q_tot
-    d_q_tot⁺  = SVector(0, 0, bc.LHF/(LH_v0))
-
-    # ----------------------------------------------------------
-    # Boundary energy fluxes
-    # ----------------------------------------------------------
-    # Assign diffusive enthalpy flux (i.e. ρ(J+D) terms)
-    d_h_tot⁺ = SVector(0, 0, bc.LHF + bc.SHF)
-
-    # Set the flux using the now defined plus-side data
-    flux_diffusive!(atmos, F, state⁺, τ⁺, d_h_tot⁺)
-    flux_diffusive!(atmos.moisture, F, state⁺, d_q_tot⁺)
-  end
 end
 # ------------------------ End Boundary Condition --------------------- #
 
@@ -166,58 +230,84 @@ Analytical description as a function of the liquid water path and inversion heig
 * Stevens, B. et. al. (2005) "Evaluation of Large-Eddy Simulations via Observations of Nocturnal Marine Stratocumulus". Mon. Wea. Rev., 133, 1443–1462, https://doi.org/10.1175/MWR2930.1
 """
 struct DYCOMSRadiation{FT} <: RadiationModel
-  "mass absorption coefficient `[m^2/kg]`"
-  κ::FT
-  "Troposphere cooling parameter `[m^(-4/3)]`"
-  α_z::FT
-  "Inversion height `[m]`"
-  z_i::FT
-  "Density"
-  ρ_i::FT
-  "Large scale divergence `[s^(-1)]`"
-  D_subsidence::FT
-  "Radiative flux parameter `[W/m^2]`"
-  F_0::FT
-  "Radiative flux parameter `[W/m^2]`"
-  F_1::FT
+    "mass absorption coefficient `[m^2/kg]`"
+    κ::FT
+    "Troposphere cooling parameter `[m^(-4/3)]`"
+    α_z::FT
+    "Inversion height `[m]`"
+    z_i::FT
+    "Density"
+    ρ_i::FT
+    "Large scale divergence `[s^(-1)]`"
+    D_subsidence::FT
+    "Radiative flux parameter `[W/m^2]`"
+    F_0::FT
+    "Radiative flux parameter `[W/m^2]`"
+    F_1::FT
 end
 
 vars_aux(m::DYCOMSRadiation, FT) = @vars(Rad_flux::FT)
 
 vars_integrals(m::DYCOMSRadiation, FT) = @vars(attenuation_coeff::FT)
-function integral_load_aux!(m::DYCOMSRadiation, integrand::Vars, state::Vars, aux::Vars)
-  FT = eltype(state)
-  integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
+function integral_load_aux!(
+    m::DYCOMSRadiation,
+    integrand::Vars,
+    state::Vars,
+    aux::Vars,
+)
+    FT = eltype(state)
+    integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
 end
 function integral_set_aux!(m::DYCOMSRadiation, aux::Vars, integrand::Vars)
-  integrand = integrand.radiation.attenuation_coeff
-  aux.∫dz.radiation.attenuation_coeff = integrand
+    integrand = integrand.radiation.attenuation_coeff
+    aux.∫dz.radiation.attenuation_coeff = integrand
 end
 
 vars_reverse_integrals(m::DYCOMSRadiation, FT) = @vars(attenuation_coeff::FT)
-function reverse_integral_load_aux!(m::DYCOMSRadiation, integrand::Vars, state::Vars, aux::Vars)
-  FT = eltype(state)
-  integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
+function reverse_integral_load_aux!(
+    m::DYCOMSRadiation,
+    integrand::Vars,
+    state::Vars,
+    aux::Vars,
+)
+    FT = eltype(state)
+    integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
 end
-function reverse_integral_set_aux!(m::DYCOMSRadiation, aux::Vars, integrand::Vars)
-  aux.∫dnz.radiation.attenuation_coeff = integrand.radiation.attenuation_coeff
+function reverse_integral_set_aux!(
+    m::DYCOMSRadiation,
+    aux::Vars,
+    integrand::Vars,
+)
+    aux.∫dnz.radiation.attenuation_coeff = integrand.radiation.attenuation_coeff
 end
 
-function flux_radiation!(m::DYCOMSRadiation, atmos::AtmosModel, flux::Grad, state::Vars,
-                         aux::Vars, t::Real)
-  FT = eltype(flux)
-  z = altitude(atmos.orientation, aux)
-  Δz_i = max(z - m.z_i, -zero(FT))
-  # Constants
-  upward_flux_from_cloud  = m.F_0 * exp(-aux.∫dnz.radiation.attenuation_coeff)
-  upward_flux_from_sfc = m.F_1 * exp(-aux.∫dz.radiation.attenuation_coeff)
-  free_troposphere_flux = m.ρ_i * FT(cp_d) * m.D_subsidence * m.α_z * cbrt(Δz_i) * (Δz_i/4 + m.z_i)
-  F_rad = upward_flux_from_sfc + upward_flux_from_cloud + free_troposphere_flux
-  ẑ = vertical_unit_vector(atmos.orientation, aux)
-  flux.ρe += F_rad * ẑ
+function flux_radiation!(
+    m::DYCOMSRadiation,
+    atmos::AtmosModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    FT = eltype(flux)
+    z = altitude(atmos.orientation, aux)
+    Δz_i = max(z - m.z_i, -zero(FT))
+    # Constants
+    upward_flux_from_cloud = m.F_0 * exp(-aux.∫dnz.radiation.attenuation_coeff)
+    upward_flux_from_sfc = m.F_1 * exp(-aux.∫dz.radiation.attenuation_coeff)
+    free_troposphere_flux =
+        m.ρ_i *
+        FT(cp_d) *
+        m.D_subsidence *
+        m.α_z *
+        cbrt(Δz_i) *
+        (Δz_i / 4 + m.z_i)
+    F_rad =
+        upward_flux_from_sfc + upward_flux_from_cloud + free_troposphere_flux
+    ẑ = vertical_unit_vector(atmos.orientation, aux)
+    flux.ρe += F_rad * ẑ
 end
-function preodefun!(m::DYCOMSRadiation, aux::Vars, state::Vars, t::Real)
-end
+function preodefun!(m::DYCOMSRadiation, aux::Vars, state::Vars, t::Real) end
 # -------------------------- End Radiation Model ------------------------ #
 
 """
@@ -240,30 +330,29 @@ URL = {https://doi.org/10.1175/MWR2930.1},
 eprint = {https://doi.org/10.1175/MWR2930.1}
 }
 """
-function init_dycoms!(bl, state, aux, (x,y,z), t)
+function init_dycoms!(bl, state, aux, (x, y, z), t)
     FT = eltype(state)
 
     z = altitude(bl.orientation, aux)
 
-    # These constants are those used by Stevens et al. (2005)
-    qref       = FT(9.0e-3)
-    q_pt_sfc   = PhasePartition(qref)
-    Rm_sfc     = FT(gas_constant_air(q_pt_sfc, bl.param_set))
-    T_sfc      = FT(290.4)
-    P_sfc      = FT(MSLP)
+    qref = FT(8.5e-3)
+    q_pt_sfc = PhasePartition(qref)
+    Rm_sfc = FT(gas_constant_air(q_pt_sfc, bl.param_set))
+    T_sfc = FT(290.4)
+    P_sfc = FT(MSLP)
 
     # Specify moisture profiles
-    q_liq      = FT(0)
-    q_ice      = FT(0)
-    zb         = FT(600)         # initial cloud bottom
-    zi         = FT(840)         # initial cloud top
+    q_liq = FT(0)
+    q_ice = FT(0)
+    zb = FT(600)         # initial cloud bottom
+    zi = FT(840)         # initial cloud top
 
     if z <= zi
-        θ_liq  = FT(289.0)
-        q_tot  = qref
+        θ_liq = FT(289.0)
+        q_tot = qref
     else
-        θ_liq  = FT(297.0) + (z - zi)^(FT(1/3))
-        q_tot  = FT(1.5e-3)
+        θ_liq = FT(297.0) + (z - zi)^(FT(1 / 3))
+        q_tot = FT(1.5e-3)
     end
 
     ugeo = FT(7)
@@ -277,20 +366,20 @@ function init_dycoms!(bl, state, aux, (x,y,z), t)
     end
 
     # Pressure
-    H     = Rm_sfc * T_sfc / grav
-    p     = P_sfc * exp(-z / H)
+    H = Rm_sfc * T_sfc / grav
+    p = P_sfc * exp(-z / H)
 
     # Density, Temperature
-    ts    = LiquidIcePotTempSHumEquil_given_pressure(θ_liq, p, q_tot, bl.param_set)
-    ρ     = air_density(ts)
+    ts = LiquidIcePotTempSHumEquil_given_pressure(θ_liq, p, q_tot, bl.param_set)
+    ρ = air_density(ts)
 
-    e_kin = FT(1/2) * FT((u^2 + v^2 + w^2))
+    e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))
     e_pot = gravitational_potential(bl.orientation, aux)
-    E     = ρ * total_energy(e_kin, e_pot, ts)
+    E = ρ * total_energy(e_kin, e_pot, ts)
 
-    state.ρ               = ρ
-    state.ρu              = SVector(ρ*u, ρ*v, ρ*w)
-    state.ρe              = E
+    state.ρ = ρ
+    state.ρu = SVector(ρ * u, ρ * v, ρ * w)
+    state.ρe = E
     state.moisture.ρq_tot = ρ * q_tot
 
     return nothing
@@ -298,64 +387,79 @@ end
 
 function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
     # Reference state
-    T_min   = FT(289)
-    T_s     = FT(290.4)
-    Γ_lapse = FT(grav/cp_d)
-    T       = LinearTemperatureProfile(T_min, T_s, Γ_lapse)
+    T_min = FT(289)
+    T_s = FT(290.4)
+    Γ_lapse = FT(grav / cp_d)
+    T = LinearTemperatureProfile(T_min, T_s, Γ_lapse)
     rel_hum = FT(0)
     ref_state = HydrostaticState(T, rel_hum)
 
     # Radiation model
-    κ             = FT(85)
-    α_z           = FT(1)
-    z_i           = FT(840)
-    ρ_i           = FT(1.13)
-    D_subsidence  = FT(0) # 0 for stable testing, 3.75e-6 in practice
-    F_0           = FT(70)
-    F_1           = FT(22)
+    κ = FT(85)
+    α_z = FT(1)
+    z_i = FT(840)
+    ρ_i = FT(1.13)
+    D_subsidence = FT(3.75e-6)
+    F_0 = FT(70)
+    F_1 = FT(22)
     radiation = DYCOMSRadiation{FT}(κ, α_z, z_i, ρ_i, D_subsidence, F_0, F_1)
 
     # Sources
-    f_coriolis    = FT(1.03e-4)
+    f_coriolis = FT(1.03e-4)
     u_geostrophic = FT(7.0)
     v_geostrophic = FT(-5.5)
-    w_ref         = FT(0)
-    u_relaxation  = SVector(u_geostrophic, v_geostrophic, w_ref)
+    w_ref = FT(0)
+    u_relaxation = SVector(u_geostrophic, v_geostrophic, w_ref)
     # Sponge
     c_sponge = 1
     # Rayleigh damping
     zsponge = FT(1500.0)
-    rayleigh_sponge = RayleighSponge{FT}(zmax, zsponge, c_sponge, u_relaxation, 2)
+    rayleigh_sponge =
+        RayleighSponge{FT}(zmax, zsponge, c_sponge, u_relaxation, 2)
     # Geostrophic forcing
-    geostrophic_forcing = GeostrophicForcing{FT}(f_coriolis, u_geostrophic, v_geostrophic)
+    geostrophic_forcing =
+        GeostrophicForcing{FT}(f_coriolis, u_geostrophic, v_geostrophic)
 
     # Boundary conditions
     # SGS Filter constants
     C_smag = FT(0.21) # 0.21 for stable testing, 0.18 in practice
     C_drag = FT(0.0011)
-    LHF    = FT(115)
-    SHF    = FT(15)
+    LHF = FT(115)
+    SHF = FT(15)
     bc = DYCOMS_BC{FT}(C_drag, LHF, SHF)
     ics = init_dycoms!
-    source = (Gravity(),
-              rayleigh_sponge,
-              Subsidence{FT}(D_subsidence),
-              geostrophic_forcing)
+    source = (
+        Gravity(),
+        rayleigh_sponge,
+        Subsidence{FT}(D_subsidence),
+        geostrophic_forcing,
+    )
 
-    model = AtmosModel{FT}(AtmosLESConfigType;
-                           ref_state=ref_state,
-                          turbulence=SmagorinskyLilly{FT}(C_smag),
-                            moisture=EquilMoist{FT}(;maxiter=5),
-                           radiation=radiation,
-                              source=source,
-                   boundarycondition=bc,
-                          init_state=ics,
-                           param_set=ParameterSet{FT}())
+    model = AtmosModel{FT}(
+        AtmosLESConfigType;
+        ref_state = ref_state,
+        turbulence = SmagorinskyLilly{FT}(C_smag),
+        moisture = EquilMoist{FT}(; maxiter = 1, tolerance = FT(50)),
+        radiation = radiation,
+        source = source,
+        boundarycondition = bc,
+        init_state = ics,
+        param_set = ParameterSet{FT}(),
+    )
 
-    config = CLIMA.AtmosLESConfiguration("DYCOMS", N, resolution, xmax, ymax, zmax,
-                                         init_dycoms!,
-                                         solver_type=CLIMA.ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch),
-                                         model=model)
+    config = CLIMA.AtmosLESConfiguration(
+        "DYCOMS",
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        init_dycoms!,
+        solver_type = CLIMA.ExplicitSolverType(
+            solver_method = LSRK144NiegemannDiehlBusch,
+        ),
+        model = model,
+    )
 
     return config
 end
@@ -378,19 +482,27 @@ function main()
     zmax = 2500
 
     t0 = FT(0)
-    timeend = FT(100)
+    timeend = FT(500)
 
     driver_config = config_dycoms(FT, N, resolution, xmax, ymax, zmax)
-    solver_config = CLIMA.setup_solver(t0, timeend, driver_config, init_on_cpu=true)
+    solver_config = CLIMA.setup_solver(
+        t0,
+        timeend,
+        driver_config;
+        Courant_number = 1.8,
+        init_on_cpu = true,
+    )
 
-    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(2) do (init=false)
+    cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
         Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
         nothing
     end
 
-    result = CLIMA.invoke!(solver_config;
-                          user_callbacks=(cbtmarfilter,),
-                          check_euclidean_distance=true)
+    result = CLIMA.invoke!(
+        solver_config;
+        user_callbacks = (cbtmarfilter,),
+        check_euclidean_distance = true,
+    )
 end
 
 main()


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

 experiments/AtmosLES/dycoms.jl:
 Modified dycoms.jl to have the correct parameters that allow it to run to completion if timeend is set to 14400. 
   * D_subsidence = 3.75e-6
   * maxiter = 1
   * tolerance = FT(50)
   * Courant_number = 1.8
These are the parameters that allowed me to run dycoms to completion off-line. I used these parameters to produce the first results plotted in the dycoms paper draft (overleaf) and in the slack #dycoms channel.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
