### PR TITLE
Scripts for formatting CLIMA's julia code

### DIFF
--- a/.dev/clima_formatter_options.jl
+++ b/.dev/clima_formatter_options.jl
@@ -1,0 +1,8 @@
+clima_formatter_options = (
+    indent = 4,
+    margin = 80,
+    always_for_in = true,
+    whitespace_typedefs = true,
+    whitespace_ops_in_indices = true,
+    remove_extra_newlines = false,
+)

--- a/.dev/climaformat.jl
+++ b/.dev/climaformat.jl
@@ -1,0 +1,79 @@
+#!/usr/bin/env julia
+#
+# This is an adapted version of format.jl from JuliaFormatter with the
+# following license:
+#
+#    MIT License
+#    Copyright (c) 2019 Dominique Luna
+#
+#    Permission is hereby granted, free of charge, to any person obtaining a
+#    copy of this software and associated documentation files (the
+#    "Software"), to deal in the Software without restriction, including
+#    without limitation the rights to use, copy, modify, merge, publish,
+#    distribute, sublicense, and/or sell copies of the Software, and to permit
+#    persons to whom the Software is furnished to do so, subject to the
+#    following conditions:
+#
+#    The above copyright notice and this permission notice shall be included
+#    in all copies or substantial portions of the Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+#    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+#    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+#    USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+
+using JuliaFormatter
+
+include("clima_formatter_options.jl")
+
+help = """
+Usage: climaformat.jl [flags] [FILE/PATH]...
+
+Formats the given julia files using the CLIMA formatting options.  If paths
+are given it will format the julia files in the paths.
+
+    -v, --verbose
+        Print the name of the files being formatted with relevant details.
+
+    -h, --help
+        Print this message.
+"""
+
+function parse_opts!(args::Vector{String})
+    i = 1
+    opts = Dict{Symbol, Union{Int, Bool}}()
+    while i ≤ length(args)
+        arg = args[i]
+        if arg[1] != '-'
+            i += 1
+            continue
+        end
+        if arg == "-v" || arg == "--verbose"
+            opt = :verbose
+        elseif arg == "-h" || arg == "--help"
+            opt = :help
+        else
+            error("invalid option $arg")
+        end
+        if opt in (:verbose, :help)
+            opts[opt] = true
+            deleteat!(args, i)
+        end
+    end
+    return opts
+end
+
+opts = parse_opts!(ARGS)
+if isempty(ARGS) || haskey(opts, :help)
+    write(stdout, help)
+    exit(0)
+end
+
+format(ARGS; clima_formatter_options..., opts...)

--- a/.dev/format.jl
+++ b/.dev/format.jl
@@ -6,20 +6,13 @@ Pkg.instantiate()
 
 using JuliaFormatter
 
+include("clima_formatter_options.jl")
+
 headbranch = get(ARGS, 1, "master")
 
 for filename in
     readlines(`git diff --name-only --diff-filter=AM $headbranch...`)
     endswith(filename, ".jl") || continue
 
-    format(
-        filename,
-        verbose = true,
-        indent = 4,
-        margin = 80,
-        always_for_in = true,
-        whitespace_typedefs = true,
-        whitespace_ops_in_indices = true,
-        remove_extra_newlines = false,
-    )
+    format(filename; clima_formatter_options...)
 end

--- a/.dev/hooks/pre-commit
+++ b/.dev/hooks/pre-commit
@@ -1,0 +1,39 @@
+#!/usr/bin/env julia
+#
+# Called by git-commit with no arguments.  This checks to make sure that all
+# .jl files are indented correctly before a commit is made.
+#
+# To enable this hook, make this file executable and copy it in
+# $GIT_DIR/hooks.
+
+toplevel_directory = chomp(read(`git rev-parse --show-toplevel`, String))
+
+using Pkg
+Pkg.activate(joinpath(toplevel_directory, ".dev"))
+Pkg.instantiate()
+
+using JuliaFormatter
+
+include(joinpath(toplevel_directory, ".dev", "clima_formatter_options.jl"))
+
+needs_format = false
+
+for filename in readlines(`git diff --name-only --cached`)
+    endswith(filename, ".jl") || continue
+
+    a = read(`git show :$filename`, String)
+    b = format_text(a; clima_formatter_options...)
+
+    if a != b
+        fullfilename = joinpath(toplevel_directory, filename)
+
+        @error """File $filename needs to be indented with:
+            julia $(joinpath(toplevel_directory, ".dev", "climaformat.jl")) $fullfilename
+        and added to the git index via
+            git add $fullfilename
+        """
+        global needs_format = true
+    end
+end
+
+exit(needs_format ? 1 : 0)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,41 @@ julia .dev/format.jl
 
 Formatting changes should be done as a separate commit, ideally the last commit of the pull request (you may want to leave it until all other changes have been approved).
 
