### PR TITLE
Make Courant absolute time aware

### DIFF
--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -27,7 +27,7 @@ function advective_courant(
     Δx,
     Δt,
     t,
-    direction
+    direction,
 )
     k̂ = vertical_unit_vector(m.orientation, aux)
     normu = norm_u(state, k̂, direction)
@@ -42,7 +42,7 @@ function nondiffusive_courant(
     Δx,
     Δt,
     t,
-    direction
+    direction,
 )
     k̂ = vertical_unit_vector(m.orientation, aux)
     normu = norm_u(state, k̂, direction)
@@ -57,7 +57,7 @@ function diffusive_courant(
     Δx,
     Δt,
     t,
-    direction
+    direction,
 )
     ν, τ = turbulence_tensors(m.turbulence, state, diffusive, aux, t)
     k̂ = vertical_unit_vector(m.orientation, aux)

--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -1,9 +1,23 @@
+using ..Mesh.Grids: Direction, HorizontalDirection, VerticalDirection
+
 advective_courant(m::AtmosLinearModel, a...) = advective_courant(m.atmos, a...)
 
 nondiffusive_courant(m::AtmosLinearModel, a...) =
     nondiffusive_courant(m.atmos, a...)
 
 diffusive_courant(m::AtmosLinearModel, a...) = diffusive_courant(m.atmos, a...)
