### PR TITLE
Add diagnostic (atmos-default) setting to Atmos experiments

### DIFF
--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -59,8 +59,10 @@ using CLIMA
 using CLIMA.Atmos
 using CLIMA.ConfigTypes
 using CLIMA.DGmethods.NumericalFluxes
+using CLIMA.Diagnostics
 using CLIMA.GenericCallbacks
 using CLIMA.Mesh.Filters
+using CLIMA.ODESolvers
 using CLIMA.MoistThermodynamics
 using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
@@ -449,6 +451,12 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax)
     return config
 end
 
+function config_diagnostics(driver_config)
+    interval = 10000 # in time steps
+    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    return CLIMA.setup_diagnostics([dgngrp])
+end
+
 function main()
     CLIMA.init()
 
@@ -483,6 +491,7 @@ function main()
         init_on_cpu = true,
         Courant_number = CFLmax,
     )
+    dgn_config = config_diagnostics(driver_config)
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
         Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
@@ -491,6 +500,7 @@ function main()
 
     result = CLIMA.invoke!(
         solver_config;
+        diagnostics_config = dgn_config,
         user_callbacks = (cbtmarfilter,),
         check_euclidean_distance = true,
     )

--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -5,6 +5,7 @@ using Test
 using CLIMA
 using CLIMA.Atmos
 using CLIMA.ConfigTypes
+using CLIMA.Diagnostics
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
@@ -107,6 +108,12 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
     return config
 end
 
+function config_diagnostics(driver_config)
+    interval = 10000 # in time steps
+    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    return CLIMA.setup_diagnostics([dgngrp])
+end
+
 function main()
     CLIMA.init()
 
@@ -137,6 +144,7 @@ function main()
         init_on_cpu = true,
         Courant_number = CFL,
     )
+    dgn_config = config_diagnostics(driver_config)
 
     # User defined filter (TMAR positivity preserving filter)
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
@@ -147,6 +155,7 @@ function main()
     # Invoke solver (calls solve! function for time-integrator)
     result = CLIMA.invoke!(
         solver_config;
+        diagnostics_config = dgn_config,
         user_callbacks = (cbtmarfilter,),
         check_euclidean_distance = true,
     )

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -10,6 +10,7 @@ using CLIMA.Atmos
 using CLIMA.ConfigTypes
 using CLIMA.GenericCallbacks
 using CLIMA.DGmethods.NumericalFluxes
+using CLIMA.Diagnostics
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
 using CLIMA.MoistThermodynamics
@@ -115,6 +116,12 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
     return config
 end
 
+function config_diagnostics(driver_config)
+    interval = 10000 # in time steps
+    dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
+    return CLIMA.setup_diagnostics([dgngrp])
+end
+
 function main()
     CLIMA.init()
     FT = Float64
@@ -133,6 +140,7 @@ function main()
     driver_config = config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
     solver_config =
         CLIMA.setup_solver(t0, timeend, driver_config, init_on_cpu = true)
+    dgn_config = config_diagnostics(driver_config)
 
     cbtmarfilter = GenericCallbacks.EveryXSimulationSteps(1) do (init = false)
         Filters.apply!(solver_config.Q, 6, solver_config.dg.grid, TMARFilter())
@@ -141,6 +149,7 @@ function main()
 
     result = CLIMA.invoke!(
         solver_config;
+        diagnostics_config = dgn_config,
         user_callbacks = (cbtmarfilter,),
         check_euclidean_distance = true,
     )


### PR DESCRIPTION
# Description
The merger of #823 results in some necessary changes to the experiment files; this PR adds the atmos-default diagnostic configuration to the BOMEX experiment (and other existing atoms experiments / examples), such that `--enable-diagnostics` will produce the appropriate `.jld2` file with horizontally averaged terms. Also uses `ODESolvers` in preparation for the MRRK methods to be built into experiments in a future PR. 
cc: @kpamnany
```
modified:   experiments/AtmosLES/bomex.jl
modified:   experiments/AtmosLES/surfacebubble.jl
modified:   experiments/AtmosLES/risingbubble.jl
modified:   examples/Atmos/dry_rayleigh_benard.jl
```

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
