### PR TITLE
Add convenience `varsindex` functionality

### DIFF
--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -9,50 +9,50 @@ using StaticArrays
 
 The number of elements specified by the template type `S`.
 """
-varsize(::Type{T}) where {T<:Real} = 1
+varsize(::Type{T}) where {T <: Real} = 1
 varsize(::Type{Tuple{}}) = 0
-varsize(::Type{NamedTuple{(),Tuple{}}}) = 0
-varsize(::Type{SVector{N,T}}) where {N,T<:Real} = N
+varsize(::Type{NamedTuple{(), Tuple{}}}) = 0
+varsize(::Type{SVector{N, T}}) where {N, T <: Real} = N
 
 include("var_names.jl")
 
 # TODO: should be possible to get rid of @generated
 @generated function varsize(::Type{S}) where {S}
-  types = fieldtypes(S)
-  isempty(types) ? 0 : sum(varsize, types)
+    types = fieldtypes(S)
+    isempty(types) ? 0 : sum(varsize, types)
 end
 
 function process_vars!(syms, typs, expr)
-  if expr isa LineNumberNode
-     return
-  elseif expr isa Expr && expr.head == :block
-    for arg in expr.args
-      process_vars!(syms, typs, arg)
+    if expr isa LineNumberNode
+        return
+    elseif expr isa Expr && expr.head == :block
+        for arg in expr.args
+            process_vars!(syms, typs, arg)
+        end
+        return
+    elseif expr.head == :(::)
+        push!(syms, expr.args[1])
+        push!(typs, expr.args[2])
+        return
+    else
+        error("Invalid expression")
     end
-    return
-  elseif expr.head == :(::)
-    push!(syms, expr.args[1])
-    push!(typs, expr.args[2])
-    return
-  else
-    error("Invalid expression")
-  end
 end
 
 macro vars(args...)
-  syms = Any[]
-  typs = Any[]
-  for arg in args
-    process_vars!(syms, typs, arg)
-  end
-  :(NamedTuple{$(tuple(syms...)), Tuple{$(esc.(typs)...)}})
+    syms = Any[]
+    typs = Any[]
+    for arg in args
+        process_vars!(syms, typs, arg)
+    end
+    :(NamedTuple{$(tuple(syms...)), Tuple{$(esc.(typs)...)}})
 end
 
 struct GetVarError <: Exception
-  sym::Symbol
+    sym::Symbol
 end
 struct SetVarError <: Exception
-  sym::Symbol
+    sym::Symbol
 end
 
 
@@ -61,76 +61,90 @@ end
 
 Defines property overloading for `array` using the type `S` as a template. `offset` is used to shift the starting element of the array.
 """
-struct Vars{S,A,offset}
-  array::A
+struct Vars{S, A, offset}
+    array::A
 end
-Vars{S}(array) where {S} = Vars{S,typeof(array),0}(array)
+Vars{S}(array) where {S} = Vars{S, typeof(array), 0}(array)
 
-Base.parent(v::Vars) = getfield(v,:array)
+Base.parent(v::Vars) = getfield(v, :array)
 Base.eltype(v::Vars) = eltype(parent(v))
 Base.propertynames(::Vars{S}) where {S} = fieldnames(S)
-Base.similar(v::Vars{S,A,offset}) where {S,A,offset} = Vars{S,A,offset}(similar(parent(v)))
+Base.similar(v::Vars{S, A, offset}) where {S, A, offset} =
+    Vars{S, A, offset}(similar(parent(v)))
 
-@generated function Base.getproperty(v::Vars{S,A,offset}, sym::Symbol) where {S,A,offset}
-  expr = quote
-    Base.@_inline_meta
-    array = parent(v)
-  end
-  for k in fieldnames(S)
-    T = fieldtype(S,k)
-    if T <: Real
-      retexpr = :($T(array[$(offset+1)]))
-      offset += 1
-    elseif T <: SHermitianCompact
-      LT = StaticArrays.lowertriangletype(T)
-      N = length(LT)
-      retexpr = :($T($LT($([:(array[$(offset + i)]) for i = 1:N]...))))
-      offset += N
-    elseif T <: StaticArray
-      N = length(T)
-      retexpr = :($T($([:(array[$(offset + i)]) for i = 1:N]...)))
-      offset += N
-    else
-      retexpr = :(Vars{$T,A,$offset}(array))
-      offset += varsize(T)
+@generated function Base.getproperty(
+    v::Vars{S, A, offset},
+    sym::Symbol,
+) where {S, A, offset}
+    expr = quote
+        Base.@_inline_meta
+        array = parent(v)
     end
