### PR TITLE
Remove moist thermo warnings

### DIFF
--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -109,7 +109,7 @@ air_pressure(
     q::PhasePartition{FT} = q_pt_0(FT),
     param_set::APS{FT} = MTPS{FT}(),
 ) where {FT <: Real} = gas_constant_air(q, param_set) * ρ * T
-air_pressure(T::FT, ρ::FT, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+air_pressure(T::FT, ρ::FT, param_set::APS{FT}) where {FT <: Real} =
     air_pressure(T, ρ, q_pt_0(FT), param_set)
 
 """
@@ -248,7 +248,7 @@ function gas_constants(
     γ = cp / cv
     return (R_gas, cp, cv, γ)
 end
-gas_constants(param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+gas_constants(param_set::APS{FT}) where {FT <: Real} =
     gas_constants(q_pt_0(FT), param_set)
 
 """
@@ -286,7 +286,7 @@ function air_temperature(
         q.ice * (FT(e_int_v0) + FT(e_int_i0))
     ) / cv_m(q, param_set)
 end
-air_temperature(e_int::FT, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+air_temperature(e_int::FT, param_set::APS{FT}) where {FT <: Real} =
     air_temperature(e_int, q_pt_0(FT), param_set)
 
 """
@@ -403,7 +403,7 @@ total_energy(
     e_kin::FT,
     e_pot::FT,
     T::FT,
-    param_set::APS{FT} = MTPS{FT}(),
+    param_set::APS{FT},
 ) where {FT <: Real} = total_energy(e_kin, e_pot, T, q_pt_0(FT), param_set)
 
 """
@@ -699,11 +699,8 @@ function q_vap_saturation(
     return q_vap_saturation_from_pressure(T, ρ, p_v_sat, param_set)
 
 end
-q_vap_saturation(
-    T::FT,
-    ρ::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = q_vap_saturation(T, ρ, q_pt_0(FT), param_set)
+q_vap_saturation(T::FT, ρ::FT, param_set::APS{FT}) where {FT <: Real} =
+    q_vap_saturation(T, ρ, q_pt_0(FT), param_set)
 
 """
     q_vap_saturation(ts::ThermodynamicState)
@@ -1138,7 +1135,7 @@ latent_heat_liq_ice(
     q::PhasePartition{FT} = q_pt_0(FT),
     param_set::APS{FT} = MTPS{FT}(),
 ) where {FT <: Real} = FT(LH_v0) * q.liq + FT(LH_s0) * q.ice
-latent_heat_liq_ice(param_set::APS{FT} = MTPS{FT}()) where {FT} =
+latent_heat_liq_ice(param_set::APS{FT}) where {FT} =
     latent_heat_liq_ice(q_pt_0(FT), param_set)
 
 
@@ -1335,7 +1332,7 @@ air_temperature_from_liquid_ice_pottemp_non_linear(
     ρ::FT,
     maxiter::Int,
     tol::FT,
-    param_set::APS{FT} = MTPS{FT}(),
+    param_set::APS{FT},
 ) where {FT <: Real} = air_temperature_from_liquid_ice_pottemp_non_linear(
     θ_liq_ice,
     ρ,
@@ -1367,7 +1364,7 @@ end
 air_temperature_from_liquid_ice_pottemp_given_pressure(
     θ_liq_ice::FT,
     p::FT,
-    param_set::APS{FT} = MTPS{FT}(),
+    param_set::APS{FT},
 ) where {FT <: Real} = air_temperature_from_liquid_ice_pottemp_given_pressure(
     θ_liq_ice,
     p,

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -97,9 +97,17 @@ function PhaseEquil(
     e_int::FT,
     ρ::FT,
     q_tot::FT,
-    maxiter::Int = 3,
-    tol::FT = FT(1e-1),
-    param_set::PS = MTPS{FT}(),
+    sat_adjust::Function,
+) where {FT <: Real, PS}
+    return PhaseEquil(e_int, ρ, q_tot, 3, FT(1e-1), sat_adjust, MTPS{FT}())
+end
+function PhaseEquil(
+    e_int::FT,
+    ρ::FT,
+    q_tot::FT,
+    maxiter::Int,
+    tol::FT,
+    param_set::PS,
 ) where {FT <: Real, PS}
     return PhaseEquil(
         e_int,
@@ -108,7 +116,7 @@ function PhaseEquil(
         maxiter,
         tol,
         saturation_adjustment,
-        param_set,
+        MTPS{FT}(),
     )
 end
 
@@ -190,7 +198,7 @@ LiquidIcePotTempSHumEquil(
     θ_liq_ice::FT,
     ρ::FT,
     q_tot::FT,
-    param_set::PS = MTPS{FT}(),
+    param_set::PS,
 ) where {FT <: Real, PS} =
     LiquidIcePotTempSHumEquil(θ_liq_ice, ρ, q_tot, 30, FT(1e-1), param_set)
 
@@ -231,7 +239,7 @@ LiquidIcePotTempSHumEquil_given_pressure(
     θ_liq_ice::FT,
     p::FT,
     q_tot::FT,
-    param_set::PS = MTPS{FT}(),
+    param_set::PS,
 ) where {FT <: Real, PS} = LiquidIcePotTempSHumEquil_given_pressure(
     θ_liq_ice,
     p,


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

Removes many warnings in moist thermo. Closes #829. Sorry for all of the noise everyone! (I couldn't wait to fix this to get #802 in)

This is not ideal, as there are a growing number of default values for various methods. I'll soon try using kwargs in moist thermo, which will fix this problem and significantly improve the interface, but I'd like to make sure this doesn't tank performance. cc: @kpamnany 

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
