### PR TITLE
limit noise from boilerplate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,13 @@
-<!--
-Thanks for submitting code to CLIMA, the Climate Machine.
-
-Before continuing, please be sure you have:
-
-1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
-2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
-3. Identified key contributors to review this submission
--->
-
 # Description
 
 A clear and concise description of the code with usage.
+
+<!--- Please fill out the following section --->
+
+I have
+
+- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
+- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
 
 <!--- Please leave the following section --->
 

--- a/bors.toml
+++ b/bors.toml
@@ -5,3 +5,4 @@ status = [
 delete_merged_branches = true
 timeout_sec = 86400
 block_labels = [ "do-not-merge-yet" ]
+cut_body_after = " <!--"

--- a/bors.toml
+++ b/bors.toml
@@ -5,4 +5,4 @@ status = [
 delete_merged_branches = true
 timeout_sec = 86400
 block_labels = [ "do-not-merge-yet" ]
-cut_body_after = " <!--"
+cut_body_after = "<!--"


### PR DESCRIPTION
Right now our git commit log is littered with:

```
    <!--
    Thanks for submitting code to CLIMA, the Climate Machine.
    Before continuing, please be sure you have:
    1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
    2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
    3. Identified key contributors to review this submission
    -->
```
this tells bors to cut the noise out. The sideeffect is that it will ignore everything afterwards.


<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

A clear and concise description of the code with usage.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)