-    push!(expr.args, :(if sym == $(QuoteNode(k))
-      return @inbounds $retexpr
-    end))
-  end
-  push!(expr.args, :(throw(GetVarError(sym))))
-  expr
+    for k in fieldnames(S)
+        T = fieldtype(S, k)
+        if T <: Real
+            retexpr = :($T(array[$(offset + 1)]))
+            offset += 1
+        elseif T <: SHermitianCompact
+            LT = StaticArrays.lowertriangletype(T)
+            N = length(LT)
+            retexpr = :($T($LT($([:(array[$(offset + i)]) for i in 1:N]...))))
+            offset += N
+        elseif T <: StaticArray
+            N = length(T)
+            retexpr = :($T($([:(array[$(offset + i)]) for i in 1:N]...)))
+            offset += N
+        else
+            retexpr = :(Vars{$T, A, $offset}(array))
+            offset += varsize(T)
+        end
+        push!(expr.args, :(
+            if sym == $(QuoteNode(k))
+                return @inbounds $retexpr
+            end
+        ))
+    end
+    push!(expr.args, :(throw(GetVarError(sym))))
+    expr
 end
 
-@generated function Base.setproperty!(v::Vars{S,A,offset}, sym::Symbol, val) where {S,A,offset}
-  expr = quote
-    Base.@_inline_meta
-    array = parent(v)
-  end
-  for k in fieldnames(S)
-    T = fieldtype(S,k)
-    if T <: Real
-      retexpr = :(array[$(offset+1)] = val)
-      offset += 1
-    elseif T <: SHermitianCompact
-      LT = StaticArrays.lowertriangletype(T)
-      N = length(LT)
-      retexpr = :(array[$(offset + 1):$(offset + N)] .= $T(val).lowertriangle)
-      offset += N
-    elseif T <: StaticArray
-      N = length(T)
-      retexpr = :(array[$(offset + 1):$(offset + N)] .= val[:])
-      offset += N
-    else
-      offset += varsize(T)
-      continue
+@generated function Base.setproperty!(
+    v::Vars{S, A, offset},
+    sym::Symbol,
+    val,
+) where {S, A, offset}
+    expr = quote
+        Base.@_inline_meta
+        array = parent(v)
     end
-    push!(expr.args, :(if sym == $(QuoteNode(k))
-      return @inbounds $retexpr
-    end))
-  end
-  push!(expr.args, :(throw(SetVarError(sym))))
-  expr
+    for k in fieldnames(S)
+        T = fieldtype(S, k)
+        if T <: Real
+            retexpr = :(array[$(offset + 1)] = val)
+            offset += 1
+        elseif T <: SHermitianCompact
+            LT = StaticArrays.lowertriangletype(T)
+            N = length(LT)
+            retexpr = :(
+                array[($(offset + 1)):($(offset + N))] .=     $T(val).lowertriangle
+            )
+            offset += N
+        elseif T <: StaticArray
+            N = length(T)
+            retexpr = :(array[($(offset + 1)):($(offset + N))] .= val[:])
+            offset += N
+        else
+            offset += varsize(T)
+            continue
+        end
+        push!(expr.args, :(
+            if sym == $(QuoteNode(k))
+                return @inbounds $retexpr
+            end
+        ))
+    end
+    push!(expr.args, :(throw(SetVarError(sym))))
+    expr
 end
 
 """
@@ -138,68 +152,84 @@ end
 
 Defines property overloading along slices of the second dimension of `array` using the type `S` as a template. `offset` is used to shift the starting element of the array.
 """
-struct Grad{S,A,offset}
-  array::A
+struct Grad{S, A, offset}
+    array::A
 end
-Grad{S}(array) where {S} = Grad{S,typeof(array),0}(array)
+Grad{S}(array) where {S} = Grad{S, typeof(array), 0}(array)
 
-Base.parent(g::Grad) = getfield(g,:array)
+Base.parent(g::Grad) = getfield(g, :array)
 Base.eltype(g::Grad) = eltype(parent(g))
 Base.propertynames(::Grad{S}) where {S} = fieldnames(S)