+
+norm_u(state::Vars, k̂::AbstractVector, ::VerticalDirection) =
+    abs(dot(state.ρu, k̂)) / state.ρ
+norm_u(state::Vars, k̂::AbstractVector, ::HorizontalDirection) =
+    norm((state.ρu .- dot(state.ρu, k̂) * k̂) / state.ρ)
+norm_u(state::Vars, k̂::AbstractVector, ::Direction) = norm(state.ρu / state.ρ)
+
+norm_ν(ν::Real, k̂::AbstractVector, ::Direction) = ν
+norm_ν(ν::AbstractVector, k̂::AbstractVector, ::VerticalDirection) = dot(ν, k̂)
+norm_ν(ν::AbstractVector, k̂::AbstractVector, ::HorizontalDirection) =
+    norm(ν - dot(ν, k̂) * k̂)
+norm_ν(ν::AbstractVector, k̂::AbstractVector, ::Direction) = norm(ν)
 
 function advective_courant(
     m::AtmosModel,
@@ -12,17 +26,12 @@ function advective_courant(
     diffusive::Vars,
     Δx,
     Δt,
-    direction,
+    t,
+    direction
 )
     k̂ = vertical_unit_vector(m.orientation, aux)
-    if direction isa VerticalDirection
-        norm_u = abs(dot(state.ρu, k̂)) / state.ρ
-    elseif direction isa HorizontalDirection
-        norm_u = norm((state.ρu - dot(state.ρu, k̂) * k̂) / state.ρ)
-    else
-        norm_u = norm(state.ρu / state.ρ)
-    end
-    return Δt * norm_u / Δx
+    normu = norm_u(state, k̂, direction)
+    return Δt * normu / Δx
 end
 
 function nondiffusive_courant(
@@ -32,17 +41,12 @@ function nondiffusive_courant(
     diffusive::Vars,
     Δx,
     Δt,
-    direction,
+    t,
+    direction
 )
     k̂ = vertical_unit_vector(m.orientation, aux)
-    if direction isa VerticalDirection
-        norm_u = abs(dot(state.ρu, k̂)) / state.ρ
-    elseif direction isa HorizontalDirection
-        norm_u = norm((state.ρu - dot(state.ρu, k̂) * k̂) / state.ρ)
-    else
-        norm_u = norm(state.ρu / state.ρ)
-    end
-    return Δt * (norm_u + soundspeed(m, m.moisture, state, aux)) / Δx
+    normu = norm_u(state, k̂, direction)
+    return Δt * (normu + soundspeed(m, m.moisture, state, aux)) / Δx
 end
 
 function diffusive_courant(
@@ -52,24 +56,11 @@ function diffusive_courant(
     diffusive::Vars,
     Δx,
     Δt,
-    direction,
+    t,
+    direction
 )
-    ν, τ = turbulence_tensors(m.turbulence, state, diffusive, aux, 0)
-    FT = eltype(state)
-
-    if ν isa Real
-        return Δt * ν / (Δx * Δx)
-    else
-        k̂ = vertical_unit_vector(m.orientation, aux)
-        ν_vert = dot(ν, k̂)
-
-        if direction isa VerticalDirection
-            return Δt * ν_vert / (Δx * Δx)
-        elseif direction isa HorizontalDirection
-            ν_horz = ν - ν_vert * k̂
-            return Δt * norm(ν_horz) / (Δx * Δx)
-        else
-            return Δt * norm(ν) / (Δx * Δx)
-        end
-    end
+    ν, τ = turbulence_tensors(m.turbulence, state, diffusive, aux, t)
+    k̂ = vertical_unit_vector(m.orientation, aux)
+    normν = norm_ν(ν, k̂, direction)
+    return Δt * normν / (Δx * Δx)
 end

--- a/src/DGmethods/DGmodel.jl
+++ b/src/DGmethods/DGmodel.jl
@@ -570,6 +570,7 @@ function courant(
     m::BalanceLaw,
     Q::MPIStateArray,
     Δt,
+    simtime,
     direction = EveryDirection(),
 )
     grid = dg.grid
@@ -604,8 +605,9 @@ function courant(
             dg.auxstate.data,
             dg.diffstate.data,
             topology.realelems,
-            direction,
-            Δt;
+            Δt,
+            simtime,
+            direction;
             ndrange = nrealelem * Nq * Nq * Nqk,
             dependencies = (event,),
         )

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -2117,8 +2117,9 @@ end
     auxstate,
     diffstate,
     elems,
-    direction,
     Δt,
+    simtime,
+    direction,
 ) where {dim, N}
     @uniform begin
         FT = eltype(Q)
@@ -2160,6 +2161,7 @@ end
             Vars{vars_diffusive(bl, FT)}(l_diff),
             Δx,
             Δt,
+            simtime,
             direction,
         )
 

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -71,14 +71,14 @@ function init_state! end
 
 using ..Courant
 """
-    calculate_dt(dg, model, Q, Courant_number, direction)
+    calculate_dt(dg, model, Q, Courant_number, direction, t)
 
 For a given model, compute a time step satisying the nondiffusive Courant number
 `Courant_number`
 """
-function calculate_dt(dg, model, Q, Courant_number, direction)
+function calculate_dt(dg, model, Q, Courant_number, t, direction)
     Δt = one(eltype(Q))
-    CFL = courant(nondiffusive_courant, dg, model, Q, Δt, direction)
+    CFL = courant(nondiffusive_courant, dg, model, Q, Δt, t, direction)
     return Courant_number / CFL
 end
 

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -385,32 +385,38 @@ function invoke!(
                 Δt = solver_config.dt
                 c_v = DGmethods.courant(
                     nondiffusive_courant,
-                    solver_config;
+                    solver_config,
+                    simtime;
                     direction = VerticalDirection(),
                 )
                 c_h = DGmethods.courant(
                     nondiffusive_courant,
-                    solver_config;
+                    solver_config,
+                    simtime;
                     direction = HorizontalDirection(),
                 )
                 ca_v = DGmethods.courant(
                     advective_courant,
-                    solver_config;
+                    solver_config,
+                    simtime;
                     direction = VerticalDirection(),
                 )
                 ca_h = DGmethods.courant(
                     advective_courant,
-                    solver_config;
+                    solver_config,
+                    simtime;
                     direction = HorizontalDirection(),
                 )
                 cd_v = DGmethods.courant(
                     diffusive_courant,
-                    solver_config;
+                    solver_config,
+                    simtime;
                     direction = VerticalDirection(),
                 )
                 cd_h = DGmethods.courant(
                     diffusive_courant,
-                    solver_config;
+                    solver_config,
+                    simtime;
                     direction = HorizontalDirection(),
                 )
                 @info @sprintf """

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -36,8 +36,9 @@ DGmethods.courant(
     sc::SolverConfiguration;
     Q = sc.Q,
     dt = sc.dt,
+    simtime = gettime(sc.solver),
     direction = EveryDirection(),
-) = DGmethods.courant(f, sc.dg, sc.dg.balancelaw, Q, dt, direction)
+) = DGmethods.courant(f, sc.dg, sc.dg.balancelaw, Q, dt, simtime, direction)
 
 """
     CLIMA.SolverConfiguration(
@@ -128,8 +129,9 @@ function SolverConfiguration(
     end
 
     # initial Δt specified or computed
+    simtime = FT(0) # TODO: needs to be more general to account for restart:
     if ode_dt === nothing
-        ode_dt = calculate_dt(dg, dtmodel, Q, Courant_number, CFL_direction)
+        ode_dt = calculate_dt(dg, dtmodel, Q, Courant_number, simtime, CFL_direction)
     end
     numberofsteps = convert(Int, cld(timeend, ode_dt))
     timeend_dt_adjust && (ode_dt = timeend / numberofsteps)

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -131,7 +131,8 @@ function SolverConfiguration(
     # initial Δt specified or computed
     simtime = FT(0) # TODO: needs to be more general to account for restart:
     if ode_dt === nothing
-        ode_dt = calculate_dt(dg, dtmodel, Q, Courant_number, simtime, CFL_direction)
+        ode_dt =
+            calculate_dt(dg, dtmodel, Q, Courant_number, simtime, CFL_direction)
     end
     numberofsteps = convert(Int, cld(timeend, ode_dt))
     timeend_dt_adjust && (ode_dt = timeend / numberofsteps)

--- a/src/Ocean/HydrostaticBoussinesq/Courant.jl
+++ b/src/Ocean/HydrostaticBoussinesq/Courant.jl
@@ -118,8 +118,15 @@ takes minimum of advective, gravity wave, diffusive, and viscous CFL
 
     CFL_advective =
         courant(advective_courant, dg, model, Q, Δt, t, VerticalDirection())
-    CFL_gravity =
-        courant(nondiffusive_courant, dg, model, Q, Δt, t, HorizontalDirection())
+    CFL_gravity = courant(
+        nondiffusive_courant,
+        dg,
+        model,
+        Q,
+        Δt,
+        t,
+        HorizontalDirection(),
+    )
     CFL_viscous =
         courant(viscous_courant, dg, model, Q, Δt, t, VerticalDirection())
     CFL_diffusive =
@@ -165,8 +172,15 @@ takes minimum of gravity wave, diffusive, and viscous CFL
 
     CFL_advective =
         courant(advective_courant, dg, ocean, Q, Δt, t, VerticalDirection())
-    CFL_gravity =
-        courant(nondiffusive_courant, dg, ocean, Q, Δt, t, HorizontalDirection())
+    CFL_gravity = courant(
+        nondiffusive_courant,
+        dg,
+        ocean,
+        Q,
+        Δt,
+        t,
+        HorizontalDirection(),
+    )
     CFL_viscous =
         courant(viscous_courant, dg, ocean, Q, Δt, t, HorizontalDirection())
     CFL_diffusive =

--- a/src/Ocean/HydrostaticBoussinesq/Courant.jl
+++ b/src/Ocean/HydrostaticBoussinesq/Courant.jl
@@ -13,6 +13,7 @@ calculates the CFL condition due to advection
     D::Vars,
     Δx,
     Δt,
+    t,
     direction = VerticalDirection(),
 )
     if direction isa VerticalDirection
@@ -40,6 +41,7 @@ calculates the CFL condition due to gravity waves
     D::Vars,
     Δx,
     Δt,
+    t,
     direction = HorizontalDirection(),
 )
     return Δt * m.cʰ / Δx
@@ -57,6 +59,7 @@ calculates the CFL condition due to viscosity
     D::Vars,
     Δx,
     Δt,
+    t,
     direction = VerticalDirection(),
 )
     ν̄ = norm_viscosity(m, direction)
@@ -83,6 +86,7 @@ factor of 1000 is for convective adjustment
     D::Vars,
     Δx,
     Δt,
+    t,
     direction = VerticalDirection(),
 )
     κ̄ = norm_diffusivity(m, direction)
@@ -96,7 +100,7 @@ end
     sqrt(2 * m.κʰ^2 + (1000 * m.κᶻ)^2)
 
 """
-    calculate_dt(dg, model::HBModel, Q, Courant_number, direction::EveryDirection)
+    calculate_dt(dg, model::HBModel, Q, Courant_number, direction::EveryDirection, t)
 
 calculates the time step based on grid spacing and model parameters
 takes minimum of advective, gravity wave, diffusive, and viscous CFL
@@ -107,18 +111,19 @@ takes minimum of advective, gravity wave, diffusive, and viscous CFL
     model::HBModel,
     Q,
     Courant_number,
+    t,
     ::EveryDirection,
 )
     Δt = one(eltype(Q))
 
     CFL_advective =
-        courant(advective_courant, dg, model, Q, Δt, VerticalDirection())
+        courant(advective_courant, dg, model, Q, Δt, t, VerticalDirection())
     CFL_gravity =
-        courant(nondiffusive_courant, dg, model, Q, Δt, HorizontalDirection())
+        courant(nondiffusive_courant, dg, model, Q, Δt, t, HorizontalDirection())
     CFL_viscous =
-        courant(viscous_courant, dg, model, Q, Δt, VerticalDirection())
+        courant(viscous_courant, dg, model, Q, Δt, t, VerticalDirection())
     CFL_diffusive =
-        courant(diffusive_courant, dg, model, Q, Δt, VerticalDirection())
+        courant(diffusive_courant, dg, model, Q, Δt, t, VerticalDirection())
 
     CFLs = [CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive]
     dts = [Courant_number / CFL for CFL in CFLs]
@@ -152,19 +157,20 @@ takes minimum of gravity wave, diffusive, and viscous CFL
     model::LinearHBModel,
     Q,
     Courant_number,
+    t,
     ::EveryDirection,
 )
     Δt = one(eltype(Q))
     ocean = model.ocean
 
     CFL_advective =
-        courant(advective_courant, dg, ocean, Q, Δt, VerticalDirection())
+        courant(advective_courant, dg, ocean, Q, Δt, t, VerticalDirection())
     CFL_gravity =
-        courant(nondiffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
+        courant(nondiffusive_courant, dg, ocean, Q, Δt, t, HorizontalDirection())
     CFL_viscous =
-        courant(viscous_courant, dg, ocean, Q, Δt, HorizontalDirection())
+        courant(viscous_courant, dg, ocean, Q, Δt, t, HorizontalDirection())
     CFL_diffusive =
-        courant(diffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
+        courant(diffusive_courant, dg, ocean, Q, Δt, t, HorizontalDirection())
 
     CFLs = [CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive]
     dts = [Courant_number / CFL for CFL in CFLs]

--- a/test/DGmethods/courant.jl
+++ b/test/DGmethods/courant.jl
@@ -153,6 +153,7 @@ let
                 c_v = Δt * (soundspeed_air(FT(T∞), model.param_set)) / Δx_v
                 d_h = Δt * diff_speed_h / Δx_h^2
                 d_v = Δt * diff_speed_v / Δx_v^2
+                simtime = FT(0)
 
                 # tests for non diffusive courant number
                 @test courant(
@@ -161,6 +162,7 @@ let
                     model,
                     Q,
                     Δt,
+                    simtime,
                     HorizontalDirection(),
                 ) ≈ c_h rtol = 1e-4
                 @test courant(
@@ -169,6 +171,7 @@ let
                     model,
                     Q,
                     Δt,
+                    simtime,
                     VerticalDirection(),
                 ) ≈ c_v rtol = 1e-4
 
@@ -179,6 +182,7 @@ let
                     model,
                     Q,
                     Δt,
+                    simtime,
                     HorizontalDirection(),
                 ) ≈ d_h
                 @test courant(
@@ -187,6 +191,7 @@ let
                     model,
                     Q,
                     Δt,
+                    simtime,
                     VerticalDirection(),
                 ) ≈ d_v
             end


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

This PR makes the Courant calculations time-aware. As pointed out by @akshaysridhar, this is useful if we want to make `C_smag` (or, effectively, the inverse timestep) decay so that we can speed up calculations after initial transient stiffness. It also simplifies some of the Courant functions.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
