### PR TITLE
Reduce aux usage for Ocean Model

### DIFF
--- a/experiments/OceanBoxGCM/homogeneous_box.jl
+++ b/experiments/OceanBoxGCM/homogeneous_box.jl
@@ -1,7 +1,6 @@
 using Test
 using CLIMA
 using CLIMA.HydrostaticBoussinesq
-using CLIMA.SimpleBox
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters

--- a/experiments/OceanBoxGCM/ocean_gyre.jl
+++ b/experiments/OceanBoxGCM/ocean_gyre.jl
@@ -1,7 +1,6 @@
 using Test
 using CLIMA
 using CLIMA.HydrostaticBoussinesq
-using CLIMA.SimpleBox
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters

--- a/src/CLIMA.jl
+++ b/src/CLIMA.jl
@@ -52,7 +52,6 @@ include(joinpath(
     "HydrostaticBoussinesq",
     "HydrostaticBoussinesqModel.jl",
 ))
-include(joinpath("Ocean", "HydrostaticBoussinesq", "SimpleBoxProblem.jl"))
 include(joinpath("DGmethods_old", "DGBalanceLawDiscretizations.jl"))
 include(joinpath("LinearSolvers", "LinearSolvers.jl"))
 include(joinpath("LinearSolvers", "GeneralizedConjugateResidualSolver.jl"))