+### Formatting utility
+
+A convenience utility is located at `.dev/climaformat.jl` that will format the julia files in the given path. For example, from the top-level CLIMA directory
+```
+julia .dev/climaformat.jl src/CLIMA.jl
+```
+will format `src/CLIMA.jl` and
+```
+julia .dev/climaformat.jl .
+```
+will format all of CLIMA's julia files.
+
+### Formatting githook
+
+A `pre-commit` script that can be placed in `$GIT_DIR/hooks/*` which will prevent commits of incorrectly formatted julia code.  It will also provide commands that can be run to format the code correctly.
+
+One may tell git about the script with (from the top-level directory of a clone of CLIMA)
+```
+ln -s ../../.dev/hooks/pre-commit .git/hooks
+```
+and then when `git commit` is run an error message will be given for julia files that are staged to be committed that are not formatted according to CLIMA's standard.  With this, when I try to commit changes to `src/Arrays/MPIStateArrays.jl` that are not formatted correctly I get the following error message.
+
+```
+❯ git commit                                                                                                           │
+Activating environment at `~/research/code/CLIMA/.dev/Project.toml`                                                    │
+┌ Error: File src/Arrays/MPIStateArrays.jl needs to be indented with:                                                  │
+│     julia /home/lucas/research/code/CLIMA/.dev/climaformat.jl /home/lucas/research/code/CLIMA/src/Arrays/MPIStateArra│
+ys.jl                                                                                                                  │
+│ and added to the git index via                                                                                       │
+│     git add /home/lucas/research/code/CLIMA/src/Arrays/MPIStateArrays.jl                                             │
+└ @ Main ~/research/code/CLIMA/.git/hooks/pre-commit:30
+```
+
+See `man 5 githooks` for more information about git hooks.
+
 ## Bors and CI
 
 All commits that end up in the CLIMA repository must pass Continuous Integration (CI).


### PR DESCRIPTION
This adds two julia scripts to help with formatting julia code using CLIMA's standards.

First, is a utility `.dev/climaformat.jl` that will format the julia files in the given path. For example, from the top-level CLIMA directory
```
julia .dev/climaformat.jl src/CLIMA.jl
```
will format `src/CLIMA.jl` and
```
julia .dev/climaformat.jl .
```
will format all of CLIMA's julia files.

The second is a `pre-commit` script that can be placed in `$GIT_DIR/hooks/*` which will  prevent commits of incorrectly formatted julia code.  It will also provide commands that can be run to format the code correctly.

One may tell git about the script with (from the top-level directory of a clone of CLIMA)
```
ln -s ../../.dev/hooks/pre-commit .git/hooks
```
and then when `git commit` is run an error message will be given for julia files that are staged to be committed that are not formatted according to CLIMA's standard.  With this, when I try to commit changes to `src/Arrays/MPIStateArrays.jl` that are not formatted correctly I get the following error message.

```
❯ git commit                                                                                                           │
Activating environment at `~/research/code/CLIMA/.dev/Project.toml`                                                    │
┌ Error: File src/Arrays/MPIStateArrays.jl needs to be indented with:                                                  │
│     julia /home/lucas/research/code/CLIMA/.dev/climaformat.jl /home/lucas/research/code/CLIMA/src/Arrays/MPIStateArra│
ys.jl                                                                                                                  │
│ and added to the git index via                                                                                       │
│     git add /home/lucas/research/code/CLIMA/src/Arrays/MPIStateArrays.jl                                             │
└ @ Main ~/research/code/CLIMA/.git/hooks/pre-commit:30
```

See `man 5 githooks` for more information about git hooks.
# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
