### PR TITLE
Changes to ease use of ocean_gyre.jl

### DIFF
--- a/experiments/OceanBoxGCM/ocean_gyre.jl
+++ b/experiments/OceanBoxGCM/ocean_gyre.jl
@@ -9,59 +9,74 @@ using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
 
 function config_simple_box(FT, N, resolution, dimensions)
-  prob = OceanGyre{FT}(dimensions...)
+    prob = OceanGyre{FT}(dimensions...)
 
-  cʰ = sqrt(grav * prob.H) # m/s
-  model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
+    cʰ = sqrt(grav * prob.H) # m/s
+    model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
 
-  config = CLIMA.OceanBoxGCMConfiguration("ocean_gyre",
-                                          N, resolution, model)
+    config = CLIMA.OceanBoxGCMConfiguration("ocean_gyre", N, resolution, model)
 
-  return config
+    return config
 end
 
-function main(;imex::Bool = false)
-  CLIMA.init()
+function run_ocean_gyre(; imex::Bool = false)
+    CLIMA.init()
 
-  FT = Float64
+    FT = Float64
 
-  # DG polynomial order
-  N = Int(4)
+    # DG polynomial order
+    N = Int(4)
 
-  # Domain resolution and size
-  Nˣ = Int(20)
-  Nʸ = Int(20)
-  Nᶻ = Int(20)
-  resolution = (Nˣ, Nʸ, Nᶻ)
+    # Domain resolution and size
+    Nˣ = Int(20)
+    Nʸ = Int(20)
+    Nᶻ = Int(20)
+    resolution = (Nˣ, Nʸ, Nᶻ)
 
-  Lˣ = 4e6    # m
-  Lʸ = 4e6    # m
-  H  = 1000   # m
-  dimensions = (Lˣ, Lʸ, H)
+    Lˣ = 4e6    # m
+    Lʸ = 4e6    # m
+    H = 1000   # m
+    dimensions = (Lˣ, Lʸ, H)
 
-  timestart = FT(0)    # s
-  timeend   = FT(30 * 86400) # s
+    timestart = FT(0)    # s
+    timeout = FT(86400) # s
+    timeend = FT(30 * 86400) # s
+    dt = FT(10)    # s
 
-  if imex
-    solver_type = CLIMA.IMEXSolverType(linear_model=LinearHBModel)
-  else
-    solver_type = CLIMA.ExplicitSolverType(solver_method=LSRK144NiegemannDiehlBusch)
-  end
+    if imex
+        solver_type = CLIMA.IMEXSolverType(linear_model = LinearHBModel)
+    else
+        solver_type =
+            CLIMA.ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
+    end
 
-  driver_config = config_simple_box(FT, N, resolution, dimensions)
+    driver_config = config_simple_box(FT, N, resolution, dimensions)
 
-  grid = driver_config.grid
-  vert_filter = CutoffFilter(grid, polynomialorder(grid)-1)
-  exp_filter  = ExponentialFilter(grid, 1, 8)
-  modeldata = (vert_filter = vert_filter, exp_filter=exp_filter)
+    grid = driver_config.grid
+    vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
+    exp_filter = ExponentialFilter(grid, 1, 8)
+    modeldata = (vert_filter = vert_filter, exp_filter = exp_filter)
 
-  solver_config = CLIMA.setup_solver(timestart, timeend, driver_config,
-                                     init_on_cpu=true,
-                                     ode_solver_type=solver_type,
-                                     modeldata=modeldata)
+    solver_config = CLIMA.setup_solver(
+        timestart,
+        timeend,
+        driver_config,
+        init_on_cpu = true,
+        # ode_dt = dt,
+        Courant_number = 0.25,
+        ode_solver_type = solver_type,
+        modeldata = modeldata,
+    )
 
-  result = CLIMA.invoke!(solver_config)
+    CLIMA.Settings.enable_vtk = true
+    CLIMA.Settings.vtk_interval = ceil(Int64, timeout / solver_config.dt)
+
+    CLIMA.Settings.enable_diagnostics = false
+    CLIMA.Settings.diagnostics_interval =
+        ceil(Int64, timeout / solver_config.dt)
+
+    result = CLIMA.invoke!(solver_config)
 
 end
 
