### PR TITLE
Convert Microphysics `saturation_adjustment` driver to new framework

### DIFF
--- a/examples/Microphysics/KinematicModel.jl
+++ b/examples/Microphysics/KinematicModel.jl
@@ -1,0 +1,235 @@
+# The set-up was designed for the
+# 8th International Cloud Modelling Workshop
+# (ICMW, Muhlbauer et al., 2013, case 1, doi:10.1175/BAMS-D-12-00188.1)
+#
+# See chapter 2 in Arabas et al 2015 for setup details:
+#@Article{gmd-8-1677-2015,
+#AUTHOR = {Arabas, S. and Jaruga, A. and Pawlowska, H. and Grabowski, W. W.},
+#TITLE = {libcloudph++ 1.0: a single-moment bulk, double-moment bulk,
+#         and particle-based warm-rain microphysics library in C++},
+#JOURNAL = {Geoscientific Model Development},
+#VOLUME = {8},
+#YEAR = {2015},
+#NUMBER = {6},
+#PAGES = {1677--1707},
+#URL = {https://www.geosci-model-dev.net/8/1677/2015/},
+#DOI = {10.5194/gmd-8-1677-2015}
+#}
+
+using Dates
+using DocStringExtensions
+using LinearAlgebra
+using Logging
+using MPI
+using Printf
+using StaticArrays
+using Test
+
+using CLIMA
+using CLIMA.Atmos
+using CLIMA.ConfigTypes
+using CLIMA.DGBalanceLawDiscretizations
+using CLIMA.DGmethods.NumericalFluxes
+using CLIMA.Grids
+using CLIMA.GenericCallbacks
+using CLIMA.Mesh.Filters
+using CLIMA.Mesh.Topologies
+using CLIMA.MoistThermodynamics
+using CLIMA.Microphysics
+using CLIMA.MPIStateArrays
+using CLIMA.ODESolvers
+using CLIMA.PlanetParameters
+using CLIMA.VariableTemplates
+using CLIMA.VTK
+
+import CLIMA.DGmethods:
+    BalanceLaw,
+    DGModel,
+    LocalGeometry,
+    vars_state,
+    vars_aux,
+    vars_gradient,
+    vars_diffusive,
+    init_state!,
+    init_aux!,
+    update_aux!,
+    nodal_update_aux!,
+    flux_nondiffusive!,
+    flux_diffusive!,
+    wavespeed,
+    boundary_state!,
+    source!
+
+struct KinematicModelConfig{FT}
+    xmax::FT
+    ymax::FT
+    zmax::FT
+    wmax::FT
+    θ_0::FT
+    p_0::FT
+    p_1000::FT
+    qt_0::FT
+    z_0::FT
+end
+
+struct KinematicModel{FT, O, M, P, S, BC, IS, DC} <: BalanceLaw
+    orientation::O
+    moisture::M
+    precipitation::P
+    source::S
+    boundarycondition::BC
+    init_state::IS
+    data_config::DC
+end
+
+function KinematicModel{FT}(
+    ::Type{AtmosLESConfigType};
+    orientation::O = FlatOrientation(),
+    moisture::M = nothing,
+    precipitation::P = nothing,
+    source::S = nothing,
+    boundarycondition::BC = nothing,
+    init_state::IS = nothing,
+    data_config::DC = nothing,
+) where {FT <: AbstractFloat, O, M, P, S, BC, IS, DC}
+
+    @assert init_state ≠ nothing
+
+    atmos = (
+        orientation,
+        moisture,
+        precipitation,
+        source,
+        boundarycondition,
+        init_state,
+        data_config,
+    )
+
+    return KinematicModel{FT, typeof.(atmos)...}(atmos...)
+end
+
+vars_gradient(m::KinematicModel, FT) = @vars()
+
+vars_diffusive(m::KinematicModel, FT) = @vars()
+
+function init_aux!(m::KinematicModel, aux::Vars, geom::LocalGeometry)
+
+    FT = eltype(aux)
+    x, y, z = geom.coord
+    dc = m.data_config
+
+    # TODO - should R_d and cp_d here be R_m and cp_m?
+    R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(dc.qt_0))
+
+    # Pressure profile assuming hydrostatic and constant θ and qt profiles.
+    # It is done this way to be consistent with Arabas paper.
+    # It's not neccesarily the best way to initialize with our model variables.
+    p =
+        dc.p_1000 *
+        (
+            (dc.p_0 / dc.p_1000)^(R_d / cp_d) -
+            R_d / cp_d * grav / dc.θ_0 / R_m * (z - dc.z_0)
+        )^(cp_d / R_d)
+    aux.p = p
+    aux.z = z
+end
+
+function init_state!(
+    m::KinematicModel,
+    state::Vars,
+    aux::Vars,
+    coords,
+    t,
+    args...,
+)
+    m.init_state(m, state, aux, coords, t, args...)
+end
+
+function update_aux!(dg::DGModel, m::KinematicModel, Q::MPIStateArray, t::Real)
+    nodal_update_aux!(kinematic_model_nodal_update_aux!, dg, m, Q, t)
+    return true
+end
+
+function boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    m::KinematicModel,
+    state⁺,
+    aux⁺,
+    n,
+    state⁻,
+    aux⁻,
+    bctype,
+    t,
+    args...,
+) end
+
+@inline function flux_diffusive!(
+    m::KinematicModel,
+    flux::Grad,
+    state::Vars,
+    diffusive::Vars,
+    hyperdiffusive::Vars,
+    aux::Vars,
+    t::Real,
+) end
+
+@inline function flux_diffusive!(
+    m::KinematicModel,
+    flux::Grad,
+    state::Vars,
+    τ,
+    d_h_tot,
+) end
+
+function config_kinematic_eddy(
+    FT,
+    N,
+    resolution,
+    xmax,
+    ymax,
+    zmax,
+    wmax,
+    θ_0,
+    p_0,
+    p_1000,
+    qt_0,
+    z_0,
+)
+    # Choose explicit solver
+    ode_solver =
+        CLIMA.ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
+
+    kmc = KinematicModelConfig(
+        FT(xmax),
+        FT(ymax),
+        FT(zmax),
+        FT(wmax),
+        FT(θ_0),
+        FT(p_0),
+        FT(p_1000),
+        FT(qt_0),
+        FT(z_0),
+    )
+
+    # Set up the model
+    model = KinematicModel{FT}(
+        AtmosLESConfigType;
+        boundarycondition = nothing,
+        init_state = init_kinematic_eddy!,
+        data_config = kmc,
+    )
+
+    config = CLIMA.AtmosLESConfiguration(
+        "KinematicModel",
+        N,
+        resolution,
+        FT(xmax),
+        FT(ymax),
+        FT(zmax),
+        init_kinematic_eddy!;
+        solver_type = ode_solver,
+        model = model,
+    )
+
+    return config
+end

--- a/examples/Microphysics/ex_1_saturation_adjustment.jl
+++ b/examples/Microphysics/ex_1_saturation_adjustment.jl
@@ -1,368 +1,281 @@
-# The test is based on a modelling set-up designed for the
-# 8th International Cloud Modelling Workshop
-# (ICMW, Muhlbauer et al., 2013, case 1, doi:10.1175/BAMS-D-12-00188.1)
-#
-# See chapter 2 in Arabas et al 2015 for setup details:
-#@Article{gmd-8-1677-2015,
-#AUTHOR = {Arabas, S. and Jaruga, A. and Pawlowska, H. and Grabowski, W. W.},
-#TITLE = {libcloudph++ 1.0: a single-moment bulk, double-moment bulk, and particle-based warm-rain microphysics library in C++},
-#JOURNAL = {Geoscientific Model Development},
-#VOLUME = {8},
-#YEAR = {2015},
-#NUMBER = {6},
-#PAGES = {1677--1707},
-#URL = {https://www.geosci-model-dev.net/8/1677/2015/},
-#DOI = {10.5194/gmd-8-1677-2015}
-#}
+include("KinematicModel.jl")
 
-using MPI
-using CLIMA
-using CLIMA.Mesh.Topologies
-using CLIMA.Mesh.Grids
-using CLIMA.DGBalanceLawDiscretizations
-using CLIMA.DGBalanceLawDiscretizations.NumericalFluxes
-using CLIMA.MPIStateArrays
-using CLIMA.ODESolvers
-using CLIMA.GenericCallbacks
-using CLIMA.VTK
-
-using LinearAlgebra
-using StaticArrays
-using Printf
-
-using CLIMA.PlanetParameters: R_d, cp_d, grav
-using CLIMA.MoistThermodynamics
-using CLIMA.Microphysics
-
-using CLIMA.Parameters
-const clima_dir = dirname(pathof(CLIMA))
-# We will depend on MoistThermodynamics's default Parameters:
-include(joinpath(clima_dir, "..", "Parameters", "EarthParameters.jl"))
-
-const _nstate = 5
-const _ρ, _ρu, _ρw, _ρe_tot, _ρq_tot = 1:_nstate
-const stateid =
-    (ρid = _ρ, ρuid = _ρu, ρwid = _ρw, ρe_tot_id = _ρe_tot, ρq_tot_id = _ρq_tot)
-const statenames = ("ρ", "ρu", "ρw", "ρe_tot", "ρq_tot")
-
-const _nauxcstate = 3
-const _c_z, _c_x, _c_p = 1:_nauxcstate
-
-
-# preflux computation for wavespeed function
-@inline function preflux(Q)
-    @inbounds begin
-        # unpack all the state variables
-        ρ, ρu, ρw, ρe_tot, ρq_tot =
-            Q[_ρ], Q[_ρu], Q[_ρw], Q[_ρe_tot], Q[_ρq_tot]
-        u, w, e_tot, q_tot = ρu / ρ, ρw / ρ, ρe_tot / ρ, ρq_tot / ρ
-
-        return (u, w, ρ, q_tot, e_tot)
+function vars_state(m::KinematicModel, FT)
+    @vars begin
+        ρ::FT
+        ρu::SVector{3, FT}
+        ρe::FT
+        ρq_tot::FT
     end
 end
 
-
-# boundary condition
-@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t)
-    @inbounds begin
-        ρu_M, ρw_M, ρe_tot_M, ρq_tot_M =
-            QM[_ρu], QM[_ρw], QM[_ρe_tot], QM[_ρq_tot]
-
-        ρu_nM = nM[1] * ρu_M + nM[2] * ρw_M
-
-        QP[_ρu] = ρu_M - 2 * nM[1] * ρu_nM
-        QP[_ρw] = ρw_M - 2 * nM[2] * ρu_nM
-
-        QP[_ρe_tot], QP[_ρq_tot] = ρe_tot_M, ρq_tot_M
-
-        auxM .= auxP
+function vars_aux(m::KinematicModel, FT)
+    @vars begin
+        # defined in init_aux
+        p::FT
+        z::FT
+        # defined in update_aux
+        u::FT
+        w::FT
+        q_tot::FT
+        q_vap::FT
+        q_liq::FT
+        q_ice::FT
+        e_tot::FT
+        e_kin::FT
+        e_pot::FT
+        e_int::FT
+        T::FT
+        S::FT
+        RH::FT
     end
 end
 
