### PR TITLE
Diagnostics - bugFix for issue #831

### DIFF
--- a/src/Diagnostics/atmos_default.jl
+++ b/src/Diagnostics/atmos_default.jl
@@ -253,7 +253,7 @@ function compute_diagnosticsums!(
     ds.wskew += MH * (w - w̃)^3
 
     # turbulent kinetic energy
-    ds.TKE += MH * 0.5 * (ds.uvariance + ds.vvariance + ds.wvariance)
+    ds.TKE = 0.5 * (ds.uvariance + ds.vvariance + ds.wvariance)
 
     return nothing
 end


### PR DESCRIPTION
	modified:   src/Diagnostics/atmos_default.jl

# Description

Fixes issue #831 : incorrect cumulative summation in diagnostics module. 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