-main(imex=false)
+run_ocean_gyre(imex = false)

--- a/src/Ocean/HydrostaticBoussinesq/Courant.jl
+++ b/src/Ocean/HydrostaticBoussinesq/Courant.jl
@@ -1,21 +1,30 @@
+using Logging, Printf
+
 """
     advective_courant(::HBModel)
 
 calculates the CFL condition due to advection
 
 """
-@inline function advective_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
-                           direction=VerticalDirection())
-  if direction isa VerticalDirection
-    ū = norm(A.w)
-  elseif direction isa HorizontalDirection
-    ū = norm(Q.u)
-  else
-    v = @SVector [Q.u[1], Q.u[2], A.w]
-    ū = norm(v)
-  end
+@inline function advective_courant(
+    m::HBModel,
+    Q::Vars,
+    A::Vars,
+    D::Vars,
+    Δx,
+    Δt,
+    direction = VerticalDirection(),
+)
+    if direction isa VerticalDirection
+        ū = norm(A.w)
+    elseif direction isa HorizontalDirection
+        ū = norm(Q.u)
+    else
+        v = @SVector [Q.u[1], Q.u[2], A.w]
+        ū = norm(v)
+    end
 
-  return Δt * ū / Δx
+    return Δt * ū / Δx
 end
 
 """
@@ -24,9 +33,16 @@ end
 calculates the CFL condition due to gravity waves
 
 """
-@inline function nondiffusive_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
-                              direction=HorizontalDirection())
-  return Δt * m.cʰ / Δx
+@inline function nondiffusive_courant(
+    m::HBModel,
+    Q::Vars,
+    A::Vars,
+    D::Vars,
+    Δx,
+    Δt,
+    direction = HorizontalDirection(),
+)
+    return Δt * m.cʰ / Δx
 end
 """
     viscous_courant(::HBModel)
@@ -34,11 +50,18 @@ end
 calculates the CFL condition due to viscosity
 
 """
-@inline function viscous_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
-                         direction=VerticalDirection())
-  ν̄ = norm_viscosity(m, direction)
+@inline function viscous_courant(
+    m::HBModel,
+    Q::Vars,
+    A::Vars,
+    D::Vars,
+    Δx,
+    Δt,
+    direction = VerticalDirection(),
+)
+    ν̄ = norm_viscosity(m, direction)
 
-  return Δt * ν̄ / Δx^2
+    return Δt * ν̄ / Δx^2
 end
 
 @inline norm_viscosity(m::HBModel, ::VerticalDirection) = m.νᶻ
@@ -53,16 +76,24 @@ calculates the CFL condition due to temperature diffusivity
 factor of 1000 is for convective adjustment
 
 """
-@inline function diffusive_courant(m::HBModel, Q::Vars, A::Vars, D::Vars, Δx, Δt,
-                           direction=VerticalDirection())
-  κ̄ = norm_diffusivity(m, direction)
+@inline function diffusive_courant(
+    m::HBModel,
+    Q::Vars,
+    A::Vars,
+    D::Vars,
+    Δx,
+    Δt,
+    direction = VerticalDirection(),
+)
+    κ̄ = norm_diffusivity(m, direction)
 
-  return Δt * κ̄ / Δx^2
+    return Δt * κ̄ / Δx^2
 end
 
 @inline norm_diffusivity(m::HBModel, ::VerticalDirection) = 1000 * m.κᶻ
 @inline norm_diffusivity(m::HBModel, ::HorizontalDirection) = sqrt(2) * m.κʰ
-@inline norm_diffusivity(m::HBModel, ::EveryDirection) = sqrt(2 * m.κʰ^2 + (1000 * m.κᶻ)^2)
+@inline norm_diffusivity(m::HBModel, ::EveryDirection) =
+    sqrt(2 * m.κʰ^2 + (1000 * m.κᶻ)^2)
 
 """
     calculate_dt(dg, model::HBModel, Q, Courant_number, direction::EveryDirection)