--- a/src/Ocean/HydrostaticBoussinesq/Courant.jl
+++ b/src/Ocean/HydrostaticBoussinesq/Courant.jl
@@ -1,0 +1,111 @@
+"""
+    advective_courant(::HBModel)
+
+calculates the CFL condition due to advection
+
+"""
+@inline function advective_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
+                           direction=VerticalDirection())
+  if direction isa VerticalDirection
+    ū = norm(A.w)
+  elseif direction isa HorizontalDirection
+    ū = norm(Q.u)
+  else
+    v = @SVector [Q.u[1], Q.u[2], A.w]
+    ū = norm(v)
+  end
+
+  return Δt * ū / Δx
+end
+
+"""
+    nondiffusive_courant(::HBModel)
+
+calculates the CFL condition due to gravity waves
+
+"""
+@inline function nondiffusive_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
+                              direction=HorizontalDirection())
+  return Δt * m.cʰ / Δx
+end
+"""
+    viscous_courant(::HBModel)
+
+calculates the CFL condition due to viscosity
+
+"""
+@inline function viscous_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
+                         direction=VerticalDirection())
+  ν̄ = norm_viscosity(m, direction)
+
+  return Δt * ν̄ / Δx^2
+end
+
+@inline norm_viscosity(m::HBModel, ::VerticalDirection) = m.νᶻ
+@inline norm_viscosity(m::HBModel, ::HorizontalDirection) = sqrt(2) * m.νʰ
+@inline norm_viscosity(m::HBModel, ::EveryDirection) = sqrt(2 * m.νʰ^2 + m.νᶻ^2)
+
+
+"""
+    diffusive_courant(::HBModel)
+
+calculates the CFL condition due to temperature diffusivity
+factor of 1000 is for convective adjustment
+
+"""
+@inline function diffusive_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
+                           direction=VerticalDirection())
+  κ̄ = norm_diffusivity(m, direction)
+
+  return Δt * κ̄ / Δx^2
+end
+
+@inline norm_diffusivity(m::HBModel, ::VerticalDirection) = 1000 * m.κᶻ
+@inline norm_diffusivity(m::HBModel, ::HorizontalDirection) = sqrt(2) * m.κʰ
+@inline norm_diffusivity(m::HBModel, ::EveryDirection) = sqrt(2 * m.κʰ^2 + (1000 * m.κᶻ)^2)
+
+"""
+    calculate_dt(dg, model::HBModel, Q, Courant_number, direction::EveryDirection)
+
+calculates the time step based on grid spacing and model parameters
+takes minimum of advective, gravity wave, diffusive, and viscous CFL
+
+"""
+@inline function calculate_dt(dg, model::HBModel, Q, Courant_number, ::EveryDirection)
+  Δt = one(eltype(Q))
+
+  CFL_advective = courant(advective_courant, dg, model, Q, Δt, VerticalDirection())
+  CFL_gravity = courant(nondiffusive_courant, dg, model, Q, Δt, HorizontalDirection())
+  CFL_viscous = courant(viscous_courant, dg, model, Q, Δt, VerticalDirection())
+  CFL_diffusive = courant(diffusive_courant, dg, model, Q, Δt, VerticalDirection())
+
+  CFL = maximum([CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive])
+  dt = Courant_number / CFL
+
+  return dt
+end
+
+
+"""
+    calculate_dt(dg, bl::LinearHBModel, Q, Courant_number,
+                 direction::EveryDirection)
+
+calculates the time step based on grid spacing and model parameters
+takes minimum of gravity wave, diffusive, and viscous CFL
+
+"""
+@inline function calculate_dt(dg, model::LinearHBModel, Q, Courant_number,
+                      ::EveryDirection)
+  Δt = one(eltype(Q))
+  ocean = model.ocean
+
+  CFL_advective = courant(advective_courant, dg, ocean, Q, Δt, VerticalDirection())
+  CFL_gravity = courant(nondiffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
+  CFL_viscous = courant(viscous_courant, dg, ocean, Q, Δt, HorizontalDirection())
+  CFL_diffusive = courant(diffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
+
+  CFL = maximum([CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive])
+  dt = Courant_number / CFL
+
+  return dt
+end

--- a/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
+++ b/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
@@ -150,7 +150,7 @@ end
 """
     OceanFloorFreeSlip
 
-applies boundary condition νν∇u = 0 and κ∇θ = 0
+applies boundary condition ν∇u = 0 and κ∇θ = 0
 """
 
 """
@@ -205,7 +205,7 @@ end
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
-sets ghost point to have no numerical flux on the boundary for νν∇u and κ∇θ
+sets ghost point to have no numerical flux on the boundary for ν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -333,7 +333,7 @@ end
 
 apply no flux boundary condition for velocity
 apply no flux boundary condition for temperature
-set ghost point to have no numerical flux on the boundary for νν∇u and κ∇θ
+set ghost point to have no numerical flux on the boundary for ν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -350,7 +350,6 @@ set ghost point to have no numerical flux on the boundary for νν∇u and κ∇
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
   D⁺.ν∇u = -D⁻.ν∇u
-
   D⁺.κ∇θ = -D⁻.κ∇θ
 
   return nothing
@@ -373,11 +372,12 @@ set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel,
+@inline function ocean_boundary_state!(m::HBModel,
                                        ::OceanSurfaceStressNoForcing,
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  τ = @SMatrix [ -0 -0; -0 -0; A⁺.τ / 1000 -0]
+  τᶻ = velocity_flux(m.problem, A⁻.y, m.ρₒ)
+  τ = @SMatrix [ -0 -0; -0 -0; τᶻ -0]
   D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
 
   D⁺.κ∇θ = -D⁻.κ∇θ
@@ -408,11 +408,8 @@ set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
   D⁺.ν∇u = -D⁻.ν∇u
 
-  θ  = Q⁻.θ
-  θʳ = A⁺.θʳ
-  λʳ = m.problem.λʳ
-
-  σ = @SVector [-0, -0, λʳ * (θʳ - θ)]
+  σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
+  σ = @SVector [-0, -0, σᶻ]
   D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
 
   return nothing
@@ -439,14 +436,12 @@ set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
                                        ::OceanSurfaceStressForcing,
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  τ = @SMatrix [ -0 -0; -0 -0; A⁺.τ / 1000 -0]
+  τᶻ = velocity_flux(m.problem, A⁻.y, m.ρₒ)
+  τ = @SMatrix [ -0 -0; -0 -0; τᶻ -0]
   D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
 
-  θ  = Q⁻.θ
-  θʳ = A⁺.θʳ
-  λʳ = m.problem.λʳ
-
-  σ = @SVector [-0, -0, λʳ * (θʳ - θ)]
+  σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
+  σ = @SVector [-0, -0, σᶻ]
   D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
 
   return nothing

--- a/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
+++ b/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
@@ -15,7 +15,7 @@ struct OceanSurfaceStressForcing     <: OceanBoundaryCondition end
 """
     CoastlineFreeSlip
 
-applies boundary condition ∇u = 0 and ∇θ = 0
+applies boundary condition ν∇u = 0 and κ∇θ = 0
 """
 
 """
@@ -45,7 +45,7 @@ end
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
-sets ghost point to have no numerical flux on the boundary for ∇u and ∇θ
+sets ghost point to have no numerical flux on the boundary for ν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -60,9 +60,9 @@ sets ghost point to have no numerical flux on the boundary for ∇u and ∇θ
 @inline function ocean_boundary_state!(::HBModel, ::CoastlineFreeSlip,
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  D⁺.∇u = Diagonal(A⁺.ν) \ (Diagonal(A⁻.ν) * -D⁻.∇u)
+  D⁺.ν∇u = -D⁻.ν∇u
 
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ)
+  D⁺.κ∇θ = -D⁻.κ∇θ
 
   return nothing
 end
@@ -70,7 +70,7 @@ end
 """
     CoastlineNoSlip
 
-applies boundary condition u = 0 and ∇θ = 0
+applies boundary condition u = 0 and κ∇θ = 0
 """
 
 """
@@ -125,7 +125,7 @@ end
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
-sets ghost point to have no numerical flux on the boundary for u and ∇θ
+sets ghost point to have no numerical flux on the boundary for u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -142,7 +142,7 @@ sets ghost point to have no numerical flux on the boundary for u and ∇θ
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
   Q⁺.u = -Q⁻.u
 
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ)
+  D⁺.κ∇θ = -D⁻.κ∇θ
 
   return nothing
 end
@@ -150,7 +150,7 @@ end
 """
     OceanFloorFreeSlip
 
-applies boundary condition ∇u = 0 and ∇θ = 0
+applies boundary condition νν∇u = 0 and κ∇θ = 0
 """
 
 """
@@ -205,7 +205,7 @@ end
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
-sets ghost point to have no numerical flux on the boundary for ∇u and ∇θ
+sets ghost point to have no numerical flux on the boundary for νν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -221,9 +221,9 @@ sets ghost point to have no numerical flux on the boundary for ∇u and ∇θ
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
   A⁺.w = -A⁻.w
-  D⁺.∇u = Diagonal(A⁺.ν) \ (Diagonal(A⁻.ν) * -D⁻.∇u)
+  D⁺.ν∇u = -D⁻.ν∇u
 
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ)
+  D⁺.κ∇θ = -D⁻.κ∇θ
 
   return nothing
 end
@@ -231,7 +231,7 @@ end
 """
     OceanFloorNoSlip
 
-applies boundary condition u = 0 and ∇θ = 0
+applies boundary condition u = 0 and κ∇θ = 0
 """
 
 """
@@ -288,7 +288,7 @@ end
 
 apply no slip boundary condition for velocity
 apply no penetration boundary for temperature
-sets ghost point to have no numerical flux on the boundary for u,w and ∇θ
+sets ghost point to have no numerical flux on the boundary for u,w and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -307,7 +307,7 @@ sets ghost point to have no numerical flux on the boundary for u,w and ∇θ
   Q⁺.u = -Q⁻.u
   A⁺.w = -A⁻.w
 
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ)
+  D⁺.κ∇θ = -D⁻.κ∇θ
 
   return nothing
 end
@@ -333,7 +333,7 @@ end
 
 apply no flux boundary condition for velocity
 apply no flux boundary condition for temperature
-set ghost point to have no numerical flux on the boundary for ∇u and ∇θ
+set ghost point to have no numerical flux on the boundary for νν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -349,9 +349,9 @@ set ghost point to have no numerical flux on the boundary for ∇u and ∇θ
                                        ::OceanSurfaceNoStressNoForcing,
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  D⁺.∇u = Diagonal(A⁺.ν) \ (Diagonal(A⁻.ν) * -D⁻.∇u)
+  D⁺.ν∇u = -D⁻.ν∇u
 
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ)
+  D⁺.κ∇θ = -D⁻.κ∇θ
 
   return nothing
 end
@@ -361,7 +361,7 @@ end
 
 apply wind-stress boundary condition for velocity
 apply no flux boundary condition for temperature
-set ghost poin for numerical flux on the boundary for ∇u and ∇θ
+set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -378,9 +378,9 @@ set ghost poin for numerical flux on the boundary for ∇u and ∇θ
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
   τ = @SMatrix [ -0 -0; -0 -0; A⁺.τ / 1000 -0]
-  D⁺.∇u = Diagonal(A⁺.ν) \ (Diagonal(A⁻.ν) * -D⁻.∇u + 2 * τ)
+  D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
 
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ)
+  D⁺.κ∇θ = -D⁻.κ∇θ
 
   return nothing
 end
@@ -390,7 +390,7 @@ end
 
 apply no flux boundary condition for velocity
 apply forcing boundary condition for temperature
-set ghost point for numerical flux on the boundary for ∇u and ∇θ
+set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -406,14 +406,14 @@ set ghost point for numerical flux on the boundary for ∇u and ∇θ
                                        ::OceanSurfaceNoStressForcing,
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  D⁺.∇u = Diagonal(A⁺.ν) \ (Diagonal(A⁻.ν) * -D⁻.∇u)
+  D⁺.ν∇u = -D⁻.ν∇u
 
   θ  = Q⁻.θ
   θʳ = A⁺.θʳ
   λʳ = m.problem.λʳ
 
   σ = @SVector [-0, -0, λʳ * (θʳ - θ)]
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ + 2 * σ)
+  D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
 
   return nothing
 end
@@ -423,7 +423,7 @@ end
 
 apply wind-stress boundary condition for velocity
 apply forcing boundary condition for temperature
-set ghost point for numerical flux on the boundary for ∇u and ∇θ
+set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -440,14 +440,14 @@ set ghost point for numerical flux on the boundary for ∇u and ∇θ
                                        ::CentralNumericalFluxDiffusive,
                                        Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
   τ = @SMatrix [ -0 -0; -0 -0; A⁺.τ / 1000 -0]
-  D⁺.∇u = Diagonal(A⁺.ν) \ (Diagonal(A⁻.ν) * -D⁻.∇u + 2 * τ)
+  D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
 
   θ  = Q⁻.θ
   θʳ = A⁺.θʳ
   λʳ = m.problem.λʳ
 
   σ = @SVector [-0, -0, λʳ * (θʳ - θ)]
-  D⁺.∇θ = Diagonal(A⁺.κ) \ (Diagonal(A⁻.κ) * -D⁻.∇θ + 2 * σ)
+  D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
 
   return nothing
 end

--- a/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
+++ b/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
@@ -1,21 +1,3 @@
-module SimpleBox
-
-export SimpleBoxProblem, HomogeneousBox, OceanGyre
-
-using StaticArrays
-using CLIMA.HydrostaticBoussinesq
-
-import CLIMA.HydrostaticBoussinesq: ocean_init_aux!, ocean_init_state!,
-                                    ocean_boundary_state!,
-                                    CoastlineFreeSlip, CoastlineNoSlip,
-                                    OceanFloorFreeSlip, OceanFloorNoSlip,
-                                    OceanSurfaceNoStressNoForcing,
-                                    OceanSurfaceStressNoForcing,
-                                    OceanSurfaceNoStressForcing,
-                                    OceanSurfaceStressForcing
-
-HBModel = HydrostaticBoussinesqModel
-
 ############################
 # Basic box problem        #
 # Set up dimensions of box #
@@ -34,6 +16,29 @@ struct SimpleBoxProblem{T} <: AbstractSimpleBoxProblem
   Lˣ::T
   Lʸ::T
   H::T
+end
+
+"""
+    ocean_init_aux!(::HBModel, ::AbstractSimpleBoxProblem)
+
+save y coordinate for computing coriolis, wind stress, and sea surface temperature
+
+# Arguments
+- `m`: model object to dispatch on and get viscosities and diffusivities
+- `p`: problem object to dispatch on and get additional parameters
+- `A`: auxiliary state vector
+- `geom`: geometry stuff
+"""
+function ocean_init_aux!(m::HBModel, p::AbstractSimpleBoxProblem, A, geom)
+  FT = eltype(A)
+  @inbounds A.y = geom.coord[2]
+
+  # not sure if this is needed but getting weird intialization stuff
+  A.w = 0
+  A.pkin = 0
+  A.wz0 = 0
+
+  return nothing
 end
 
 ##########################
@@ -57,14 +62,10 @@ struct HomogeneousBox{T} <: AbstractSimpleBoxProblem
   Lʸ::T
   H::T
   τₒ::T
-  fₒ::T
-  β::T
   function HomogeneousBox{FT}(Lˣ, Lʸ, H;
                                     τₒ = FT(1e-1),  # (m/s)^2
-                                    fₒ = FT(1e-4),  # Hz
-                                    β  = FT(1e-11), # Hz / m)
                                     ) where {FT <: AbstractFloat}
-    return new{FT}(Lˣ, Lʸ, H, τₒ, fₒ, β)
+    return new{FT}(Lˣ, Lʸ, H, τₒ)
   end
 end
 
@@ -102,35 +103,20 @@ function ocean_init_state!(p::HomogeneousBox, Q, A, coords, t)
   Q.u = @SVector [rand(),rand()]
   Q.η = 0
   Q.θ = 20
+
+  return nothing
 end
 
 """
-    ocean_init_aux!(::HBModel, ::HomgoneousBox)
+    velocity_flux(::HomogeneousBox)
 
-initiaze auxiliary states
 jet stream like windstress
-northern hemisphere coriolis
-cool-warm north-south linear temperature gradient
 
 # Arguments
-- `m`: model object to dispatch on and get viscosities and diffusivities
 - `p`: problem object to dispatch on and get additional parameters
-- `A`: auxiliary state vector
-- `geom`: geometry stuff
+- `y`: y-coordinate in the box
 """
-# aux is Filled afer the state
-function ocean_init_aux!(m::HBModel, p::HomogeneousBox, A, geom)
-  FT = eltype(A)
-  @inbounds y = geom.coord[2]
-
-  Lʸ = p.Lʸ
-  τₒ = p.τₒ
-  fₒ = p.fₒ
-  β  = p.β
-
-  A.τ  = -τₒ * cos(y * π / Lʸ)
-  A.f  =  fₒ + β * y
-end
+@inline velocity_flux(p::HomogeneousBox, y, ρ) = -(p.τₒ / ρ) * cos(y * π / p.Lʸ)
 
 ##########################
 # Homogenous wind stress #
@@ -145,8 +131,6 @@ Lˣ = zonal (east-west) length
 Lʸ = meridional (north-south) length
 H  = height of the ocean
 τₒ = maximum value of wind-stress (amplitude)
-fₒ = first coriolis parameter (constant term)
-β  = second coriolis parameter (linear term)
 λʳ = temperature relaxation penetration constant (meters / second)
 θᴱ = maximum surface temperature
 """
@@ -155,18 +139,14 @@ struct OceanGyre{T} <: AbstractSimpleBoxProblem
   Lʸ::T
   H::T
   τₒ::T
-  fₒ::T
-  β::T
   λʳ::T
   θᴱ::T
   function OceanGyre{FT}(Lˣ, Lʸ, H;
                          τₒ = FT(1e-1),       # (m/s)^2
-                         fₒ = FT(1e-4),       # Hz
-                         β  = FT(1e-11),      # Hz / m
                          λʳ = FT(4 // 86400), # m / s
                          θᴱ = FT(25),         # K
                          ) where {FT <: AbstractFloat}
-    return new{FT}(Lˣ, Lʸ, H, τₒ, fₒ, β, λʳ, θᴱ)
+    return new{FT}(Lˣ, Lʸ, H, τₒ, λʳ, θᴱ)
   end
 end
 
@@ -207,36 +187,32 @@ function ocean_init_state!(p::OceanGyre, Q, A, coords, t)
   Q.u = @SVector [0,0]
   Q.η = 0
   Q.θ = 9 + 8z/H
+
+  return nothing
 end
 
 """
-    ocean_init_aux!(::HBModel, ::OceanGyre)
+    velocity_flux(::OceanGyre)
 
-initiaze auxiliary states
 jet stream like windstress
-northern hemisphere coriolis
+
+# Arguments
+- `p`: problem object to dispatch on and get additional parameters
+- `y`: y-coordinate in the box
+"""
+@inline velocity_flux(p::OceanGyre, y, ρ) = - (p.τₒ / ρ) * cos(y * π / p.Lʸ)
+
+"""
+    temperature_flux(::OceanGyre)
+
 cool-warm north-south linear temperature gradient
 
 # Arguments
-- `m`: model object to dispatch on and get viscosities and diffusivities
 - `p`: problem object to dispatch on and get additional parameters
-- `A`: auxiliary state vector
-- `geom`: geometry stuff
+- `y`: y-coordinate in the box
+- `θ`: temperature within element on boundary
 """
-# aux is Filled afer the state
-function ocean_init_aux!(m::HBModel, p::OceanGyre, A, geom)
-  FT = eltype(A)
-  @inbounds y = geom.coord[2]
-
-  Lʸ = p.Lʸ
-  τₒ = p.τₒ
-  fₒ = p.fₒ
-  β  = p.β
-  θᴱ = p.θᴱ
-
-  A.τ  = -τₒ * cos(y * π / Lʸ)
-  A.f  =  fₒ + β * y
-  A.θʳ =  θᴱ * (1 - y / Lʸ)
-end
-
+@inline function temperature_flux(p::OceanGyre, y, θ)
+  θʳ =  p.θᴱ * (1 - y / p.Lʸ)
+  return p.λʳ * (θʳ - θ)
 end

--- a/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
+++ b/src/Ocean/HydrostaticBoussinesq/SimpleBoxProblem.jl
@@ -130,9 +130,6 @@ function ocean_init_aux!(m::HBModel, p::HomogeneousBox, A, geom)
 
   A.τ  = -τₒ * cos(y * π / Lʸ)
   A.f  =  fₒ + β * y
-
-  A.ν = @SVector [m.νʰ, m.νʰ, m.νᶻ]
-  A.κ = @SVector [m.κʰ, m.κʰ, m.κᶻ]
 end
 
 ##########################
@@ -240,9 +237,6 @@ function ocean_init_aux!(m::HBModel, p::OceanGyre, A, geom)
   A.τ  = -τₒ * cos(y * π / Lʸ)
   A.f  =  fₒ + β * y
   A.θʳ =  θᴱ * (1 - y / Lʸ)
-
-  A.ν = @SVector [m.νʰ, m.νʰ, m.νᶻ]
-  A.κ = @SVector [m.κʰ, m.κʰ, m.κᶻ]
 end
 
 end

--- a/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
@@ -1,7 +1,6 @@
 using Test
 using CLIMA
 using CLIMA.HydrostaticBoussinesq
-using CLIMA.SimpleBox
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters

--- a/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
@@ -1,7 +1,6 @@
 using Test
 using CLIMA
 using CLIMA.HydrostaticBoussinesq
-using CLIMA.SimpleBox
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

I realized instead of storing the values for viscosity and diffusivity we could just use a function to calculate them pointwise. I would like to do something similar with the Coriolis `f`, wind stress `τ`, and sea surface temperature `θʳ` variables, but these require accessing either `geom` or `coords` in `source!`, `numerical_boundary_flux_*!` and `boundary_state!`.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
