### PR TITLE
Print AtmosModel composition to the init-info statement 

### DIFF
--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -130,6 +130,19 @@ struct DriverConfiguration{FT}
     end
 end
 
+function print_model_info(model)
+    @printf("---------------------------------------\n")
+    @info @sprintf("""AtmosModel Composition""")
+    for key in fieldnames(typeof(model))
+        @info @sprintf(
+            """%s = %s \n""",
+            string(key),
+            string((getproperty(model, key)))
+        )
+    end
+    @printf("---------------------------------------\n")
+end
+
 function AtmosLESConfiguration(
     name::String,
     N::Int,
@@ -157,24 +170,7 @@ function AtmosLESConfiguration(
     gradnumflux = CentralNumericalFluxGradient(),
 ) where {FT <: AbstractFloat}
 
-    @info @sprintf(
-        """Establishing Atmos LES configuration for %s
-        precision        = %s
-        polynomial order = %d
-        domain           = %.2fx%.2fx%.2f
-        resolution       = %dx%dx%d
-        MPI ranks        = %d""",
-        name,
-        FT,
-        N,
-        xmax,
-        ymax,
-        zmax,
-        Δx,
-        Δy,
-        Δz,
-        MPI.Comm_size(mpicomm)
-    )
+    print_model_info(model)
 
     brickrange = (
         grid1d(xmin, xmax, elemsize = Δx * N),
@@ -194,6 +190,29 @@ function AtmosLESConfiguration(
         DeviceArray = array_type,
         polynomialorder = N,
         meshwarp = meshwarp,
+    )
+
+    @info @sprintf(
+        """Establishing Atmos LES configuration for %s
+        precision        = %s
+        polynomial order = %d
+        domain           = %.2f m x%.2f m x%.2f m  
+        resolution       = %dx%dx%d
+        MPI ranks        = %d
+        min(Δ_horz)      = %.2f m 
+        min(Δ_vert)      = %.2f m \n""",
+        name,
+        FT,
+        N,
+        xmax,
+        ymax,
+        zmax,
+        Δx,
+        Δy,
+        Δz,
+        MPI.Comm_size(mpicomm),
+        min_node_distance(grid, HorizontalDirection()),
+        min_node_distance(grid, VerticalDirection())
     )
 
     return DriverConfiguration(
@@ -232,22 +251,8 @@ function AtmosGCMConfiguration(
     numfluxdiff = CentralNumericalFluxDiffusive(),
     gradnumflux = CentralNumericalFluxGradient(),
 ) where {FT <: AbstractFloat}
-    @info @sprintf(
-        """Establishing Atmos GCM configuration for %s
-        precision        = %s
-        polynomial order = %d
-        #horiz elems     = %d
-        #vert_elems      = %d
-        domain height    = %.2e
-        MPI ranks        = %d""",
-        name,
-        FT,
-        N,
-        nelem_horz,
-        nelem_vert,
-        domain_height,
-        MPI.Comm_size(mpicomm)
-    )
+
+    print_model_info(model)
 
     vert_range = grid1d(
         FT(planet_radius),
@@ -263,6 +268,27 @@ function AtmosGCMConfiguration(
         DeviceArray = array_type,
         polynomialorder = N,
         meshwarp = meshwarp,
+    )
+
+    @info @sprintf(
+        """Establishing Atmos GCM configuration for %s
+        precision        = %s
+        polynomial order = %d
+        #horiz elems     = %d
+        #vert_elems      = %d
+        domain height    = %.2e m
+        MPI ranks        = %d
+        min(Δ_horz)      = %.2f m
+        min(Δ_vert)      = %.2f m\n""",
+        name,
+        FT,
+        N,
+        nelem_horz,
+        nelem_vert,
+        domain_height,
+        MPI.Comm_size(mpicomm),
+        min_node_distance(grid, HorizontalDirection()),
+        min_node_distance(grid, VerticalDirection())
     )
 
     return DriverConfiguration(


### PR DESCRIPTION
	modified:   src/Driver/driver_configs.jl

# Description

To help with logging, this PR provides access to fields of `AtmosModel` and prints it 
with the initial simulation start-up information. 

Boundary conditions are captured, but a bit cumbersome to read through at this logging level since all the terms are lumped; initial conditions are not at all represented in a useful form. I've found this useful in keeping track of simulation parameters as I submit a bunch of stuff to the cluster. Formatting could use a bit of work to make it easier to interpret. Would also be useful to extend this to `solver` properties in a separate PR. 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)