-Base.similar(g::Grad{S,A,offset}) where {S,A,offset} = Grad{S,A,offset}(similar(parent(g)))
+Base.similar(g::Grad{S, A, offset}) where {S, A, offset} =
+    Grad{S, A, offset}(similar(parent(g)))
 
-@generated function Base.getproperty(v::Grad{S,A,offset}, sym::Symbol) where {S,A,offset}
-  M = size(A,1)
-  expr = quote
-    Base.@_inline_meta
-    array = parent(v)
-  end
-  for k in fieldnames(S)
-    T = fieldtype(S,k)
-    if T <: Real
-      retexpr = :(SVector{$M,$T}($([:(array[$i,$(offset+1)]) for i = 1:M]...)))
-      offset += 1
-    elseif T <: StaticArray
-      N = length(T)
-      retexpr = :(SMatrix{$M,$N,$(eltype(T))}($([:(array[$i,$(offset + j)]) for i = 1:M, j = 1:N]...)))
-      offset += N
-    else
-      retexpr = :(Grad{$T,A,$offset}(array))
-      offset += varsize(T)
+@generated function Base.getproperty(
+    v::Grad{S, A, offset},
+    sym::Symbol,
+) where {S, A, offset}
+    M = size(A, 1)
+    expr = quote
+        Base.@_inline_meta
+        array = parent(v)
     end
-    push!(expr.args, :(if sym == $(QuoteNode(k))
-      return @inbounds $retexpr
-    end))
-  end
-  push!(expr.args, :(throw(GetVarError(sym))))
-  expr
+    for k in fieldnames(S)
+        T = fieldtype(S, k)
+        if T <: Real
+            retexpr = :(SVector{$M, $T}(
+                $([:(array[$i, $(offset + 1)]) for i in 1:M]...),
+            ))
+            offset += 1
+        elseif T <: StaticArray
+            N = length(T)
+            retexpr = :(SMatrix{$M, $N, $(eltype(T))}(
+                $([:(array[$i, $(offset + j)]) for i in 1:M, j in 1:N]...),
+            ))
+            offset += N
+        else
+            retexpr = :(Grad{$T, A, $offset}(array))
+            offset += varsize(T)
+        end
+        push!(expr.args, :(
+            if sym == $(QuoteNode(k))
+                return @inbounds $retexpr
+            end
+        ))
+    end
+    push!(expr.args, :(throw(GetVarError(sym))))
+    expr
 end
 
-@generated function Base.setproperty!(v::Grad{S,A,offset}, sym::Symbol, val) where {S,A,offset}
-  M = size(A,1)
-  expr = quote
-    Base.@_inline_meta
-    array = parent(v)
-  end
-  for k in fieldnames(S)
-    T = fieldtype(S,k)
-    if T <: Real
-      retexpr = :(array[:, $(offset+1)] .= val)
-      offset += 1
-    elseif T <: StaticArray
-      N = length(T)
-      retexpr = :(array[:, $(offset + 1):$(offset + N)] .= val)
-      offset += N
-    else
-      offset += varsize(T)
-      continue
+@generated function Base.setproperty!(
+    v::Grad{S, A, offset},
+    sym::Symbol,
+    val,
+) where {S, A, offset}
+    M = size(A, 1)
+    expr = quote
+        Base.@_inline_meta
+        array = parent(v)
     end
-    push!(expr.args, :(if sym == $(QuoteNode(k))
-      return @inbounds $retexpr
-    end))
-  end
-  push!(expr.args, :(throw(SetVarError(sym))))
-  expr
+    for k in fieldnames(S)
+        T = fieldtype(S, k)
+        if T <: Real
+            retexpr = :(array[:, $(offset + 1)] .= val)
+            offset += 1
+        elseif T <: StaticArray
+            N = length(T)
+            retexpr = :(array[:, ($(offset + 1)):($(offset + N))] .= val)
+            offset += N
+        else
+            offset += varsize(T)
+            continue
+        end
+        push!(expr.args, :(
+            if sym == $(QuoteNode(k))
+                return @inbounds $retexpr
+            end
+        ))
+    end
+    push!(expr.args, :(throw(SetVarError(sym))))
+    expr
 end
 
 end # module

--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -4,6 +4,33 @@ export varsize, Vars, Grad, @vars
 
 using StaticArrays
 