+function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
+    FT = eltype(state)
+    dc = eddy_model.data_config
 
-# max eigenvalue
-@inline function wavespeed(n, Q, aux, t)
-    u, w, ρ, q_tot, e_tot = preflux(Q)
-    @inbounds abs(n[1] * u + n[2] * w)
+    # density
+    q_pt_0 = PhasePartition(dc.qt_0)
+    R_m, cp_m, cv_m, γ = gas_constants(q_pt_0)
+    T::FT = dc.θ_0 * (aux.p / dc.p_1000)^(R_m / cp_m)
+    ρ::FT = aux.p / R_m / T
+    state.ρ = ρ
+
+    # moisture
+    state.ρq_tot = ρ * dc.qt_0
+
+    # velocity (derivative of streamfunction)
+    ρu::FT =
+        dc.wmax * dc.xmax / dc.zmax *
+        cos(π * z / dc.zmax) *
+        cos(2 * π * x / dc.xmax)
+    ρw::FT = 2 * dc.wmax * sin(π * z / dc.zmax) * sin(2 * π * x / dc.xmax)
+    state.ρu = SVector(ρu, FT(0), ρw)
+    u::FT = ρu / ρ
+    w::FT = ρw / ρ
+
+    # energy
+    e_kin::FT = 1 // 2 * (u^2 + w^2)
+    e_pot::FT = grav * z
+    e_int::FT = internal_energy(T, q_pt_0)
+    e_tot::FT = e_kin + e_pot + e_int
+    state.ρe = ρ * e_tot
+
+    return nothing
 end
 
