### PR TITLE
Fix for #827, domain extents in LES are now floats

### DIFF
--- a/examples/Atmos/dry_rayleigh_benard.jl
+++ b/examples/Atmos/dry_rayleigh_benard.jl
@@ -155,7 +155,7 @@ function main()
     t0 = FT(0)
     CFLmax = FT(0.90)
     timeend = FT(1000)
-    xmax, ymax, zmax = 250, 250, 500
+    xmax, ymax, zmax = FT(250), FT(250), FT(500)
 
     @testset "DryRayleighBenardTest" begin
         for Δh in Δh

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -463,9 +463,9 @@ function main()
     resolution = (Δh, Δh, Δv)
 
     # Prescribe domain parameters
-    xmax = 6400
-    ymax = 6400
-    zmax = 3000
+    xmax = FT(6400)
+    ymax = FT(6400)
+    zmax = FT(3000)
 
     t0 = FT(0)
 

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -352,9 +352,9 @@ function main()
     Δv = FT(20)
     resolution = (Δh, Δh, Δv)
 
-    xmax = 1000
-    ymax = 1000
-    zmax = 2500
+    xmax = FT(1000)
+    ymax = FT(1000)
+    zmax = FT(2500)
 
     t0 = FT(0)
     timeend = FT(100)

--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -119,9 +119,9 @@ function main()
     Δv = FT(50)
     resolution = (Δh, Δh, Δv)
     # Domain extents
-    xmax = 2500
-    ymax = 2500
-    zmax = 2500
+    xmax = FT(2500)
+    ymax = FT(2500)
+    zmax = FT(2500)
     # Simulation time
     t0 = FT(0)
     timeend = FT(1000)

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -124,9 +124,9 @@ function main()
     Δh = FT(50)
     Δv = FT(50)
     resolution = (Δh, Δh, Δv)
-    xmax = 2000
-    ymax = 2000
-    zmax = 2000
+    xmax = FT(2000)
+    ymax = FT(2000)
+    zmax = FT(2000)
     t0 = FT(0)
     timeend = FT(2000)
 

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -134,13 +134,13 @@ function AtmosLESConfiguration(
     name::String,
     N::Int,
     (Δx, Δy, Δz)::NTuple{3, FT},
-    xmax::Int,
-    ymax::Int,
-    zmax::Int,
+    xmax::FT,
+    ymax::FT,
+    zmax::FT,
     init_LES!;
-    xmin = 0,
-    ymin = 0,
-    zmin = 0,
+    xmin = zero(FT),
+    ymin = zero(FT),
+    zmin = zero(FT),
     array_type = CLIMA.array_type(),
     solver_type = IMEXSolverType(linear_solver = SingleColumnLU),
     model = AtmosModel{FT}(
@@ -161,7 +161,7 @@ function AtmosLESConfiguration(
         """Establishing Atmos LES configuration for %s
         precision        = %s
         polynomial order = %d
-        grid             = %dx%dx%d
+        domain           = %.2fx%.2fx%.2f
         resolution       = %dx%dx%d
         MPI ranks        = %d""",
         name,

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -111,9 +111,9 @@ function main()
     Δv = FT(20)
     resolution = (Δh, Δh, Δv)
 
-    xmax = 1500
-    ymax = 1500
-    zmax = 1500
+    xmax = FT(1500)
+    ymax = FT(1500)
+    zmax = FT(1500)
 
     t0 = FT(0)
     dt = FT(0.01)

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -65,9 +65,9 @@ function main()
     Δv = FT(40)
     resolution = (Δh, Δh, Δv)
 
-    xmax = 320
-    ymax = 320
-    zmax = 400
+    xmax = FT(320)
+    ymax = FT(320)
+    zmax = FT(400)
 
     t0 = FT(0)
     timeend = FT(10)


### PR DESCRIPTION
Fix grid1d (min extent), and float-type in driver configs.
This closes #827 
@charleskawczynski 

# Description
Fixes issue  #827. Users can now set either integer or float values for their domain extents (preserves functionality of current experiments). Also changes (in sim-summary info) `grid` -> `domain` , since `grid` might (in this case incorrectly) imply number of grid points for the printed output. 
 
# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