+function varsindex(::Type{S}, insym::Symbol) where {S <: NamedTuple}
+    offset = 0
+    for varsym in fieldnames(S)
+        T = fieldtype(S, varsym)
+        if T <: Real
+            offset += 1
+            varrange = offset:offset
+        elseif T <: SHermitianCompact
+            LT = StaticArrays.lowertriangletype(T)
+            N = length(LT)
+            varrange = offset .+ (1:N)
+            offset += N
+        elseif T <: StaticArray
+            N = length(T)
+            varrange = offset .+ (1:N)
+            offset += N
+        else
+            varrange = offset .+ (1:varsize(T))
+            offset += varsize(T)
+        end
+        if insym == varsym
+            return varrange
+        end
+    end
+    error("symbol '$insym' not found")
+end
+
 """
     varsize(S)
 

--- a/test/Utilities/VariableTemplates/runtests.jl
+++ b/test/Utilities/VariableTemplates/runtests.jl
@@ -1,34 +1,31 @@
 using Test, StaticArrays
 using CLIMA.VariableTemplates
 
-struct TestModel{A,B,C}
-  a::A
-  b::B
-  c::C
+struct TestModel{A, B, C}
+    a::A
+    b::B
+    c::C
 end
 
-struct SubModelA
-end
-struct SubModelB
-end
-struct SubModelC{N}
-end
+struct SubModelA end
+struct SubModelB end
+struct SubModelC{N} end
 
 function state(m::TestModel, T)
-  @vars begin
-    ρ::T
-    ρu::SVector{3,T}
-    ρe::T
-    a::state(m.a,T)
-    b::state(m.b,T)
-    c::state(m.c,T)
-    S::SHermitianCompact{3,T,6}
-  end
+    @vars begin
+        ρ::T
+        ρu::SVector{3, T}
+        ρe::T
+        a::state(m.a, T)
+        b::state(m.b, T)
+        c::state(m.c, T)
+        S::SHermitianCompact{3, T, 6}
+    end
 end
 
 state(m::SubModelA, T) = @vars()
 state(m::SubModelB, T) = @vars(ρqt::T)
-state(m::SubModelC{N}, T) where {N} = @vars(ρk::SVector{N,T})
+state(m::SubModelC{N}, T) where {N} = @vars(ρk::SVector{N, T})
 
 model = TestModel(SubModelA(), SubModelB(), SubModelC{5}())
 
@@ -36,40 +33,40 @@ st = state(model, Float64)
 
 @test varsize(st) == 17
 
-v = Vars{st}(zeros(MVector{varsize(st),Float64}))
-g = Grad{st}(zeros(MMatrix{3,varsize(st),Float64}))
+v = Vars{st}(zeros(MVector{varsize(st), Float64}))
+g = Grad{st}(zeros(MMatrix{3, varsize(st), Float64}))
 
 @test v.ρ === 0.0
 @test v.ρu === SVector(0.0, 0.0, 0.0)
-v.ρu = SVector(1,2,3)
+v.ρu = SVector(1, 2, 3)
 @test v.ρu === SVector(1.0, 2.0, 3.0)
 
 @test v.b.ρqt === 0.0
 v.b.ρqt = 12.0
 @test v.b.ρqt === 12.0
 
-@test v.S === zeros(SHermitianCompact{3,Float64,6})
-v.S = SHermitianCompact{3,Float64,6}(1,2,3,2,3,4,3,4,5)
-@test v.S[1,1] === 1.0
-@test v.S[1,3] === 3.0
-@test v.S[3,1] === 3.0
-@test v.S[3,3] === 5.0
+@test v.S === zeros(SHermitianCompact{3, Float64, 6})
+v.S = SHermitianCompact{3, Float64, 6}(1, 2, 3, 2, 3, 4, 3, 4, 5)
+@test v.S[1, 1] === 1.0
+@test v.S[1, 3] === 3.0
+@test v.S[3, 1] === 3.0
+@test v.S[3, 3] === 5.0
 
-v.S = ones(SMatrix{3,3,Int64})
-@test v.S[1,1] === 1.0
-@test v.S[1,3] === 1.0
-@test v.S[3,1] === 1.0
-@test v.S[3,3] === 1.0
+v.S = ones(SMatrix{3, 3, Int64})
+@test v.S[1, 1] === 1.0
+@test v.S[1, 3] === 1.0
+@test v.S[3, 1] === 1.0
+@test v.S[3, 3] === 1.0
 
 @test propertynames(v.a) == ()
 @test propertynames(g.a) == ()
 
-@test g.ρu == zeros(SMatrix{3,3,Float64})
-g.ρu = SMatrix{3,3}(1:9)
-@test g.ρu == SMatrix{3,3,Float64}(1:9)
+@test g.ρu == zeros(SMatrix{3, 3, Float64})
+g.ρu = SMatrix{3, 3}(1:9)
+@test g.ρu == SMatrix{3, 3, Float64}(1:9)
 
 @test size(v.c.ρk) == (5,)
-@test size(g.c.ρk) == (3,5)
+@test size(g.c.ρk) == (3, 5)
 
 sv = similar(v)
 @test typeof(sv) == typeof(v)
@@ -79,7 +76,22 @@ sg = similar(g)
 @test typeof(sg) == typeof(g)
 @test size(parent(sg)) == size(parent(g))
 
-@test flattenednames(st) == ["ρ","ρu[1]","ρu[2]","ρu[3]","ρe",
-                            "b.ρqt",
-                            "c.ρk[1]","c.ρk[2]","c.ρk[3]","c.ρk[4]","c.ρk[5]",
-                            "S[1,1]", "S[2,1]", "S[3,1]", "S[2,2]", "S[3,2]", "S[3,3]"]
+@test flattenednames(st) == [
+    "ρ",
+    "ρu[1]",
+    "ρu[2]",
+    "ρu[3]",
+    "ρe",
+    "b.ρqt",
+    "c.ρk[1]",
+    "c.ρk[2]",
+    "c.ρk[3]",
+    "c.ρk[4]",
+    "c.ρk[5]",
+    "S[1,1]",
+    "S[2,1]",
+    "S[3,1]",
+    "S[2,2]",
+    "S[3,2]",
+    "S[3,3]",
+]

--- a/test/Utilities/VariableTemplates/runtests.jl
+++ b/test/Utilities/VariableTemplates/runtests.jl
@@ -95,3 +95,5 @@ sg = similar(g)
     "S[3,2]",
     "S[3,3]",
 ]
+
+include("varsindex.jl")

--- a/test/Utilities/VariableTemplates/varsindex.jl
+++ b/test/Utilities/VariableTemplates/varsindex.jl
@@ -1,0 +1,43 @@
+using Test, StaticArrays
+using CLIMA.VariableTemplates: varsindex, @vars
+using StaticArrays
+
+struct MoistureModel{FT} end
+struct AtmosModel{FT}
+    moisture::MoistureModel{FT}
+end
+
+function vars_state(::MoistureModel, FT)
+    @vars begin
+        ρq_tot::FT
+        ρq_x::SVector{5, FT}
+        ρq_liq::FT
+        ρq_vap::FT
+    end
+end
+function vars_state(m::AtmosModel, FT)
+    @vars begin
+        ρ::FT
+        ρu::SVector{3, FT}
+        ρe::FT
+        moisture::vars_state(m.moisture, FT)
+    end
+end
+@testset "Varsindex" begin
+    FT = Float64
+    m = AtmosModel(MoistureModel{FT}())
+
+    @test 1:1 === varsindex(vars_state(m, FT), :ρ)
+    @test 2:4 === varsindex(vars_state(m, FT), :ρu)
+    @test 5:5 === varsindex(vars_state(m, FT), :ρe)
+
+    # Since moisture is defined recusively this will get all the fields
+    moist = varsindex(vars_state(m, FT), :moisture)
+    @test 6:13 === moist
+
+    # To get the specific onnes we need something like
+    @test 6:6 === moist[varsindex(vars_state(m.moisture, FT), :ρq_tot)]
+    @test 7:11 === moist[varsindex(vars_state(m.moisture, FT), :ρq_x)]
+    @test 12:12 === moist[varsindex(vars_state(m.moisture, FT), :ρq_liq)]
+    @test 13:13 === moist[varsindex(vars_state(m.moisture, FT), :ρq_vap)]
+end


### PR DESCRIPTION
Adds a convenience function `varsindex` for determining which array indices a symbol corresponds to in a `VariableTemplate` defined `NamedTuple`

This functionality is already in #731 and this makes that functionality a standalone PR.

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
