### PR TITLE
Fix git pre-commit hook for file removal

### DIFF
--- a/.dev/hooks/pre-commit
+++ b/.dev/hooks/pre-commit
@@ -18,8 +18,10 @@ include(joinpath(toplevel_directory, ".dev", "clima_formatter_options.jl"))
 
 needs_format = false
 
-for filename in readlines(`git diff --name-only --cached`)
-    endswith(filename, ".jl") || continue
+for diffoutput in split.(readlines(`git diff --name-status --cached`))
+    status = diffoutput[1]
+    filename = diffoutput[end]
+    (!startswith(status, "D") && endswith(filename, ".jl")) || continue
 
     a = read(`git show :$filename`, String)
     b = format_text(a; clima_formatter_options...)


### PR DESCRIPTION
# Description

The git pre-commit hook for the `JuliaFormatter` should ignore files that have been deleted.

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
