### PR TITLE
Fix integration of pkin in ocean model

### DIFF
--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -312,6 +312,7 @@ location to store integrands for bottom up integrals
 function vars_integrals(m::HBModel, T)
     @vars begin
         ∇hu::T
+        αᵀθ::T
     end
 end
 
@@ -329,6 +330,7 @@ A -> array of aux variables
 """
 @inline function integral_load_aux!(m::HBModel, I::Vars, Q::Vars, A::Vars)
     I.∇hu = A.w # borrow the w value from A...
+    I.αᵀθ = -m.αᵀ * Q.θ # integral will be reversed below
 
     return nothing
 end
@@ -346,6 +348,7 @@ I -> array of integrand variables
 """
 @inline function integral_set_aux!(m::HBModel, A::Vars, I::Vars)
     A.w = I.∇hu
+    A.pkin = I.αᵀθ
 
     return nothing
 end
@@ -613,7 +616,6 @@ function update_aux_diffusive!(
             ν = viscosity_tensor(m)
             ∇u = ν \ D.ν∇u
             A.w = -(∇u[1, 1] + ∇u[2, 2])
-            A.pkin = -m.αᵀ * Q.θ
         end
 
         return nothing

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -1,8 +1,12 @@
 module HydrostaticBoussinesq
 
-export HydrostaticBoussinesqModel, AbstractHydrostaticBoussinesqProblem,
-       LinearHBModel, calculate_dt,
-       SimpleBoxProblem, HomogeneousBox, OceanGyre
+export HydrostaticBoussinesqModel,
+    AbstractHydrostaticBoussinesqProblem,
+    LinearHBModel,
+    calculate_dt,
+    SimpleBoxProblem,
+    HomogeneousBox,
+    OceanGyre
 
 using StaticArrays
 using LinearAlgebra: I, dot, Diagonal, norm
@@ -11,31 +15,57 @@ using ..MPIStateArrays
 using ..DGmethods: init_ode_state
 using ..PlanetParameters: grav
 using ..Mesh.Filters: CutoffFilter, apply!, ExponentialFilter
-using ..Mesh.Grids: polynomialorder, VerticalDirection, HorizontalDirection, EveryDirection, min_node_distance
+using ..Mesh.Grids:
+    polynomialorder,
+    VerticalDirection,
+    HorizontalDirection,
+    EveryDirection,
+    min_node_distance
 using ..DGmethods: courant
 
-using ..DGmethods.NumericalFluxes: Rusanov, CentralNumericalFluxGradient,
-                                   CentralNumericalFluxDiffusive,
-                                   CentralNumericalFluxNonDiffusive
+using ..DGmethods.NumericalFluxes:
+    Rusanov,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxDiffusive,
+    CentralNumericalFluxNonDiffusive
 
-import ..Courant: advective_courant, nondiffusive_courant, diffusive_courant, viscous_courant
+import ..Courant:
+    advective_courant, nondiffusive_courant, diffusive_courant, viscous_courant
 
-import ..DGmethods.NumericalFluxes: update_penalty!, numerical_flux_diffusive!,
-                                    NumericalFluxNonDiffusive
+import ..DGmethods.NumericalFluxes:
+    update_penalty!, numerical_flux_diffusive!, NumericalFluxNonDiffusive
 
-import ..DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
-                    vars_diffusive, flux_nondiffusive!,
-                    flux_diffusive!, source!, wavespeed,
-                    boundary_state!, update_aux!, update_aux_diffusive!,
-                    gradvariables!, init_aux!, init_state!,
-                    LocalGeometry, DGModel, nodal_update_aux!, diffusive!,
-                    copy_stack_field_down!, create_state, calculate_dt,
-                    vars_integrals, vars_reverse_integrals,
-                    indefinite_stack_integral!,
-                    reverse_indefinite_stack_integral!,
-                    integral_load_aux!, integral_set_aux!,
-                    reverse_integral_load_aux!,
-                    reverse_integral_set_aux!
+import ..DGmethods:
+    BalanceLaw,
+    vars_aux,
+    vars_state,
+    vars_gradient,
+    vars_diffusive,
+    flux_nondiffusive!,
+    flux_diffusive!,
+    source!,
+    wavespeed,
+    boundary_state!,
+    update_aux!,
+    update_aux_diffusive!,
+    gradvariables!,
+    init_aux!,
+    init_state!,
+    LocalGeometry,
+    DGModel,
+    nodal_update_aux!,
+    diffusive!,
+    copy_stack_field_down!,
+    create_state,
+    calculate_dt,
+    vars_integrals,
+    vars_reverse_integrals,
+    indefinite_stack_integral!,
+    reverse_indefinite_stack_integral!,
+    integral_load_aux!,
+    integral_set_aux!,
+    reverse_integral_load_aux!,
+    reverse_integral_set_aux!
 
 ×(a::SVector, b::SVector) = StaticArrays.cross(a, b)
 ∘(a::SVector, b::SVector) = StaticArrays.dot(a, b)
@@ -65,32 +95,45 @@ fₒ = first coriolis parameter (constant term)
     HydrostaticBoussinesqModel(problem)
 
 """
-struct HydrostaticBoussinesqModel{P,T} <: BalanceLaw
-  problem::P
-  ρₒ::T
-  cʰ::T
-  cᶻ::T
-  αᵀ::T
-  νʰ::T
-  νᶻ::T
-  κʰ::T
-  κᶻ::T
-  fₒ::T
-  β::T
-  function HydrostaticBoussinesqModel{FT}(problem;
-                                      ρₒ = FT(1000),  # kg / m^3
-                                      cʰ = FT(0),     # m/s
-                                      cᶻ = FT(0),     # m/s
-                                      αᵀ = FT(2e-4),  # (m/s)^2 / K
-                                      νʰ = FT(5e3),   # m^2 / s
-                                      νᶻ = FT(5e-3),  # m^2 / s
-                                      κʰ = FT(1e3),   # m^2 / s
-                                      κᶻ = FT(1e-4),  # m^2 / s
-                                      fₒ = FT(1e-4),  # Hz
-                                      β  = FT(1e-11), # Hz / m
-                                      ) where {FT <: AbstractFloat}
-    return new{typeof(problem),FT}(problem, ρₒ, cʰ, cᶻ, αᵀ, νʰ, νᶻ, κʰ, κᶻ, fₒ, β)
-  end
+struct HydrostaticBoussinesqModel{P, T} <: BalanceLaw
+    problem::P
+    ρₒ::T
+    cʰ::T
+    cᶻ::T
+    αᵀ::T
+    νʰ::T
+    νᶻ::T
+    κʰ::T
+    κᶻ::T
+    fₒ::T
+    β::T
+    function HydrostaticBoussinesqModel{FT}(
+        problem;
+        ρₒ = FT(1000),  # kg / m^3
+        cʰ = FT(0),     # m/s
+        cᶻ = FT(0),     # m/s
+        αᵀ = FT(2e-4),  # (m/s)^2 / K
+        νʰ = FT(5e3),   # m^2 / s
+        νᶻ = FT(5e-3),  # m^2 / s
+        κʰ = FT(1e3),   # m^2 / s
+        κᶻ = FT(1e-4),  # m^2 / s
+        fₒ = FT(1e-4),  # Hz
+        β = FT(1e-11), # Hz / m
+    ) where {FT <: AbstractFloat}
+        return new{typeof(problem), FT}(
+            problem,
+            ρₒ,
+            cʰ,
+            cᶻ,
+            αᵀ,
+            νʰ,
+            νᶻ,
+            κʰ,
+            κᶻ,
+            fₒ,
+            β,
+        )
+    end
 end
 HBModel = HydrostaticBoussinesqModel
 
@@ -105,11 +148,11 @@ u = (u,v) = (zonal velocity, meridional velocity)
 """
 # If this order is changed check the filter usage!
 function vars_state(m::HBModel, T)
-  @vars begin
-    u::SVector{2, T}
-    η::T # real a 2-D variable TODO: should be 2D
-    θ::T
-  end
+    @vars begin
+        u::SVector{2, T}
+        η::T # real a 2-D variable TODO: should be 2D
+        θ::T
+    end
 end
 
 """
@@ -120,7 +163,7 @@ dispatches to ocean_init_state! which is defined in a problem file such as Simpl
 """
 function ocean_init_state! end
 function init_state!(m::HBModel, Q::Vars, A::Vars, coords, t)
-  return ocean_init_state!(m.problem, Q, A, coords, t)
+    return ocean_init_state!(m.problem, Q, A, coords, t)
 end
 
 """
@@ -144,12 +187,12 @@ f = coriolis force
 """
 # If this order is changed check update_aux!
 function vars_aux(m::HBModel, T)
-  @vars begin
-    w::T     # ∫(-∇⋅u)
-    pkin::T  # ∫(-αᵀθ)
-    wz0::T   # w at z=0
-    y::T     # y-coordinate of the box
-  end
+    @vars begin
+        w::T     # ∫(-∇⋅u)
+        pkin::T  # ∫(-αᵀθ)
+        wz0::T   # w at z=0
+        y::T     # y-coordinate of the box
+    end
 end
 
 """
@@ -160,7 +203,7 @@ dispatches to ocean_init_aux! which is defined in a problem file such as SimpleB
 """
 function ocean_init_aux! end
 function init_aux!(m::HBModel, A::Vars, geom::LocalGeometry)
-  return ocean_init_aux!(m, m.problem, A, geom)
+    return ocean_init_aux!(m, m.problem, A, geom)
 end
 
 """
@@ -170,10 +213,10 @@ variables that you want to take a gradient of
 these are just copies in our model
 """
 function vars_gradient(m::HBModel, T)
-  @vars begin
-    u::SVector{2, T}
-    θ::T
-  end
+    @vars begin
+        u::SVector{2, T}
+        θ::T
+    end
 end
 
 """
@@ -190,10 +233,10 @@ this computation is done pointwise at each nodal point
 - `t`: time, not used
 """
 @inline function gradvariables!(m::HBModel, G::Vars, Q::Vars, A, t)
-  G.u = Q.u
-  G.θ = Q.θ
+    G.u = Q.u
+    G.θ = Q.θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -203,10 +246,10 @@ the output of the gradient computations
 multiplies ∇u by viscosity tensor and ∇θ by the diffusivity tensor
 """
 function vars_diffusive(m::HBModel, T)
-  @vars begin
-    ν∇u::SMatrix{3, 2, T, 6}
-    κ∇θ::SVector{3, T}
-  end
+    @vars begin
+        ν∇u::SMatrix{3, 2, T, 6}
+        κ∇θ::SVector{3, T}
+    end
 end
 
 """
@@ -223,15 +266,14 @@ this computation is done pointwise at each nodal point
 - `A`: array of aux variables
 - `t`: time, not used
 """
-@inline function diffusive!(m::HBModel, D::Vars, G::Grad, Q::Vars,
-                            A::Vars, t)
-  ν = viscosity_tensor(m)
-  D.ν∇u = ν * G.u
+@inline function diffusive!(m::HBModel, D::Vars, G::Grad, Q::Vars, A::Vars, t)
+    ν = viscosity_tensor(m)
+    D.ν∇u = ν * G.u
 
-  κ = diffusivity_tensor(m, G.θ[3])
-  D.κ∇θ = κ * G.θ
+    κ = diffusivity_tensor(m, G.θ[3])
+    D.κ∇θ = κ * G.θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -255,9 +297,10 @@ applies convective adjustment in the vertical, bump by 1000 if ∂θ∂z < 0
 - `∂θ∂z`: value of the derivative of temperature in the z-direction
 """
 @inline function diffusivity_tensor(m::HBModel, ∂θ∂z)
-  ∂θ∂z < 0 ? κ = (@SVector [m.κʰ, m.κʰ, 1000 * m.κᶻ]) : κ = (@SVector [m.κʰ, m.κʰ, m.κᶻ])
+    ∂θ∂z < 0 ? κ = (@SVector [m.κʰ, m.κʰ, 1000 * m.κᶻ]) : κ =
+        (@SVector [m.κʰ, m.κʰ, m.κᶻ])
 
-  return Diagonal(κ)
+    return Diagonal(κ)
 end
 
 """
@@ -267,9 +310,9 @@ location to store integrands for bottom up integrals
 ∇hu = the horizontal divegence of u, e.g. dw/dz
 """
 function vars_integrals(m::HBModel, T)
-  @vars begin
-    ∇hu::T
-  end
+    @vars begin
+        ∇hu::T
+    end
 end
 
 """
@@ -285,9 +328,9 @@ Q -> array of state variables
 A -> array of aux variables
 """
 @inline function integral_load_aux!(m::HBModel, I::Vars, Q::Vars, A::Vars)
-  I.∇hu = A.w # borrow the w value from A...
+    I.∇hu = A.w # borrow the w value from A...
 
-  return nothing
+    return nothing
 end
 
 """
@@ -302,9 +345,9 @@ A -> array of aux variables
 I -> array of integrand variables
 """
 @inline function integral_set_aux!(m::HBModel, A::Vars, I::Vars)
-  A.w = I.∇hu
+    A.w = I.∇hu
 
-  return nothing
+    return nothing
 end
 
 """
@@ -314,9 +357,9 @@ location to store integrands for top down integrals
 αᵀθ = density perturbation
 """
 function vars_reverse_integrals(m::HBModel, T)
-  @vars begin
-    αᵀθ::T
-  end
+    @vars begin
+        αᵀθ::T
+    end
 end
 
 """
@@ -330,10 +373,15 @@ m -> model in this case HBModel
 I -> array of integrand variables
 A -> array of aux variables
 """
-@inline function reverse_integral_load_aux!(m::HBModel, I::Vars, Q::Vars, A::Vars)
-  I.αᵀθ = A.pkin
+@inline function reverse_integral_load_aux!(
+    m::HBModel,
+    I::Vars,
+    Q::Vars,
+    A::Vars,
+)
+    I.αᵀθ = A.pkin
 
-  return nothing
+    return nothing
 end
 
 """
@@ -348,9 +396,9 @@ A -> array of aux variables
 I -> array of integrand variables
 """
 @inline function reverse_integral_set_aux!(m::HBModel, A::Vars, I::Vars)
-  A.pkin = I.αᵀθ
+    A.pkin = I.αᵀθ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -370,34 +418,41 @@ t -> time, not used
 ∂ᵗu = ∇∘(g*η + g∫αᵀθdz + v∘u)
 ∂ᵗθ = ∇∘(vθ) where v = (u,v,w)
 """
-@inline function flux_nondiffusive!(m::HBModel, F::Grad, Q::Vars,
-                                    A::Vars, t::Real)
-  @inbounds begin
-    u = Q.u # Horizontal components of velocity
-    η = Q.η
-    θ = Q.θ
-    w = A.w   # vertical velocity
-    pkin = A.pkin
+@inline function flux_nondiffusive!(
+    m::HBModel,
+    F::Grad,
+    Q::Vars,
+    A::Vars,
+    t::Real,
+)
+    @inbounds begin
+        u = Q.u # Horizontal components of velocity
+        η = Q.η
+        θ = Q.θ
+        w = A.w   # vertical velocity
+        pkin = A.pkin
 
-    v = @SVector [u[1], u[2], w]
-    Iʰ = @SMatrix [ 1 -0;
-                   -0  1;
-                   -0 -0]
+        v = @SVector [u[1], u[2], w]
+        Iʰ = @SMatrix [
+            1 -0
+            -0 1
+            -0 -0
+        ]
 
-    # ∇h • (g η)
-    F.u += grav * η * Iʰ
+        # ∇h • (g η)
+        F.u += grav * η * Iʰ
 
-    # ∇h • (- ∫(αᵀ θ))
-    F.u += grav * pkin * Iʰ
+        # ∇h • (- ∫(αᵀ θ))
+        F.u += grav * pkin * Iʰ
 
-    # ∇h • (v ⊗ u)
-    # F.u += v * u'
+        # ∇h • (v ⊗ u)
+        # F.u += v * u'
 
-    # ∇ • (u θ)
-    F.θ += v * θ
-  end
+        # ∇ • (u θ)
+        F.θ += v * θ
+    end
 
-  return nothing
+    return nothing
 end
 
 """
@@ -418,12 +473,19 @@ this computation is done pointwise at each nodal point
 ∂ᵗu = -∇∘(ν∇u)
 ∂ᵗθ = -∇∘(κ∇θ)
 """
-@inline function flux_diffusive!(m::HBModel, F::Grad, Q::Vars, D::Vars,
-                                 HD::Vars, A::Vars, t::Real)
-  F.u -= D.ν∇u
-  F.θ -= D.κ∇θ
+@inline function flux_diffusive!(
+    m::HBModel,
+    F::Grad,
+    Q::Vars,
+    D::Vars,
+    HD::Vars,
+    A::Vars,
+    t::Real,
+)
+    F.u -= D.ν∇u
+    F.θ -= D.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -442,20 +504,26 @@ end
     ∂ᵗu = -f×u
     ∂ᵗη = w|(z=0)
 """
-@inline function source!(m::HBModel{P}, S::Vars, Q::Vars,
-                         D::Vars, A::Vars, t::Real) where P
-  @inbounds begin
-    u,v = Q.u # Horizontal components of velocity
-    wz0 = A.wz0
+@inline function source!(
+    m::HBModel{P},
+    S::Vars,
+    Q::Vars,
+    D::Vars,
+    A::Vars,
+    t::Real,
+) where {P}
+    @inbounds begin
+        u, v = Q.u # Horizontal components of velocity
+        wz0 = A.wz0
 
-    # f × u
-    f = coriolis_force(m, A.y)
-    S.u -= @SVector [-f * v, f * u]
+        # f × u
+        f = coriolis_force(m, A.y)
+        S.u -= @SVector [-f * v, f * u]
 
-    S.η += wz0
-  end
+        S.η += wz0
+    end
 
-  return nothing
+    return nothing
 end
 
 """
@@ -481,11 +549,21 @@ calculates the wavespeed for rusanov flux
     set Δη = 0 when computing numerical fluxes
 """
 # We want not have jump penalties on η (since not a flux variable)
-function update_penalty!(::Rusanov, ::HBModel, n⁻, λ, ΔQ::Vars,
-                         Q⁻, A⁻, Q⁺, A⁺, t)
-  ΔQ.η = -0
+function update_penalty!(
+    ::Rusanov,
+    ::HBModel,
+    n⁻,
+    λ,
+    ΔQ::Vars,
+    Q⁻,
+    A⁻,
+    Q⁺,
+    A⁺,
+    t,
+)
+    ΔQ.η = -0
 
-  return nothing
+    return nothing
 end
 
 """
@@ -497,18 +575,18 @@ end
     doesn't actually touch the aux variables any more, but we need a better filter interface than this anyways
 """
 function update_aux!(dg::DGModel, m::HBModel, Q::MPIStateArray, t::Real)
-  MD = dg.modeldata
+    MD = dg.modeldata
 
-  # required to ensure that after integration velocity field is divergence free
-  vert_filter = MD.vert_filter
-  # Q[1] = u[1] = u, Q[2] = u[2] = v
-  apply!(Q, (1, 2), dg.grid, vert_filter, VerticalDirection())
+    # required to ensure that after integration velocity field is divergence free
+    vert_filter = MD.vert_filter
+    # Q[1] = u[1] = u, Q[2] = u[2] = v
+    apply!(Q, (1, 2), dg.grid, vert_filter, VerticalDirection())
 
-  exp_filter = MD.exp_filter
-  # Q[4] = θ
-  apply!(Q, (4,), dg.grid, exp_filter, VerticalDirection())
+    exp_filter = MD.exp_filter
+    # Q[4] = θ
+    apply!(Q, (4,), dg.grid, exp_filter, VerticalDirection())
 
-  return true
+    return true
 end
 
 """
@@ -521,32 +599,37 @@ end
     now for actual update aux stuff
     implements convective adjustment by bumping the vertical diffusivity up by a factor of 1000 if dθdz < 0
 """
-function update_aux_diffusive!(dg::DGModel, m::HBModel, Q::MPIStateArray, t::Real)
-  A  = dg.auxstate
+function update_aux_diffusive!(
+    dg::DGModel,
+    m::HBModel,
+    Q::MPIStateArray,
+    t::Real,
+)
+    A = dg.auxstate
 
-  # store ∇ʰu as integrand for w
-  function f!(m::HBModel, Q, A, D, t)
-    @inbounds begin
-      ν = viscosity_tensor(m)
-      ∇u = ν \ D.ν∇u
-      A.w = -(∇u[1,1] + ∇u[2,2])
-      A.pkin = -m.αᵀ * Q.θ
+    # store ∇ʰu as integrand for w
+    function f!(m::HBModel, Q, A, D, t)
+        @inbounds begin
+            ν = viscosity_tensor(m)
+            ∇u = ν \ D.ν∇u
+            A.w = -(∇u[1, 1] + ∇u[2, 2])
+            A.pkin = -m.αᵀ * Q.θ
+        end
+
+        return nothing
     end
+    nodal_update_aux!(f!, dg, m, Q, t; diffusive = true)
 
-    return nothing
-  end
-  nodal_update_aux!(f!, dg, m, Q, t; diffusive=true)
+    # compute integrals for w and pkin
+    indefinite_stack_integral!(dg, m, Q, A, t) # bottom -> top
+    reverse_indefinite_stack_integral!(dg, m, Q, A, t) # top -> bottom
 
-  # compute integrals for w and pkin
-  indefinite_stack_integral!(dg, m, Q, A, t) # bottom -> top
-  reverse_indefinite_stack_integral!(dg, m, Q, A, t) # top -> bottom
+    # project w(z=0) down the stack
+    # Need to be consistent with vars_aux
+    # A[1] = w, A[3] = wz0
+    copy_stack_field_down!(dg, m, A, 1, 3)
 
-  # project w(z=0) down the stack
-  # Need to be consistent with vars_aux
-  # A[1] = w, A[3] = wz0
-  copy_stack_field_down!(dg, m, A, 1, 3)
-
-  return true
+    return true
 end
 
 """
@@ -555,9 +638,30 @@ end
 applies boundary conditions for the hyperbolic fluxes
 dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
 """
-@inline function boundary_state!(nf, m::HBModel, Q⁺::Vars, A⁺::Vars, n⁻,
-                                 Q⁻::Vars, A⁻::Vars, bctype, t, _...)
-  return ocean_boundary_state!(m, m.problem, bctype, nf, Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
+@inline function boundary_state!(
+    nf,
+    m::HBModel,
+    Q⁺::Vars,
+    A⁺::Vars,
+    n⁻,
+    Q⁻::Vars,
+    A⁻::Vars,
+    bctype,
+    t,
+    _...,
+)
+    return ocean_boundary_state!(
+        m,
+        m.problem,
+        bctype,
+        nf,
+        Q⁺,
+        A⁺,
+        n⁻,
+        Q⁻,
+        A⁻,
+        t,
+    )
 end
 
 """
@@ -566,12 +670,34 @@ end
 applies boundary conditions for the parabolic fluxes
 dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
 """
-@inline function boundary_state!(nf, m::HBModel,
-                                 Q⁺::Vars, D⁺::Vars, A⁺::Vars,
-                                 n⁻,
-                                 Q⁻::Vars, D⁻::Vars, A⁻::Vars,
-                                 bctype, t, _...)
-  return ocean_boundary_state!(m, m.problem, bctype, nf, Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
+@inline function boundary_state!(
+    nf,
+    m::HBModel,
+    Q⁺::Vars,
+    D⁺::Vars,
+    A⁺::Vars,
+    n⁻,
+    Q⁻::Vars,
+    D⁻::Vars,
+    A⁻::Vars,
+    bctype,
+    t,
+    _...,
+)
+    return ocean_boundary_state!(
+        m,
+        m.problem,
+        bctype,
+        nf,
+        Q⁺,
+        D⁺,
+        A⁺,
+        n⁻,
+        Q⁻,
+        D⁻,
+        A⁻,
+        t,
+    )
 end
 
 include("SimpleBoxProblem.jl")


### PR DESCRIPTION
#727 lacked the integration of pkin in the ocean model. This fixes that.

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)