+function kinematic_model_nodal_update_aux!(
+    m::KinematicModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    FT = eltype(state)
 
-@inline function constant_auxiliary_init!(aux, x, z, _...)
-    @inbounds begin
-        aux[_c_z] = z  # for gravity
-        aux[_c_x] = x
+    aux.u = state.ρu[1] / state.ρ
+    aux.w = state.ρu[3] / state.ρ
 
-        FT = eltype(aux)
+    aux.q_tot = state.ρq_tot / state.ρ
 
-        # initial condition
-        θ_0::FT = 289         # K
-        p_0::FT = 101500      # Pa
-        p_1000::FT = 100000      # Pa
-        qt_0::FT = 7.5 * 1e-3  # kg/kg
-        z_0::FT = 0           # m
+    aux.e_tot = state.ρe / state.ρ
+    aux.e_kin = 1 // 2 * (aux.u^2 + aux.w^2)
+    aux.e_pot = grav * aux.z
+    aux.e_int = aux.e_tot - aux.e_kin - aux.e_pot
 
-        R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
+    # saturation adjustment happens here
+    ts = PhaseEquil(aux.e_int, state.ρ, aux.q_tot)
+    pp = PhasePartition(ts)
 
-        # Pressure profile assuming hydrostatic and constant θ and qt profiles.
-        # It is done this way to be consistent with Arabas paper.
-        # It's not neccesarily the best way to initialize with our model variables.
-        p =
-            p_1000 *
-            (
-                (p_0 / p_1000)^(R_d / cp_d) -
-                R_d / cp_d * grav / θ_0 / R_m * (z - z_0)
-            )^(cp_d / R_d)
+    aux.T = ts.T
+    aux.q_vap = aux.q_tot - pp.liq - pp.ice
+    aux.q_liq = pp.liq
+    aux.q_ice = pp.ice
 
-        aux[_c_p] = p  # for prescribed pressure gradient (kinematic setup)
-    end
+    q = PhasePartition(aux.q_tot, aux.q_liq, aux.q_ice)
+    aux.S =
+        max(0, aux.q_vap / q_vap_saturation(aux.T, state.ρ, q) - FT(1)) *
+        FT(100)
+    aux.RH = aux.q_vap / q_vap_saturation(aux.T, state.ρ, q) * FT(100)
 end
 
+function boundary_state!(
+    ::Rusanov,
+    m::KinematicModel,
+    state⁺,
+    aux⁺,
+    n,
+    state⁻,
+    aux⁻,
+    bctype,
+    t,
+    args...,
+) end
 
-# physical flux function
-@inline function eulerflux!(F, Q, QV, aux, t)
-    u, w, ρ, q_tot, e_tot = preflux(Q)
-    @inbounds begin
-        p = aux[_c_p]
-
-        F .= 0
-        # advect the moisture and energy
-        F[1, _ρq_tot], F[2, _ρq_tot] = u * ρ * q_tot, w * ρ * q_tot
-        F[1, _ρe_tot], F[2, _ρe_tot] = u * (ρ * e_tot + p), w * (ρ * e_tot + p)
-        # don't advect momentum (kinematic setup)
-    end
+@inline function wavespeed(
+    m::KinematicModel,
+    nM,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    u = state.ρu / state.ρ
+    return abs(dot(nM, u))
 end
 
+@inline function flux_nondiffusive!(
+    m::KinematicModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    FT = eltype(state)
 
-# initial condition
-const w_max = 0.6    # m/s
-const Z_max = 1500.0 # m
-const X_max = 1500.0 # m
-
-@inline function single_eddy!(Q, t, x, z, _...)
-    FT = eltype(Q)
-
-    # initial condition
-    θ_0::FT = 289         # K
-    p_0::FT = 101500      # Pa
-    p_1000::FT = 100000      # Pa
-    qt_0::FT = 7.5 * 1e-3  # kg/kg
-    z_0::FT = 0           # m
-
-    R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
-
-    @inbounds begin
-        # Pressure profile assuming hydrostatic and constant θ and qt profiles.
-        # It is done this way to be consistent with Arabas paper.
-        # It's not neccesarily the best way to initialize with our model variables.
-        p =
-            p_1000 *
-            (
-                (p_0 / p_1000)^(R_d / cp_d) -
-                R_d / cp_d * grav / θ_0 / R_m * (z - z_0)
-            )^(cp_d / R_d)
-        T::FT = θ_0 * exner_given_pressure(p, PhasePartition(qt_0))
-        ρ::FT = p / R_m / T
-
-        # TODO should this be more "grid aware"?
-        # the velocity is calculated as derivative of streamfunction
-        ρu::FT =
-            w_max * X_max / Z_max * cos(π * z / Z_max) * cos(2 * π * x / X_max)
-        ρw::FT = 2 * w_max * sin(π * z / Z_max) * sin(2 * π * x / X_max)
-        u = ρu / ρ
-        w = ρw / ρ
-
-        ρq_tot::FT = ρ * qt_0
-
-        e_int = internal_energy(T, PhasePartition(qt_0))
-        ρe_tot = ρ * (grav * z + (1 // 2) * (u^2 + w^2) + e_int)
-
-        Q[_ρ], Q[_ρu], Q[_ρw], Q[_ρe_tot], Q[_ρq_tot] =
-            ρ, ρu, ρw, ρe_tot, ρq_tot
-    end
-end
-
-
-function main(
-    mpicomm,
-    FT,
-    topl::AbstractTopology{dim},
-    N,
-    timeend,
-    ArrayType,
-    dt,
-) where {dim}
-
-    grid = DiscontinuousSpectralElementGrid(
-        topl,
-        FloatType = FT,
-        DeviceArray = ArrayType,
-        polynomialorder = N,
+    # advect moisture ...
+    flux.ρq_tot = SVector(
+        state.ρu[1] * state.ρq_tot / state.ρ,
+        FT(0),
+        state.ρu[3] * state.ρq_tot / state.ρ,
     )
-    numflux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed)
-    numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(
-        x...,
-        eulerflux!,
-        bcstate!,
-        wavespeed,
+    # ... energy ...
+    flux.ρe = SVector(
+        state.ρu[1] / state.ρ * (state.ρe + aux.p),
+        FT(0),
+        state.ρu[3] / state.ρ * (state.ρe + aux.p),
     )
-
-
-
-    # spacedisc = data needed for evaluating the right-hand side function
-    spacedisc = DGBalanceLaw(
-        grid = grid,
-        length_state_vector = _nstate,
-        flux! = eulerflux!,
-        numerical_flux! = numflux!,
-        numerical_boundary_flux! = numbcflux!,
-        auxiliary_state_length = _nauxcstate,
-        auxiliary_state_initialization! = constant_auxiliary_init!,
-    )
-
-    # This is a actual state/function that lives on the grid
-    initialcondition(Q, x...) = single_eddy!(Q, FT(0), x...)
-    Q = MPIStateArray(spacedisc, initialcondition)
-
-    npoststates = 9
-    v_q_liq, v_q_vap, v_q_tot, v_p, v_T, v_e_tot, v_e_int, v_e_kin, v_e_pot =
-        1:npoststates
-    postnames = (
-        "q_liq",
-        "q_vap",
-        "q_tot",
-        "p",
-        "T",
-        "e_tot",
-        "e_int",
-        "e_kin",
-        "e_pot",
-    )
-    postprocessarray = MPIStateArray(spacedisc; nstate = npoststates)
-
-    writevtk("initial_condition", Q, spacedisc, statenames)
-
-    lsrk = LSRK54CarpenterKennedy(spacedisc, Q; dt = dt, t0 = 0)
-
-    io = MPI.Comm_rank(mpicomm) == 0 ? stdout : devnull
-    eng0 = norm(Q)
-    @printf(io, "----\n")
-    @printf(io, "||Q||₂ (initial) =  %.16e\n", eng0)
-
-    # Set up the information callback
-    timer = [time_ns()]
-    cbinfo = GenericCallbacks.EveryXWallTimeSeconds(10, mpicomm) do (s = false)
-        if s
-            timer[1] = time_ns()
-        else
-            run_time = (time_ns() - timer[1]) * 1e-9
-            (min, sec) = fldmod(run_time, 60)
-            (hrs, min) = fldmod(min, 60)
-            @printf(io, "----\n")
-            @printf(io, "simtime =  %.16e\n", ODESolvers.gettime(lsrk))
-            @printf(
-                io,
-                "runtime =  %03d:%02d:%05.2f (hour:min:sec)\n",
-                hrs,
-                min,
-                sec
-            )
-            @printf(io, "||Q||₂  =  %.16e\n", norm(Q))
-        end
-        nothing
-    end
-
-    step = [0]
-    mkpath("vtk")
-
-    cbvtk = GenericCallbacks.EveryXSimulationSteps(60) do (init = false)
-        DGBalanceLawDiscretizations.dof_iteration!(
-            postprocessarray,
-            spacedisc,
-            Q,
-        ) do R, Q, QV, aux
-            @inbounds begin
-                u, w, ρ, q_tot, e_tot = preflux(Q)
-                z = aux[_c_z]
-                p = aux[_c_p]
-
-                e_int = e_tot - 1 // 2 * (u^2 + w^2) - grav * z
-                ts = PhaseEquil(e_int, ρ, q_tot) # saturation adjustment happens here
-                pp = PhasePartition(ts)
-                R[v_T] = ts.T
-                R[v_p] = p
-
-                R[v_q_tot] = q_tot
-                R[v_q_vap] = q_tot - pp.liq
-                R[v_q_liq] = pp.liq
-
-                R[v_e_tot] = e_tot
-                R[v_e_int] = e_int
-                R[v_e_kin] = 1 // 2 * (u^2 + w^2)
-                R[v_e_pot] = grav * z
-
-            end
-        end
-
-        outprefix = @sprintf(
-            "vtk/ex_1_microphysics_sat_adj_%dD_mpirank%04d_step%04d",
-            dim,
-            MPI.Comm_rank(mpicomm),
-            step[1]
-        )
-        @printf(io, "----\n")
-        @printf(io, "doing VTK output =  %s\n", outprefix)
-        writevtk(
-            outprefix,
-            Q,
-            spacedisc,
-            statenames,
-            postprocessarray,
-            postnames,
-        )
-        step[1] += 1
-        nothing
-    end
-
-    solve!(Q, lsrk; timeend = timeend, callbacks = (cbinfo, cbvtk))
-
-    Qe = MPIStateArray(
-        spacedisc,
-        (Q, x...) -> single_eddy!(Q, FT(timeend), x...),
-    )
-
-    # Print some end of the simulation information
-    engf = norm(Q)
-    @printf(io, "----\n")
-    @printf(io, "||Q||₂ ( final ) = %.16e\n", engf)
+    # ... and don't advect momentum (kinematic setup)
 end
 
-function run(dim, Ne, N, timeend, FT)
+function source!(
+    m::KinematicModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+) end
 
+function main()
     CLIMA.init()
-    ArrayType = CLIMA.array_type()
+
+    # Working precision
+    FT = Float64
+    # DG polynomial order
+    N = 4
+    # Domain resolution and size
+    Δx = FT(20)
+    Δy = FT(1)
+    Δz = FT(20)
+    resolution = (Δx, Δy, Δz)
+    # Domain extents
+    xmax = 1500
+    ymax = 10
+    zmax = 1500
+    # initial configuration
+    wmax = FT(0.6)  # max velocity of the eddy  [m/s]
+    θ_0 = FT(289) # init. theta value (const) [K]
+    p_0 = FT(101500) # surface pressure [Pa]
+    p_1000 = FT(100000) # reference pressure in theta definition [Pa]
+    qt_0 = FT(7.5 * 1e-3) # init. total water specific humidity (const) [kg/kg]
+    z_0 = FT(0) # surface height
+
+    # time stepping
+    t_ini = FT(0)
+    t_end = FT(60 * 30)
+    dt = 40
+    output_freq = 9
+
+    driver_config = config_kinematic_eddy(
+        FT,
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        wmax,
+        θ_0,
+        p_0,
+        p_1000,
+        qt_0,
+        z_0,
+    )
+    solver_config = CLIMA.SolverConfiguration(
+        t_ini,
+        t_end,
+        driver_config;
+        ode_dt = dt,
+        init_on_cpu = true,
+        #Courant_number = CFL,
+    )
 
     mpicomm = MPI.COMM_WORLD
 
-    brickrange = ntuple(j -> range(FT(0); length = Ne[j] + 1, stop = Z_max), 2)
+    # output for paraview
+    model = driver_config.bl
+    step = [0]
+    cbvtk =
+        GenericCallbacks.EveryXSimulationSteps(output_freq) do (init = false)
+            mkpath("vtk/")
+            outprefix = @sprintf(
+                "vtk/new_ex_1_mpirank%04d_step%04d",
+                MPI.Comm_rank(mpicomm),
+                step[1]
+            )
+            @info "doing VTK output" outprefix
+            writevtk(
+                outprefix,
+                solver_config.Q,
+                solver_config.dg,
+                flattenednames(vars_state(model, FT)),
+                solver_config.dg.auxstate,
+                flattenednames(vars_aux(model, FT)),
+            )
+            step[1] += 1
+            nothing
+        end
 
-    topl = BrickTopology(mpicomm, brickrange, periodicity = (true, false))
-    dt = 1
+    # get aux variables indices for testing
+    q_tot_ind = varsindex(vars_aux(model, FT), :q_tot)
+    q_vap_ind = varsindex(vars_aux(model, FT), :q_vap)
+    q_liq_ind = varsindex(vars_aux(model, FT), :q_liq)
+    q_ice_ind = varsindex(vars_aux(model, FT), :q_ice)
+    S_ind = varsindex(vars_aux(model, FT), :S)
 
-    main(mpicomm, FT, topl, N, timeend, ArrayType, dt)
+    # call solve! function for time-integrator
+    result = CLIMA.invoke!(
+        solver_config;
+        user_callbacks = (cbvtk,),
+        check_euclidean_distance = true,
+    )
 
+    # no supersaturation
+    max_S = maximum(abs.(solver_config.dg.auxstate[:, S_ind, :]))
+    @test isequal(max_S, FT(0))
+
+    # qt is conserved
+    max_q_tot = maximum(abs.(solver_config.dg.auxstate[:, q_tot_ind, :]))
+    min_q_tot = minimum(abs.(solver_config.dg.auxstate[:, q_tot_ind, :]))
+    @test isapprox(max_q_tot, qt_0; rtol = 1e-3)
+    @test isapprox(min_q_tot, qt_0; rtol = 1e-3)
+
+    # q_vap + q_liq = q_tot
+    max_water_diff = maximum(abs.(
+        solver_config.dg.auxstate[:, q_tot_ind, :] .-
+        solver_config.dg.auxstate[:, q_vap_ind, :] .-
+        solver_config.dg.auxstate[:, q_liq_ind, :],
+    ))
+    @test isequal(max_water_diff, FT(0))
+
+    # no ice
+    max_q_ice = maximum(abs.(solver_config.dg.auxstate[:, q_ice_ind, :]))
+    @test isequal(max_q_ice, FT(0))
+
+    # q_liq ∈ reference range
+    max_q_liq = max(solver_config.dg.auxstate[:, q_liq_ind, :]...)
+    min_q_liq = min(solver_config.dg.auxstate[:, q_liq_ind, :]...)
+    @test max_q_liq < FT(1e-3)
+    @test isequal(min_q_liq, FT(0))
 end
 
-using Test
-let
-    timeend = 30 * 60
-    numelem = (75, 75)
-    lvls = 3
-    dim = 2
-    FT = Float64
-
-    polynomialorder = 4
-
-    run(dim, ntuple(j -> numelem[j], dim), polynomialorder, timeend, FT)
-end
-
-nothing
+main()

--- a/examples/Microphysics/ex_2_Kessler.jl
+++ b/examples/Microphysics/ex_2_Kessler.jl
@@ -1,474 +1,406 @@
-# The test is based on a modelling set-up designed for the
-# 8th International Cloud Modelling Workshop
-# (ICMW, Muhlbauer et al., 2013, case 1, doi:10.1175/BAMS-D-12-00188.1)
-#
-# See chapter 2 in Arabas et al 2015 for setup details:
-#@Article{gmd-8-1677-2015,
-#AUTHOR = {Arabas, S. and Jaruga, A. and Pawlowska, H. and Grabowski, W. W.},
-#TITLE = {libcloudph++ 1.0: a single-moment bulk, double-moment bulk, and particle-based warm-rain microphysics library in C++},
-#JOURNAL = {Geoscientific Model Development},
-#VOLUME = {8},
-#YEAR = {2015},
-#NUMBER = {6},
-#PAGES = {1677--1707},
-#URL = {https://www.geosci-model-dev.net/8/1677/2015/},
-#DOI = {10.5194/gmd-8-1677-2015}
-#}
+include("KinematicModel.jl")
 
-using MPI
-using CLIMA
-using CLIMA.Mesh.Topologies
-using CLIMA.Mesh.Grids
-using CLIMA.DGBalanceLawDiscretizations
-using CLIMA.DGBalanceLawDiscretizations.NumericalFluxes
-using CLIMA.MPIStateArrays
-using CLIMA.ODESolvers
-using CLIMA.GenericCallbacks
-using CLIMA.VTK
+function vars_state(m::KinematicModel, FT)
+    @vars begin
+        ρ::FT
+        ρu::SVector{3, FT}
+        ρe::FT
+        ρq_tot::FT
+        ρq_liq::FT
+        ρq_ice::FT
+        ρq_rai::FT
+    end
+end
 
-using LinearAlgebra
-using StaticArrays
-using Printf
+function vars_aux(m::KinematicModel, FT)
+    @vars begin
+        # defined in init_aux
+        p::FT
+        z::FT
+        # defined in update_aux
+        u::FT
+        w::FT
+        q_tot::FT
+        q_vap::FT
+        q_liq::FT
+        q_ice::FT
+        q_rai::FT
+        e_tot::FT
+        e_kin::FT
+        e_pot::FT
+        e_int::FT
+        T::FT
+        S::FT
+        RH::FT
+        rain_w::FT
+        # uncomment below for more diagnostics
+        #src_cloud_liq::FT
+        #src_cloud_ice::FT
+        #src_acnv::FT
+        #src_accr::FT
+        #src_rain_evap::FT
+        #flag_rain::FT
+        #flag_cloud_liq::FT
+        #flag_cloud_ice::FT
+    end
+end
 
-using CLIMA.PlanetParameters: R_d, cp_d, cv_d, cv_v, T_0, e_int_v0, grav
-using CLIMA.MoistThermodynamics
-using CLIMA.Microphysics
+function init_kinematic_eddy!(eddy_model, state, aux, (x, y, z), t)
+    FT = eltype(state)
+    dc = eddy_model.data_config
 
-using CLIMA.Parameters
-const clima_dir = dirname(pathof(CLIMA))
-# We will depend on MoistThermodynamics's default Parameters:
-include(joinpath(clima_dir, "..", "Parameters", "EarthParameters.jl"))
+    # density
+    q_pt_0 = PhasePartition(dc.qt_0)
+    R_m, cp_m, cv_m, γ = gas_constants(q_pt_0)
+    T::FT = dc.θ_0 * (aux.p / dc.p_1000)^(R_m / cp_m)
+    ρ::FT = aux.p / R_m / T
+    state.ρ = ρ
 
-const _nstate = 7
-const _ρ, _ρu, _ρw, _ρe_tot, _ρq_tot, _ρq_liq, _ρq_rai = 1:_nstate
-const stateid = (
-    ρ_id = _ρ,
-    ρu_id = _ρu,
-    ρw_id = _ρw,
-    ρe_tot_id = _ρe_tot,
-    ρq_tot_id = _ρq_tot,
-    ρq_liq_id = _ρq_liq,
-    ρq_rai_id = _ρq_rai,
+    # moisture
+    state.ρq_tot = ρ * dc.qt_0
+    state.ρq_liq = ρ * q_pt_0.liq
+    state.ρq_ice = ρ * q_pt_0.ice
+    state.ρq_rai = ρ * FT(0)
+
+    # velocity (derivative of streamfunction)
+    ρu::FT =
+        dc.wmax * dc.xmax / dc.zmax *
+        cos(π * z / dc.zmax) *
+        cos(2 * π * x / dc.xmax)
+    ρw::FT = 2 * dc.wmax * sin(π * z / dc.zmax) * sin(2 * π * x / dc.xmax)
+    state.ρu = SVector(ρu, FT(0), ρw)
+    u::FT = ρu / ρ
+    w::FT = ρw / ρ
+
+    # energy
+    e_kin::FT = 1 // 2 * (u^2 + w^2)
+    e_pot::FT = grav * z
+    e_int::FT = internal_energy(T, q_pt_0)
+    e_tot::FT = e_kin + e_pot + e_int
+    state.ρe = ρ * e_tot
+
+    return nothing
+end
+
+function kinematic_model_nodal_update_aux!(
+    m::KinematicModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
 )
-const statenames = ("ρ", "ρu", "ρw", "ρe_tot", "ρq_tot", "ρq_liq", "ρq_rai")
+    FT = eltype(state)
+    # velocity
+    aux.u = state.ρu[1] / state.ρ
+    aux.w = state.ρu[3] / state.ρ
+    # water
+    aux.q_tot = state.ρq_tot / state.ρ
+    aux.q_liq = state.ρq_liq / state.ρ
+    aux.q_ice = state.ρq_ice / state.ρ
+    aux.q_rai = state.ρq_rai / state.ρ
+    aux.q_vap = aux.q_tot - aux.q_liq - aux.q_ice
+    # energy
+    aux.e_tot = state.ρe / state.ρ
+    aux.e_kin = 1 // 2 * (aux.u^2 + aux.w^2)
+    aux.e_pot = grav * aux.z
+    aux.e_int = aux.e_tot - aux.e_kin - aux.e_pot
+    # supersaturation
+    q = PhasePartition(aux.q_tot, aux.q_liq, aux.q_ice)
+    aux.T = air_temperature(aux.e_int, q)
+    aux.S =
+        max(0, aux.q_vap / q_vap_saturation(aux.T, state.ρ, q) - FT(1)) *
+        FT(100)
+    aux.RH = aux.q_vap / q_vap_saturation(aux.T, state.ρ, q) * FT(100)
 
-const _nauxcstate = 3
-const _c_z, _c_x, _c_p = 1:_nauxcstate
+    aux.rain_w = terminal_velocity(aux.q_rai, state.ρ)
 
-
-# preflux computation
-@inline function preflux(Q)
-    FT = eltype(Q)
-    @inbounds begin
-        # unpack all the state variables
-        ρ, ρu, ρw, ρq_tot, ρq_liq, ρq_rai, ρe_tot = Q[_ρ],
-        Q[_ρu],
-        Q[_ρw],
-        Q[_ρq_tot],
-        Q[_ρq_liq],
-        Q[_ρq_rai],
-        Q[_ρe_tot]
-        u, w, q_tot, q_liq, q_rai, e_tot =
-            ρu / ρ, ρw / ρ, ρq_tot / ρ, ρq_liq / ρ, ρq_rai / ρ, ρe_tot / ρ
-
-        # compute rain fall speed
-        if (q_rai >= FT(0)) #TODO - need a way to prevent negative values
-            rain_w = terminal_velocity(q_rai, ρ)
-        else
-            rain_w = FT(0)
-        end
-
-        return (u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot)
-    end
+    # uncomment below for more diagnostics
+    #q_eq = PhasePartition_equil(aux.T, state.ρ, aux.q_tot)
+    #aux.src_cloud_liq = conv_q_vap_to_q_liq(q_eq, q)
+    #aux.src_cloud_ice = conv_q_vap_to_q_ice(q_eq, q)
+    #aux.src_acnv = conv_q_liq_to_q_rai_acnv(aux.q_liq)
+    #aux.src_accr = conv_q_liq_to_q_rai_accr(aux.q_liq, aux.q_rai, state.ρ)
+    #aux.src_rain_evap = conv_q_rai_to_q_vap(aux.q_rai, q, aux.T, aux.p, state.ρ)
+    #aux.flag_cloud_liq = FT(0)
+    #aux.flag_cloud_ice = FT(0)
+    #aux.flag_rain = FT(0)
+    #if (aux.q_liq >= FT(0))
+    #    aux.flag_cloud_liq = FT(1)
+    #end
+    #if (aux.q_ice >= FT(0))
+    #    aux.flag_cloud_ice = FT(1)
+    #end
+    #if (aux.q_rai >= FT(0))
+    #    aux.flag_rain = FT(1)
+    #end
 end
 
-
-# boundary condition
-@inline function bcstate!(QP, VFP, auxP, nM, QM, VFM, auxM, bctype, t)
-    FT = eltype(QP)
-    @inbounds begin
-
-        ρu_M, ρw_M, ρe_tot_M, ρq_tot_M, ρq_liq_M, ρq_rai_M =
-            QM[_ρu], QM[_ρw], QM[_ρe_tot], QM[_ρq_tot], QM[_ρq_liq], QM[_ρq_rai]
-
-        ρu_nM = nM[1] * ρu_M + nM[2] * ρw_M
-
-        QP[_ρu] = ρu_M - 2 * nM[1] * ρu_nM
-        QP[_ρw] = ρw_M - 2 * nM[2] * ρu_nM
-
-        QP[_ρe_tot], QP[_ρq_tot], QP[_ρq_liq] = ρe_tot_M, ρq_tot_M, ρq_liq_M
-
-        QP[_ρq_rai] = FT(0)
-
-        auxM .= auxP
-    end
+function boundary_state!(
+    ::Rusanov,
+    m::KinematicModel,
+    state⁺,
+    aux⁺,
+    n,
+    state⁻,
+    aux⁻,
+    bctype,
+    t,
+    args...,
+)
+    #state⁺.ρu -= 2 * dot(state⁻.ρu, n) .* SVector(n)
+    state⁺.ρq_rai = -state⁻.ρq_rai
 end
 
+@inline function wavespeed(
+    m::KinematicModel,
+    nM,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    FT = eltype(state)
+    u = state.ρu / state.ρ
+    rain_w = terminal_velocity(state.ρq_rai / state.ρ, state.ρ)
+    nu = nM[1] * u[1] + nM[3] * max(u[3], rain_w, u[3] - rain_w)
 
-# max eigenvalue
-@inline function wavespeed(n, Q, aux, t)
-    u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
-    @inbounds begin
-        abs(n[1] * u + n[2] * max(w, rain_w, w - rain_w))
-    end
+    return abs(nu)
 end
 
+@inline function flux_nondiffusive!(
+    m::KinematicModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    FT = eltype(state)
+    rain_w = terminal_velocity(state.ρq_rai / state.ρ, state.ρ)
 
-@inline function constant_auxiliary_init!(aux, x, z, _...)
-    FT = eltype(aux)
-    @inbounds begin
-        aux[_c_z] = z  # for gravity
-        aux[_c_x] = x
-
-
-        # initial condition
-        θ_0::FT = 289         # K
-        p_0::FT = 101500      # Pa
-        p_1000::FT = 100000      # Pa
-        qt_0::FT = 7.5 * 1e-3  # kg/kg
-        z_0::FT = 0           # m
-
-        R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
-
-        # Pressure profile assuming hydrostatic and constant θ and qt profiles.
-        # It is done this way to be consistent with Arabas paper.
-        # It's not neccesarily the best way to initialize with our model variables.
-        p =
-            p_1000 *
-            (
-                (p_0 / p_1000)^(R_d / cp_d) -
-                R_d / cp_d * grav / θ_0 / R_m * (z - z_0)
-            )^(cp_d / R_d)
-
-        aux[_c_p] = p  # for prescribed pressure gradient (kinematic setup)
-    end
-end
-
-
-# time tendencies
-@inline function source!(S, Q, diffusive, aux, t)
-    FT = eltype(Q)
-    u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
-    @inbounds begin
-
-        x = aux[_c_x]
-        z = aux[_c_z]
-        p = aux[_c_p]
-
-        S .= 0
-
-        # current state
-        e_int = e_tot - 1 // 2 * (u^2 + w^2) - grav * z
-        q = PhasePartition(q_tot, q_liq, FT(0))
-        T = air_temperature(e_int, q)
-        # equilibrium state at current T
-        q_eq = PhasePartition_equil(T, ρ, q_tot)
-
-        # cloud water condensation/evaporation
-        src_q_liq = conv_q_vap_to_q_liq(q_eq, q) # TODO - ensure positive definite
-        S[_ρq_liq] = ρ * src_q_liq
-
-        # tendencies from rain
-        # TODO - ensure positive definite
-        if (q_tot >= FT(0) && q_liq >= FT(0) && q_rai >= FT(0))
-
-            src_q_rai_acnv = conv_q_liq_to_q_rai_acnv(q.liq)
-            src_q_rai_accr = conv_q_liq_to_q_rai_accr(q.liq, q_rai, ρ)
-            src_q_rai_evap = conv_q_rai_to_q_vap(q_rai, q, T, p, ρ)
-            src_q_rai_tot = src_q_rai_acnv + src_q_rai_accr + src_q_rai_evap
-
-            S[_ρq_liq] -= ρ * (src_q_rai_acnv + src_q_rai_accr)
-            S[_ρq_rai] = ρ * src_q_rai_tot
-            S[_ρq_tot] -= ρ * src_q_rai_tot
-            S[_ρe_tot] -=
-                ρ *
-                src_q_rai_tot *
-                (FT(e_int_v0) - (FT(cv_v) - FT(cv_d)) * (T - FT(T_0)))
-        end
-    end
-end
-
-# physical flux function
-@inline function eulerflux!(F, Q, QV, aux, t)
-    FT = eltype(Q)
-    u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
-    @inbounds begin
-        p = aux[_c_p]
-
-        F .= FT(0)
-
-        # advect the moisture and energy
-        # don't advect momentum and density (kinematic setup)
-
-        F[1, _ρq_tot] = u * ρ * q_tot
-        F[1, _ρq_liq] = u * ρ * q_liq
-        F[1, _ρq_rai] = u * ρ * q_rai
-        F[1, _ρe_tot] = u * (ρ * e_tot + p)
-
-        F[2, _ρq_tot] = w * ρ * q_tot
-        F[2, _ρq_liq] = w * ρ * q_liq
-        F[2, _ρq_rai] = (w - rain_w) * ρ * q_rai
-        F[2, _ρe_tot] = w * (ρ * e_tot + p)
-
-    end
-end
-
-
-# initial condition
-const w_max = 0.6    # m/s
-const Z_max = 1500.0 # m
-const X_max = 1500.0 # m
-
-function single_eddy!(Q, t, x, z, _...)
-    FT = eltype(Q)
-
-    # initial condition
-    θ_0::FT = 289         # K
-    p_0::FT = 101500      # Pa
-    p_1000::FT = 100000      # Pa
-    qt_0::FT = 7.5 * 1e-3  # kg/kg
-    z_0::FT = 0           # m
-
-    R_m, cp_m, cv_m, γ = gas_constants(PhasePartition(qt_0))
-
-    @inbounds begin
-        # Pressure profile assuming hydrostatic and constant θ and qt profiles.
-        # It is done this way to be consistent with Arabas paper.
-        # It's not neccesarily the best way to initialize with our model variables.
-        p =
-            p_1000 *
-            (
-                (p_0 / p_1000)^(R_d / cp_d) -
-                R_d / cp_d * grav / θ_0 / R_m * (z - z_0)
-            )^(cp_d / R_d)
-        T::FT = θ_0 * exner_given_pressure(p, PhasePartition(qt_0))
-        ρ::FT = p / R_m / T
-
-        # TODO should this be more "grid aware"?
-        # the velocity is calculated as derivative of streamfunction
-        ρu::FT =
-            w_max * X_max / Z_max * cos(π * z / Z_max) * cos(2 * π * x / X_max)
-        ρw::FT = 2 * w_max * sin(π * z / Z_max) * sin(2 * π * x / X_max)
-        u = ρu / ρ
-        w = ρw / ρ
-
-        ρq_tot::FT = ρ * qt_0
-        ρq_liq::FT = 0
-        ρq_rai::FT = 0
-
-        e_int = internal_energy(T, PhasePartition(qt_0))
-        ρe_tot = ρ * (grav * z + (1 // 2) * (u^2 + w^2) + e_int)
-
-        Q[_ρ], Q[_ρu], Q[_ρw], Q[_ρe_tot], Q[_ρq_tot], Q[_ρq_liq], Q[_ρq_rai] =
-            ρ, ρu, ρw, ρe_tot, ρq_tot, ρq_liq, ρq_rai
-    end
-end
-
-function main(
-    mpicomm,
-    FT,
-    topl::AbstractTopology{dim},
-    N,
-    timeend,
-    ArrayType,
-    dt,
-) where {dim}
-
-    grid = DiscontinuousSpectralElementGrid(
-        topl,
-        FloatType = FT,
-        DeviceArray = ArrayType,
-        polynomialorder = N,
+    # advect moisture ...
+    flux.ρq_tot = SVector(
+        state.ρu[1] * state.ρq_tot / state.ρ,
+        FT(0),
+        state.ρu[3] * state.ρq_tot / state.ρ,
     )
-    numflux!(x...) = NumericalFluxes.rusanov!(x..., eulerflux!, wavespeed)
-    numbcflux!(x...) = NumericalFluxes.rusanov_boundary_flux!(
-        x...,
-        eulerflux!,
-        bcstate!,
-        wavespeed,
+    flux.ρq_liq = SVector(
+        state.ρu[1] * state.ρq_liq / state.ρ,
+        FT(0),
+        state.ρu[3] * state.ρq_liq / state.ρ,
     )
-
-    # spacedisc = data needed for evaluating the right-hand side function
-    spacedisc = DGBalanceLaw(
-        grid = grid,
-        length_state_vector = _nstate,
-        flux! = eulerflux!,
-        numerical_flux! = numflux!,
-        numerical_boundary_flux! = numbcflux!,
-        auxiliary_state_length = _nauxcstate,
-        auxiliary_state_initialization! = constant_auxiliary_init!,
-        source! = source!,
+    flux.ρq_ice = SVector(
+        state.ρu[1] * state.ρq_ice / state.ρ,
+        FT(0),
+        state.ρu[3] * state.ρq_ice / state.ρ,
     )
-
-    # This is a actual state/function that lives on the grid
-    initialcondition(Q, x...) = single_eddy!(Q, FT(0), x...)
-    Q = MPIStateArray(spacedisc, initialcondition)
-
-    npoststates = 11
-    v_q_liq,
-    v_q_tot,
-    v_q_vap,
-    v_q_rai,
-    v_term_vel,
-    v_p,
-    v_T,
-    v_e_kin,
-    v_e_pot,
-    v_e_int,
-    v_e_tot = 1:npoststates
-    postnames = (
-        "q_liq",
-        "q_tot",
-        "q_vap",
-        "q_rai",
-        "terminal_vel",
-        "p",
-        "T",
-        "e_kin",
-        "e_pot",
-        "e_int",
-        "e_tot",
+    flux.ρq_rai = SVector(
+        state.ρu[1] * state.ρq_rai / state.ρ,
+        FT(0),
+        (state.ρu[3] / state.ρ - rain_w) * state.ρq_rai,
     )
-
-    postprocessarray = MPIStateArray(spacedisc; nstate = npoststates)
-
-    writevtk("initial_condition", Q, spacedisc, statenames)
-
-    lsrk = LSRK54CarpenterKennedy(spacedisc, Q; dt = dt, t0 = 0)
-    #@show(minimum(diff(collect(lsrk.RKC))) * dt )
-    #@show(maximum(diff(collect(lsrk.RKC))) * dt )
-
-    io = MPI.Comm_rank(mpicomm) == 0 ? stdout : devnull
-    eng0 = norm(Q)
-    @printf(io, "----\n")
-    @printf(io, "||Q||₂ (initial) =  %.16e\n", eng0)
-
-    # Set up the information callback
-    timer = [time_ns()]
-    cbinfo = GenericCallbacks.EveryXWallTimeSeconds(10, mpicomm) do (s = false)
-        if s
-            timer[1] = time_ns()
-        else
-            run_time = (time_ns() - timer[1]) * 1e-9
-            (min, sec) = fldmod(run_time, 60)
-            (hrs, min) = fldmod(min, 60)
-            @printf(io, "----\n")
-            @printf(io, "simtime =  %.16e\n", ODESolvers.gettime(lsrk))
-            @printf(
-                io,
-                "runtime =  %03d:%02d:%05.2f (hour:min:sec)\n",
-                hrs,
-                min,
-                sec
-            )
-            @printf(io, "||Q||₂  =  %.16e\n", norm(Q))
-        end
-        nothing
-    end
-
-    step = [0]
-    mkpath("vtk")
-
-    # set output frequency
-    cbvtk = GenericCallbacks.EveryXSimulationSteps(120) do (init = false)
-
-        DGBalanceLawDiscretizations.dof_iteration!(
-            postprocessarray,
-            spacedisc,
-            Q,
-        ) do R, Q, QV, aux
-            local FT = eltype(Q)
-            @inbounds begin
-
-                u, w, rain_w, ρ, q_tot, q_liq, q_rai, e_tot = preflux(Q)
-                z = aux[_c_z]
-                p = aux[_c_p]
-
-                e_int = e_tot - 1 // 2 * (u^2 + w^2) - grav * z
-                q = PhasePartition(q_tot, q_liq, FT(0))
-
-                R[v_T] = air_temperature(e_int, q)
-                R[v_p] = p
-
-                R[v_q_liq] = q_liq
-                R[v_q_tot] = q_tot
-                R[v_q_vap] = q_tot - q_liq
-                R[v_q_rai] = q_rai
-
-                R[v_e_tot] = e_tot
-                R[v_e_int] = e_int
-                R[v_e_kin] = 1 // 2 * (u^2 + w^2)
-                R[v_e_pot] = grav * z
-
-                if (q_rai > FT(0)) # TODO - ensure positive definite elswhere
-                    R[v_term_vel] = terminal_velocity(q_rai, ρ)
-                else
-                    R[v_term_vel] = FT(0)
-                end
-
-            end
-        end
-
-        outprefix = @sprintf(
-            "vtk/ex_2_microphysics_Kessler_%dD_mpirank%04d_step%04d",
-            dim,
-            MPI.Comm_rank(mpicomm),
-            step[1]
-        )
-        @printf(io, "----\n")
-        @printf(io, "doing VTK output =  %s\n", outprefix)
-        writevtk(
-            outprefix,
-            Q,
-            spacedisc,
-            statenames,
-            postprocessarray,
-            postnames,
-        )
-        step[1] += 1
-        nothing
-    end
-
-    solve!(Q, lsrk; timeend = timeend, callbacks = (cbinfo, cbvtk))
-
-    Qe = MPIStateArray(
-        spacedisc,
-        (Q, x...) -> single_eddy!(Q, FT(timeend), x...),
+    # ... energy ...
+    flux.ρe = SVector(
+        state.ρu[1] / state.ρ * (state.ρe + aux.p),
+        FT(0),
+        state.ρu[3] / state.ρ * (state.ρe + aux.p),
     )
-
-    # Print some end of the simulation information
-    engf = norm(Q)
-    @printf(io, "----\n")
-    @printf(io, "||Q||₂ ( final ) = %.16e\n", engf)
+    # ... and don't advect momentum (kinematic setup)
 end
 
-function run(dim, Ne, N, timeend, FT)
+function source!(
+    m::KinematicModel,
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+)
+    # TODO - ensure positive definite
+    FT = eltype(state)
 
+    e_tot = state.ρe / state.ρ
+    q_tot = state.ρq_tot / state.ρ
+    q_liq = state.ρq_liq / state.ρ
+    q_ice = state.ρq_ice / state.ρ
+    q_rai = state.ρq_rai / state.ρ
+    u = state.ρu[1] / state.ρ
+    w = state.ρu[3] / state.ρ
+    e_int = e_tot - 1 // 2 * (u^2 + w^2) - grav * aux.z
+
+    q = PhasePartition(q_tot, q_liq, q_ice)
+    T = air_temperature(e_int, q)
+    # equilibrium state at current T
+    q_eq = PhasePartition_equil(T, state.ρ, q_tot)
+
+    # zero out the source terms
+    source.ρq_tot = FT(0)
+    source.ρq_liq = FT(0)
+    source.ρq_ice = FT(0)
+    source.ρq_rai = FT(0)
+    source.ρe = FT(0)
+
+    # cloud water and ice condensation/evaporation
+    source.ρq_liq += state.ρ * conv_q_vap_to_q_liq(q_eq, q)
+    source.ρq_ice += state.ρ * conv_q_vap_to_q_ice(q_eq, q)
+
+    # tendencies from rain
+    src_q_rai_acnv = conv_q_liq_to_q_rai_acnv(q_liq)
+    src_q_rai_accr = conv_q_liq_to_q_rai_accr(q_liq, q_rai, state.ρ)
+    src_q_rai_evap = conv_q_rai_to_q_vap(q_rai, q, T, aux.p, state.ρ)
+
+    src_q_rai_tot = src_q_rai_acnv + src_q_rai_accr + src_q_rai_evap
+
+    source.ρq_liq -= state.ρ * (src_q_rai_acnv + src_q_rai_accr)
+    source.ρq_rai += state.ρ * src_q_rai_tot
+    source.ρq_tot -= state.ρ * src_q_rai_tot
+    source.ρe -=
+        state.ρ *
+        src_q_rai_tot *
+        (FT(e_int_v0) - (FT(cv_v) - FT(cv_d)) * (T - FT(T_0)))
+end
+
+function main()
     CLIMA.init()
-    ArrayType = CLIMA.array_type()
+
+    # Working precision
+    FT = Float64
+    # DG polynomial order
+    N = 4
+    # Domain resolution and size
+    Δx = FT(20)
+    Δy = FT(1)
+    Δz = FT(20)
+    resolution = (Δx, Δy, Δz)
+    # Domain extents
+    xmax = 1500
+    ymax = 10
+    zmax = 1500
+    # initial configuration
+    wmax = FT(0.6)  # max velocity of the eddy  [m/s]
+    θ_0 = FT(289) # init. theta value (const) [K]
+    p_0 = FT(101500) # surface pressure [Pa]
+    p_1000 = FT(100000) # reference pressure in theta definition [Pa]
+    qt_0 = FT(7.5 * 1e-3) # init. total water specific humidity (const) [kg/kg]
+    z_0 = FT(0) # surface height
+
+    # time stepping
+    t_ini = FT(0)
+    t_end = FT(30 * 60)
+    dt = FT(5)
+    #CFL = FT(1.75)
+    filter_freq = 1
+    output_freq = 72
+
+    driver_config = config_kinematic_eddy(
+        FT,
+        N,
+        resolution,
+        xmax,
+        ymax,
+        zmax,
+        wmax,
+        θ_0,
+        p_0,
+        p_1000,
+        qt_0,
+        z_0,
+    )
+    solver_config = CLIMA.SolverConfiguration(
+        t_ini,
+        t_end,
+        driver_config;
+        ode_dt = dt,
+        init_on_cpu = true,
+        #Courant_number = CFL,
+    )
+
+    model = driver_config.bl
 
     mpicomm = MPI.COMM_WORLD
 
-    brickrange = ntuple(j -> range(FT(0); length = Ne[j] + 1, stop = Z_max), 2)
+    # get state variables indices for filtering
+    ρq_liq_ind = varsindex(vars_state(model, FT), :ρq_liq)
+    ρq_ice_ind = varsindex(vars_state(model, FT), :ρq_ice)
+    ρq_rai_ind = varsindex(vars_state(model, FT), :ρq_rai)
+    # get aux variables indices for testing
+    q_tot_ind = varsindex(vars_aux(model, FT), :q_tot)
+    q_vap_ind = varsindex(vars_aux(model, FT), :q_vap)
+    q_liq_ind = varsindex(vars_aux(model, FT), :q_liq)
+    q_ice_ind = varsindex(vars_aux(model, FT), :q_ice)
+    q_rai_ind = varsindex(vars_aux(model, FT), :q_rai)
+    S_ind = varsindex(vars_aux(model, FT), :S)
+    rain_w_ind = varsindex(vars_aux(model, FT), :rain_w)
 
-    topl = BrickTopology(mpicomm, brickrange, periodicity = (true, false))
-    dt = 0.5
+    # filetr out negative values
+    cb_tmar_filter =
+        GenericCallbacks.EveryXSimulationSteps(filter_freq) do (init = false)
+            Filters.apply!(
+                solver_config.Q,
+                (ρq_liq_ind[1], ρq_ice_ind[1], ρq_rai_ind[1]),
+                solver_config.dg.grid,
+                TMARFilter(),
+            )
+            nothing
+        end
 
-    main(mpicomm, FT, topl, N, timeend, ArrayType, dt)
+    # output for paraview
+    step = [0]
+    cb_vtk =
+        GenericCallbacks.EveryXSimulationSteps(output_freq) do (init = false)
+            mkpath("vtk/")
+            outprefix = @sprintf(
+                "vtk/new_ex_2_mpirank%04d_step%04d",
+                MPI.Comm_rank(mpicomm),
+                step[1]
+            )
+            @info "doing VTK output" outprefix
+            writevtk(
+                outprefix,
+                solver_config.Q,
+                solver_config.dg,
+                flattenednames(vars_state(model, FT)),
+                solver_config.dg.auxstate,
+                flattenednames(vars_aux(model, FT)),
+            )
+            step[1] += 1
+            nothing
+        end
 
+    # call solve! function for time-integrator
+    result = CLIMA.invoke!(
+        solver_config;
+        user_callbacks = (cb_tmar_filter, cb_vtk),
+        check_euclidean_distance = true,
+    )
+
+    # supersaturation in the model
+    max_S = maximum(abs.(solver_config.dg.auxstate[:, S_ind, :]))
+    @test max_S < FT(0.25)
+    @test max_S > FT(0)
+
+    # qt < reference number
+    max_q_tot = maximum(abs.(solver_config.dg.auxstate[:, q_tot_ind, :]))
+    @test max_q_tot < FT(0.0077)
+
+    # no ice
+    max_q_ice = maximum(abs.(solver_config.dg.auxstate[:, q_ice_ind, :]))
+    @test isequal(max_q_ice, FT(0))
+
+    # q_liq ∈ reference range
+    max_q_liq = max(solver_config.dg.auxstate[:, q_liq_ind, :]...)
+    min_q_liq = min(solver_config.dg.auxstate[:, q_liq_ind, :]...)
+    @test max_q_liq < FT(1e-3)
+    @test abs(min_q_liq) < FT(1e-5)
+
+    # q_rai ∈ reference range
+    max_q_rai = max(solver_config.dg.auxstate[:, q_rai_ind, :]...)
+    min_q_rai = min(solver_config.dg.auxstate[:, q_rai_ind, :]...)
+    @test max_q_rai < FT(3e-5)
+    @test abs(min_q_rai) < FT(3e-8)
+
+    # terminal velocity ∈ reference range
+    max_rain_w = max(solver_config.dg.auxstate[:, rain_w_ind, :]...)
+    min_rain_w = min(solver_config.dg.auxstate[:, rain_w_ind, :]...)
+    @test max_rain_w < FT(4)
+    @test isequal(min_rain_w, FT(0))
 end
 
-using Test
-let
-    timeend = 4 * 60 #TODO - 30 * 60
-    numelem = (75, 75)
-    lvls = 3
-    dim = 2
-    FT = Float64
-
-    polynomialorder = 4
-
-    run(dim, ntuple(j -> numelem[j], dim), polynomialorder, timeend, FT)
-end
-
-nothing
+main()

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -8,6 +8,7 @@ cpu = [
   { file = "test/DGmethods/advection_diffusion/pseudo1D_heat_eqn.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/DGmethods/advection_diffusion/periodic_3D_hyperdiffusion.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/ODESolvers/ode_tests_convergence.jl", slurmargs = ["--ntasks=1"], args = [] },
+  { file = "examples/Microphysics/ex_1_saturation_adjustment.jl", slurmargs = ["--ntasks=3"], args = [] },
 ]
 
 cpu_gpu = [
@@ -41,7 +42,6 @@ cpu_gpu = [
   { file = "examples/DGmethods_old/ex_002_solid_body_rotation.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "examples/DGmethods_old/ex_003_acoustic_wave.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "examples/DGmethods_old/ex_004_nonnegative.jl", slurmargs = ["--ntasks=3"], args = [] },
-  { file = "examples/Microphysics/ex_1_saturation_adjustment.jl", slurmargs = ["--ntasks=3"], args = [] },
 #  { file = "examples/Microphysics/ex_2_Kessler.jl", slurmargs = ["--ntasks=3"], args = [] },
 ]
 

--- a/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/Microphysics.jl
@@ -21,6 +21,7 @@ export terminal_velocity
 
 # rates of conversion between microphysics categories
 export conv_q_vap_to_q_liq
+export conv_q_vap_to_q_ice
 export conv_q_liq_to_q_rai_acnv
 export conv_q_liq_to_q_rai_accr
 export conv_q_rai_to_q_vap
@@ -52,16 +53,19 @@ Marshall Palmer 1948 distribution of rain drops.
 """
 function terminal_velocity(q_rai::FT, ρ::FT) where {FT <: Real}
 
-    v_c = terminal_velocity_single_drop_coeff(ρ)
+    rain_w = FT(0)
 
-    # gamma(9/2)
-    gamma_9_2 = FT(11.631728396567448)
+    if q_rai > FT(0)
+        v_c = terminal_velocity_single_drop_coeff(ρ)
+        # gamma(9/2)
+        gamma_9_2 = FT(11.631728396567448)
 
-    lambda::FT = (FT(8) * π * ρ_cloud_liq * MP_n_0 / ρ / q_rai)^FT(1 / 4)
+        lambda::FT = (FT(8) * π * ρ_cloud_liq * MP_n_0 / ρ / q_rai)^FT(1 / 4)
+        rain_w = gamma_9_2 * v_c / FT(6) * sqrt(grav / lambda)
+    end
 
-    return gamma_9_2 * v_c / FT(6) * sqrt(grav / lambda)
+    return rain_w
 end
-
 
 """
     conv_q_vap_to_q_liq(q_sat, q)
@@ -79,15 +83,27 @@ function conv_q_vap_to_q_liq(
     q::PhasePartition{FT},
 ) where {FT <: Real}
 
-    if q_sat.ice != FT(0)
-        error("1-moment bulk microphysics is not defined for snow/ice")
-        #This should be the q_ice tendency due to sublimation/resublimation.
-        #src_q_ice = (q_sat.ice - q.ice) / τ_subl_resubl
-    end
-
     return (q_sat.liq - q.liq) / τ_cond_evap
 end
 
+"""
+    conv_q_vap_to_q_ice(q_sat, q)
+
+where:
+- `q_sat` - PhasePartition at equilibrium
+- `q`     - current PhasePartition
+
+Returns the q_ice tendency due to condensation/evaporation.
+The tendency is obtained assuming a relaxation to equilibrium with
+constant timescale.
+"""
+function conv_q_vap_to_q_ice(
+    q_sat::PhasePartition{FT},
+    q::PhasePartition{FT},
+) where {FT <: Real}
+
+    return (q_sat.ice - q.ice) / τ_sub_resub
+end
 
 """
     conv_q_liq_to_q_rai_acnv(q_liq)
@@ -121,25 +137,31 @@ function conv_q_liq_to_q_rai_accr(
     ρ::FT,
 ) where {FT <: Real}
 
-    # terminal_vel_of_individual_drop = v_drop_coeff * drop_radius^(1/2)
-    v_c = terminal_velocity_single_drop_coeff(ρ)
+    accr_rate = FT(0)
 
-    #gamma(7/2)
-    gamma_7_2 = FT(3.3233509704478426)
+    if (q_rai > FT(0) && q_liq > FT(0))
+        # terminal_vel_of_individual_drop = v_drop_coeff * drop_radius^(1/2)
+        v_c = terminal_velocity_single_drop_coeff(ρ)
 
-    accr_coeff::FT =
-        gamma_7_2 *
-        FT(8)^FT(-7 / 8) *
-        π^FT(1 / 8) *
-        v_c *
-        E_col *
-        (ρ / ρ_cloud_liq)^FT(7 / 8)
+        #gamma(7/2)
+        gamma_7_2 = FT(3.3233509704478426)
 
-    return accr_coeff *
-           FT(MP_n_0)^FT(1 / 8) *
-           sqrt(FT(grav)) *
-           q_liq *
-           q_rai^FT(7 / 8)
+        accr_coeff::FT =
+            gamma_7_2 *
+            FT(8)^FT(-7 / 8) *
+            π^FT(1 / 8) *
+            v_c *
+            E_col *
+            (ρ / ρ_cloud_liq)^FT(7 / 8)
+
+        accr_rate =
+            accr_coeff *
+            FT(MP_n_0)^FT(1 / 8) *
+            sqrt(FT(grav)) *
+            q_liq *
+            q_rai^FT(7 / 8)
+    end
+    return accr_rate
 end
 
 """
@@ -163,36 +185,41 @@ function conv_q_rai_to_q_vap(
     ρ::FT,
 ) where {FT <: Real}
 
-    qv_sat = q_vap_saturation(T, ρ, q)
-    q_v = q.tot - q.liq - q.ice
-    S = q_v / qv_sat - 1
+    evap_rate = FT(0)
 
-    L = latent_heat_vapor(T)
-    p_vs = saturation_vapor_pressure(T, Liquid())
-    G::FT =
-        FT(1) /
-        (L / K_therm / T * (L / R_v / T - FT(1)) + R_v * T / D_vapor / p_vs)
+    if qr > FT(0)
+        qv_sat = q_vap_saturation(T, ρ, q)
+        q_v = q.tot - q.liq - q.ice
+        S = q_v / qv_sat - FT(1)
 
-    # gamma(11/4)
-    gamma_11_4 = FT(1.6083594219855457)
-    N_Sc::FT = ν_air / D_vapor
-    v_c = terminal_velocity_single_drop_coeff(ρ)
+        L = latent_heat_vapor(T)
+        p_vs = saturation_vapor_pressure(T, Liquid())
+        G::FT =
+            FT(1) /
+            (L / K_therm / T * (L / R_v / T - FT(1)) + R_v * T / D_vapor / p_vs)
 
-    av::FT = sqrt(2 * π) * a_vent * sqrt(ρ / ρ_cloud_liq)
-    bv::FT =
-        FT(2)^FT(7 / 16) *
-        gamma_11_4 *
-        π^FT(5 / 16) *
-        b_vent *
-        (N_Sc)^FT(1 / 3) *
-        sqrt(v_c) *
-        (ρ / ρ_cloud_liq)^FT(11 / 16)
+        # gamma(11/4)
+        gamma_11_4 = FT(1.6083594219855457)
+        N_Sc::FT = ν_air / D_vapor
+        v_c = terminal_velocity_single_drop_coeff(ρ)
 
-    F::FT =
-        av * sqrt(qr) +
-        bv * grav^FT(1 / 4) / (MP_n_0)^FT(3 / 16) / sqrt(ν_air) * qr^FT(11 / 16)
+        av::FT = sqrt(2 * π) * a_vent * sqrt(ρ / ρ_cloud_liq)
+        bv::FT =
+            FT(2)^FT(7 / 16) *
+            gamma_11_4 *
+            π^FT(5 / 16) *
+            b_vent *
+            (N_Sc)^FT(1 / 3) *
+            sqrt(v_c) *
+            (ρ / ρ_cloud_liq)^FT(11 / 16)
 
-    return S * F * G * sqrt(MP_n_0) / ρ
+        F::FT =
+            av * sqrt(qr) +
+            bv * grav^FT(1 / 4) / (MP_n_0)^FT(3 / 16) / sqrt(ν_air) *
+            qr^FT(11 / 16)
+
+        evap_rate = min(FT(0), S * F * G * sqrt(MP_n_0) / ρ)
+    end
+    return evap_rate
 end
-
 end #module Microphysics.jl

--- a/src/Atmos/Parameterizations/CloudPhysics/MicrophysicsParameters.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/MicrophysicsParameters.jl
@@ -10,6 +10,7 @@ using CLIMA.ParametersType
 @exportparameter C_drag          0.55            "drag coefficient for rain drops [-]"
 
 @exportparameter τ_cond_evap     10              "condensation/evaporation timescale [s]"
+@exportparameter τ_sub_resub     10              "sublimation/resublimation timescale [s]"
 
 @exportparameter q_liq_threshold 5e-4            "autoconversion threshold [-]  ∈(0.5, 1) * 1e-3 "
 @exportparameter τ_acnv          1e3             "autoconversion timescale [s]  ∈(1e3, 1e4) "

--- a/src/Atmos/Parameterizations/CloudPhysics/MicrophysicsParameters.jl
+++ b/src/Atmos/Parameterizations/CloudPhysics/MicrophysicsParameters.jl
@@ -6,21 +6,21 @@ Module containing 1-moment bulk microphysics parameters.
 module MicrophysicsParameters
 using CLIMA.ParametersType
 
-@exportparameter MP_n_0          8e6 * 2         "Marshall-Palmer distribution n_0 coeff [1/m4]"
-@exportparameter C_drag          0.55            "drag coefficient for rain drops [-]"
+@exportparameter MP_n_0 8e6 * 2 "Marshall-Palmer distribution n_0 coeff [1/m4]"
+@exportparameter C_drag 0.55 "drag coefficient for rain drops [-]"
 
-@exportparameter τ_cond_evap     10              "condensation/evaporation timescale [s]"
-@exportparameter τ_sub_resub     10              "sublimation/resublimation timescale [s]"
+@exportparameter τ_cond_evap 10 "condensation/evaporation timescale [s]"
+@exportparameter τ_sub_resub 10 "sublimation/resublimation timescale [s]"
 
-@exportparameter q_liq_threshold 5e-4            "autoconversion threshold [-]  ∈(0.5, 1) * 1e-3 "
-@exportparameter τ_acnv          1e3             "autoconversion timescale [s]  ∈(1e3, 1e4) "
+@exportparameter q_liq_threshold 5e-4 "autoconversion threshold [-]  ∈(0.5, 1) * 1e-3 "
+@exportparameter τ_acnv 1e3 "autoconversion timescale [s]  ∈(1e3, 1e4) "
 
-@exportparameter E_col           0.8             "collision efficiency [-]"
+@exportparameter E_col 0.8 "collision efficiency [-]"
 
-@exportparameter a_vent          1.5             "ventilation factor coefficient [-]"
-@exportparameter b_vent          0.53            "ventilation factor coefficient [-]"
-@exportparameter K_therm         2.4e-2          "thermal conductivity of air [J/m/s/K] "
-@exportparameter D_vapor         2.26e-5         "diffusivity of water vapor [m2/s]"
-@exportparameter ν_air           1.6e-5          "kinematic viscosity of air [m2/s]"
-@exportparameter N_Sc            ν_air/D_vapor   "Schmidt number [-]"
+@exportparameter a_vent 1.5 "ventilation factor coefficient [-]"
+@exportparameter b_vent 0.53 "ventilation factor coefficient [-]"
+@exportparameter K_therm 2.4e-2 "thermal conductivity of air [J/m/s/K] "
+@exportparameter D_vapor 2.26e-5 "diffusivity of water vapor [m2/s]"
+@exportparameter ν_air 1.6e-5 "kinematic viscosity of air [m2/s]"
+@exportparameter N_Sc ν_air / D_vapor "Schmidt number [-]"
 end

--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -1,6 +1,6 @@
 module VariableTemplates
 
-export varsize, Vars, Grad, @vars
+export varsize, Vars, Grad, @vars, varsindex
 
 using StaticArrays
 
@@ -153,7 +153,7 @@ end
             LT = StaticArrays.lowertriangletype(T)
             N = length(LT)
             retexpr = :(
-                array[($(offset + 1)):($(offset + N))] .= $T(val).lowertriangle
+                array[($(offset + 1)):($(offset + N))] .=     $T(val).lowertriangle
             )
             offset += N
         elseif T <: StaticArray

--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -153,7 +153,7 @@ end
             LT = StaticArrays.lowertriangletype(T)
             N = length(LT)
             retexpr = :(
-                array[($(offset + 1)):($(offset + N))] .=     $T(val).lowertriangle
+                array[($(offset + 1)):($(offset + N))] .= $T(val).lowertriangle
             )
             offset += N
         elseif T <: StaticArray

--- a/test/Atmos/Parameterizations/Microphysics/runtests.jl
+++ b/test/Atmos/Parameterizations/Microphysics/runtests.jl
@@ -5,136 +5,146 @@ using CLIMA.MoistThermodynamics
 using CLIMA.PlanetParameters
 
 @testset "RainDropFallSpeed" begin
-  # two typical rain drop sizes
-  r_small = 0.5 * 1e-3
-  r_big   = 3.5 * 1e-3
+    # two typical rain drop sizes
+    r_small = 0.5 * 1e-3
+    r_big = 3.5 * 1e-3
 
-  # example atmospheric conditions
-  p_range = [1013., 900., 800., 700., 600., 500.] .* 100
-  T_range = [  20.,  20.,  15.,  10.,   0., -10.] .+ 273.15
-  ρ_range = p_range ./ R_d ./ T_range
+    # example atmospheric conditions
+    p_range = [1013.0, 900.0, 800.0, 700.0, 600.0, 500.0] .* 100
+    T_range = [20.0, 20.0, 15.0, 10.0, 0.0, -10.0] .+ 273.15
+    ρ_range = p_range ./ R_d ./ T_range
 
-  # previousely calculated terminal velocity values
-  ref_term_vel_small = [4.44,  4.71,  4.96, 5.25, 5.57, 5.99]
-  ref_term_vel_big   = [11.75, 12.47, 13.11, 13.90, 14.74, 15.85]
+    # previousely calculated terminal velocity values
+    ref_term_vel_small = [4.44, 4.71, 4.96, 5.25, 5.57, 5.99]
+    ref_term_vel_big = [11.75, 12.47, 13.11, 13.90, 14.74, 15.85]
 
-  for idx in range(Int(1), stop=Int(6))
-    vc = terminal_velocity_single_drop_coeff(ρ_range[idx])
+    for idx in range(Int(1), stop = Int(6))
+        vc = terminal_velocity_single_drop_coeff(ρ_range[idx])
 
-    term_vel_small = vc .* sqrt(r_small .* grav)
-    term_vel_big   = vc .* sqrt(r_big   .* grav)
+        term_vel_small = vc .* sqrt(r_small .* grav)
+        term_vel_big = vc .* sqrt(r_big .* grav)
 
-    @test term_vel_small ≈ ref_term_vel_small[idx] atol = 0.01
-    @test term_vel_big   ≈ ref_term_vel_big[idx]   atol = 0.01
-  end
+        @test term_vel_small ≈ ref_term_vel_small[idx] atol = 0.01
+        @test term_vel_big ≈ ref_term_vel_big[idx] atol = 0.01
+    end
 end
 
 @testset "RainFallSpeed" begin
 
-  # eq. 5d in Smolarkiewicz and Grabowski 1996
-  # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
-  function terminal_velocity_empir(q_rai::FT, q_tot::FT, ρ::FT,
-                                      ρ_air_ground::FT) where {FT<:Real}
-      rr  = q_rai / (1 - q_tot)
-      vel = FT(14.34) * ρ_air_ground^FT(0.5) * ρ^-FT(0.3654) * rr^FT(0.1346)
-      return vel
-  end
+    # eq. 5d in Smolarkiewicz and Grabowski 1996
+    # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
+    function terminal_velocity_empir(
+        q_rai::FT,
+        q_tot::FT,
+        ρ::FT,
+        ρ_air_ground::FT,
+    ) where {FT <: Real}
+        rr = q_rai / (1 - q_tot)
+        vel = FT(14.34) * ρ_air_ground^FT(0.5) * ρ^-FT(0.3654) * rr^FT(0.1346)
+        return vel
+    end
 
-  # some example values
-  q_rain_range = range(1e-8, stop=5e-3, length=10)
-  ρ_air, q_tot, ρ_air_ground = 1.2, 20 * 1e-3, 1.22
+    # some example values
+    q_rain_range = range(1e-8, stop = 5e-3, length = 10)
+    ρ_air, q_tot, ρ_air_ground = 1.2, 20 * 1e-3, 1.22
 
-  for q_rai in q_rain_range
-    @test terminal_velocity(q_rai, ρ_air) ≈
-          terminal_velocity_empir(q_rai, q_tot, ρ_air, ρ_air_ground) atol =
+    for q_rai in q_rain_range
+        @test terminal_velocity(q_rai, ρ_air) ≈
+              terminal_velocity_empir(q_rai, q_tot, ρ_air, ρ_air_ground) atol =
             0.2 * terminal_velocity_empir(q_rai, q_tot, ρ_air, ρ_air_ground)
-  end
+    end
 end
 
 @testset "CloudCondEvap" begin
 
-  q_liq_sat = 5e-3
-  frac = [0., 0.5, 1., 1.5]
+    q_liq_sat = 5e-3
+    frac = [0.0, 0.5, 1.0, 1.5]
 
-  for fr in frac
-   q_liq = q_liq_sat * fr
-   @test conv_q_vap_to_q_liq(PhasePartition(0., q_liq_sat, 0.),
-                             PhasePartition(0., q_liq, 0.)) ≈
-         (1 - fr) * q_liq_sat / τ_cond_evap
-  end
+    for fr in frac
+        q_liq = q_liq_sat * fr
+        @test conv_q_vap_to_q_liq(
+            PhasePartition(0.0, q_liq_sat, 0.0),
+            PhasePartition(0.0, q_liq, 0.0),
+        ) ≈ (1 - fr) * q_liq_sat / τ_cond_evap
+    end
 end
 
 @testset "RainAutoconversion" begin
 
-  q_liq_small = 0.5 * q_liq_threshold
-  @test conv_q_liq_to_q_rai_acnv(q_liq_small) == 0.
+    q_liq_small = 0.5 * q_liq_threshold
+    @test conv_q_liq_to_q_rai_acnv(q_liq_small) == 0.0
 
-  q_liq_big = 1.5 * q_liq_threshold
-  @test conv_q_liq_to_q_rai_acnv(q_liq_big) ==
-        0.5 * q_liq_threshold / τ_acnv
+    q_liq_big = 1.5 * q_liq_threshold
+    @test conv_q_liq_to_q_rai_acnv(q_liq_big) == 0.5 * q_liq_threshold / τ_acnv
 end
 
 @testset "RainAccretion" begin
 
-  # eq. 5b in Smolarkiewicz and Grabowski 1996
-  # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
-  function accretion_empir(q_rai::FT, q_liq::FT, q_tot::FT) where {FT<:Real}
-      rr  = q_rai / (FT(1) - q_tot)
-      rl  = q_liq / (FT(1) - q_tot)
-      return FT(2.2) * rl * rr^FT(7/8)
-  end
+    # eq. 5b in Smolarkiewicz and Grabowski 1996
+    # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
+    function accretion_empir(q_rai::FT, q_liq::FT, q_tot::FT) where {FT <: Real}
+        rr = q_rai / (FT(1) - q_tot)
+        rl = q_liq / (FT(1) - q_tot)
+        return FT(2.2) * rl * rr^FT(7 / 8)
+    end
 
-  # some example values
-  q_rain_range = range(1e-8, stop=5e-3, length=10)
-  ρ_air, q_liq, q_tot = 1.2, 5e-4, 20e-3
+    # some example values
+    q_rain_range = range(1e-8, stop = 5e-3, length = 10)
+    ρ_air, q_liq, q_tot = 1.2, 5e-4, 20e-3
 
-  for q_rai in q_rain_range
-    @test conv_q_liq_to_q_rai_accr(q_liq, q_rai, ρ_air) ≈
-          accretion_empir(q_rai, q_liq, q_tot) atol =
+    for q_rai in q_rain_range
+        @test conv_q_liq_to_q_rai_accr(q_liq, q_rai, ρ_air) ≈
+              accretion_empir(q_rai, q_liq, q_tot) atol =
             0.1 * accretion_empir(q_rai, q_liq, q_tot)
-  end
+    end
 end
 
 @testset "RainEvaporation" begin
 
-  # eq. 5c in Smolarkiewicz and Grabowski 1996
-  # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
-  function rain_evap_empir(q_rai::FT, q::PhasePartition,
-                           T::FT, p::FT, ρ::FT) where {FT<:Real}
+    # eq. 5c in Smolarkiewicz and Grabowski 1996
+    # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
+    function rain_evap_empir(
+        q_rai::FT,
+        q::PhasePartition,
+        T::FT,
+        p::FT,
+        ρ::FT,
+    ) where {FT <: Real}
 
-      q_sat  = q_vap_saturation(T, ρ, q)
-      q_vap  = q.tot - q.liq
-      rr     = q_rai / (1 - q.tot)
-      rv_sat = q_sat / (1 - q.tot)
-      S      = q_vap/q_sat - 1
+        q_sat = q_vap_saturation(T, ρ, q)
+        q_vap = q.tot - q.liq
+        rr = q_rai / (1 - q.tot)
+        rv_sat = q_sat / (1 - q.tot)
+        S = q_vap / q_sat - 1
 
-      ag, bg = FT(5.4 * 1e2), FT(2.55 * 1e5)
-      G = FT(1) / (ag + bg / p / rv_sat) / ρ
+        ag, bg = FT(5.4 * 1e2), FT(2.55 * 1e5)
+        G = FT(1) / (ag + bg / p / rv_sat) / ρ
 
-      av, bv = FT(1.6), FT(124.9)
-      F = av * (ρ/FT(1e3))^FT(0.525)  * rr^FT(0.525) +
-          bv * (ρ/FT(1e3))^FT(0.7296) * rr^FT(0.7296)
+        av, bv = FT(1.6), FT(124.9)
+        F =
+            av * (ρ / FT(1e3))^FT(0.525) * rr^FT(0.525) +
+            bv * (ρ / FT(1e3))^FT(0.7296) * rr^FT(0.7296)
 
-      return 1 / (1 - q.tot) * S * F * G
-  end
+        return 1 / (1 - q.tot) * S * F * G
+    end
 
-  # example values
-  T, p = 273.15 + 15, 90000.
-  ϵ = 1. / molmass_ratio
-  p_sat = saturation_vapor_pressure(T, Liquid())
-  q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1.))
-  q_rain_range = range(1e-8, stop=5e-3, length=10)
-  q_tot = 15e-3
-  q_vap = 0.15 * q_sat
-  q_ice = 0.
-  q_liq = q_tot - q_vap - q_ice
-  q = PhasePartition(q_tot, q_liq, q_ice)
-  R = gas_constant_air(q)
-  ρ = p / R / T
+    # example values
+    T, p = 273.15 + 15, 90000.0
+    ϵ = 1.0 / molmass_ratio
+    p_sat = saturation_vapor_pressure(T, Liquid())
+    q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1.0))
+    q_rain_range = range(1e-8, stop = 5e-3, length = 10)
+    q_tot = 15e-3
+    q_vap = 0.15 * q_sat
+    q_ice = 0.0
+    q_liq = q_tot - q_vap - q_ice
+    q = PhasePartition(q_tot, q_liq, q_ice)
+    R = gas_constant_air(q)
+    ρ = p / R / T
 
-  for q_rai in q_rain_range
-    @test conv_q_rai_to_q_vap(q_rai, q, T, p, ρ) ≈
-          rain_evap_empir(q_rai, q, T, p, ρ) atol =
+    for q_rai in q_rain_range
+        @test conv_q_rai_to_q_vap(q_rai, q, T, p, ρ) ≈
+              rain_evap_empir(q_rai, q, T, p, ρ) atol =
             -0.5 * rain_evap_empir(q_rai, q, T, p, ρ)
-  end
+    end
 end

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -115,12 +115,12 @@ function main()
     ugeo_abs = FT(7)
     vgeo_abs = FT(5.5)
     Δt = solver_config.dt
-    caₕ = ugeo_abs * (Δt / Δh) + vgeo_abs * (Δt / Δh)
+    ca_h = ugeo_abs * (Δt / Δh) + vgeo_abs * (Δt / Δh)
     # vertical velocity is 0
     caᵥ = FT(0.0)
     @test isapprox(CFL_adv_v, caᵥ)
-    @test isapprox(CFL_adv_h, caₕ, atol = 0.0005)
-    @test isapprox(CFL_adv, caₕ, atol = 0.0005)
+    @test isapprox(CFL_adv_h, ca_h, atol = 0.0005)
+    @test isapprox(CFL_adv, ca_h, atol = 0.0005)
 
     cb_test = 0
     result = CLIMA.invoke!(solver_config)


### PR DESCRIPTION
<!--
Thanks for submitting code to CLIMA, the Climate Machine.

Before continuing, please be sure you have:

1. Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
2. Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html)
3. Identified key contributors to review this submission
-->

# Description

Converts the microphysics example, `examples/Microphysics/ex_1_saturation_adjustment.jl` to the new framework.

It would be nice to reduce the boundary condition boilerplate. cc: @simonbyrne 

Co-authors: @trontrytel 

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