@@ -71,18 +102,40 @@ calculates the time step based on grid spacing and model parameters
 takes minimum of advective, gravity wave, diffusive, and viscous CFL
 
 """
-@inline function calculate_dt(dg, model::HBModel, Q, Courant_number, ::EveryDirection)
-  Δt = one(eltype(Q))
+@inline function calculate_dt(
+    dg,
+    model::HBModel,
+    Q,
+    Courant_number,
+    ::EveryDirection,
+)
+    Δt = one(eltype(Q))
 
-  CFL_advective = courant(advective_courant, dg, model, Q, Δt, VerticalDirection())
-  CFL_gravity = courant(nondiffusive_courant, dg, model, Q, Δt, HorizontalDirection())
-  CFL_viscous = courant(viscous_courant, dg, model, Q, Δt, VerticalDirection())
-  CFL_diffusive = courant(diffusive_courant, dg, model, Q, Δt, VerticalDirection())
+    CFL_advective =
+        courant(advective_courant, dg, model, Q, Δt, VerticalDirection())
+    CFL_gravity =
+        courant(nondiffusive_courant, dg, model, Q, Δt, HorizontalDirection())
+    CFL_viscous =
+        courant(viscous_courant, dg, model, Q, Δt, VerticalDirection())
+    CFL_diffusive =
+        courant(diffusive_courant, dg, model, Q, Δt, VerticalDirection())
 
-  CFL = maximum([CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive])
-  dt = Courant_number / CFL
+    CFLs = [CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive]
+    dts = [Courant_number / CFL for CFL in CFLs]
+    dt = min(dts...)
 
-  return dt
+    @info @sprintf(
+        """Calculating timestep
+         Advective Constraint    = %.1f seconds
+         Nondiffusive Constraint = %.1f seconds
+         Viscous Constraint      = %.1f seconds
+         Diffusive Constrait     = %.1f seconds
+         Timestep                = %.1f seconds""",
+        dts...,
+        dt
+    )
+
+    return dt
 end
 
 
@@ -94,18 +147,40 @@ calculates the time step based on grid spacing and model parameters
 takes minimum of gravity wave, diffusive, and viscous CFL
 
 """
-@inline function calculate_dt(dg, model::LinearHBModel, Q, Courant_number,
-                      ::EveryDirection)
-  Δt = one(eltype(Q))
-  ocean = model.ocean
+@inline function calculate_dt(
+    dg,
+    model::LinearHBModel,
+    Q,
+    Courant_number,
+    ::EveryDirection,
+)
+    Δt = one(eltype(Q))
+    ocean = model.ocean
 
-  CFL_advective = courant(advective_courant, dg, ocean, Q, Δt, VerticalDirection())
-  CFL_gravity = courant(nondiffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
-  CFL_viscous = courant(viscous_courant, dg, ocean, Q, Δt, HorizontalDirection())
-  CFL_diffusive = courant(diffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
+    CFL_advective =
+        courant(advective_courant, dg, ocean, Q, Δt, VerticalDirection())
+    CFL_gravity =
+        courant(nondiffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
+    CFL_viscous =
+        courant(viscous_courant, dg, ocean, Q, Δt, HorizontalDirection())
+    CFL_diffusive =
+        courant(diffusive_courant, dg, ocean, Q, Δt, HorizontalDirection())
 
-  CFL = maximum([CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive])
-  dt = Courant_number / CFL
+    CFLs = [CFL_advective, CFL_gravity, CFL_viscous, CFL_diffusive]
+    dts = [Courant_number / CFL for CFL in CFLs]
+    dt = min(dts...)
 
-  return dt
+    @info @sprintf(
+        """Calculating timestep
+         Advective Constraint    = %.1f seconds
+         Nondiffusive Constraint = %.1f seconds
+         Viscous Constraint      = %.1f seconds
+         Diffusive Constrait     = %.1f seconds
+         Timestep                = %.1f seconds""",
+        dts...,
+        dt
+    )
+
+
+    return dt
 end


### PR DESCRIPTION
# Description

A clear and concise description of the code with usage.

<!--- Please fill out the following section --->

Exposes vtk and diagnostics saving methods. Reduces default courant number to somewhere near stable and shows how to manually set the time step. Better information from the automatic timestep calculation. Also applied the JuliaFormattere to these two files.

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
