### PR TITLE
New settings to make Held-Suarez 3x faster than before

### DIFF
--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -25,32 +25,28 @@ using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 struct HeldSuarezDataConfig{FT}
-    p_sfc::FT
-    T_init::FT
-    domain_height::FT
+    T_ref::FT
 end
 
 function init_heldsuarez!(bl, state, aux, coords, t)
     FT = eltype(state)
 
     # Parameters need to set initial state
-    T_init = bl.data_config.T_init
-    p_sfc = bl.data_config.p_sfc
-    scale_height = FT(R_d(bl.param_set)) * T_init / FT(grav(bl.param_set))
+    T_ref = bl.data_config.T_ref
+    temp_profile = IsothermalProfile(T_ref)
 
     # Calculate the initial state variables
-    z = altitude(bl.orientation, aux)
-    p = p_sfc * exp(-z / scale_height)
-    thermo_state = PhaseDry_given_pT(p, T_init, bl.param_set)
+    T, p = temp_profile(bl.orientation, aux)
+    thermo_state = PhaseDry_given_pT(p, T, bl.param_set)
     ρ = air_density(thermo_state)
     e_int = internal_energy(thermo_state)
     e_pot = gravitational_potential(bl.orientation, aux)
 
     # Set initial state with random perturbation
-    rnd = FT(1.0 + rand(Uniform(-1e-6, 1e-6)))
-    state.ρ = rnd * ρ
+    rnd = FT(1.0 + rand(Uniform(-1e-3, 1e-3)))
+    state.ρ = ρ
     state.ρu = SVector{3, FT}(0, 0, 0)
-    state.ρe = state.ρ * (e_int + e_pot)
+    state.ρe = rnd * state.ρ * (e_int + e_pot)
 
     nothing
 end
@@ -59,23 +55,18 @@ function config_heldsuarez(FT, poly_order, resolution)
     exp_name = "HeldSuarez"
 
     # Parameters
-    p_sfc::FT = MSLP(param_set)
-    T_init::FT = 255
-    T_ref::FT = 300
+    T_ref::FT = 255
     Rh_ref::FT = 0
     domain_height::FT = 30e3
     turb_visc::FT = 0 # no visc. here
 
     # Set up a reference state for linearization
-    Γ = FT(0.7 * FT(grav(param_set)) / FT(cp_d(param_set))) # lapse rate
-    T_sfc = FT(300.0)
-    T_min = FT(200.0)
-    temp_profile_ref = LinearTemperatureProfile(T_min, T_sfc, Γ)
+    temp_profile_ref = IsothermalProfile(T_ref)
     ref_state = HydrostaticState(temp_profile_ref, Rh_ref)
 
     # Rayleigh sponge to dampen flow at the top of the domain
     z_sponge = FT(15e3) # height at which sponge begins
-    α_relax = FT(1 / 60 / 60) # sponge relaxation rate in (1/seconds)
+    α_relax = FT(1 / 60 / 15) # sponge relaxation rate in (1/seconds)
     u_relax = SVector(FT(0), FT(0), FT(0)) # relaxation velocity
     exp_sponge = 2 # sponge exponent for squared-sinusoid profile
     sponge = RayleighSponge{FT}(
@@ -94,7 +85,7 @@ function config_heldsuarez(FT, poly_order, resolution)
         moisture = DryModel(),
         source = (Gravity(), Coriolis(), held_suarez_forcing!, sponge),
         init_state = init_heldsuarez!,
-        data_config = HeldSuarezDataConfig(p_sfc, T_init, domain_height),
+        data_config = HeldSuarezDataConfig(T_ref),
         param_set = param_set,
     )
 
@@ -114,7 +105,7 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
     FT = eltype(state)
 
     # Parameters
-    T_init = bl.data_config.T_init
+    T_ref = bl.data_config.T_ref
 
     # Extract the state
     ρ = state.ρ
@@ -142,7 +133,7 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
     λ = longitude(bl.orientation, aux)
     φ = latitude(bl.orientation, aux)
     z = altitude(bl.orientation, aux)
-    scale_height = _R_d * T_init / _grav
+    scale_height = _R_d * T_ref / _grav
     σ = exp(-z / scale_height)
 
     # TODO: use
@@ -163,7 +154,7 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
 end
 
 function config_diagnostics(FT, driver_config)
-    interval = 100 # in time steps
+    interval = 1000 # in time steps
 
     _planet_radius = FT(planet_radius(param_set))
 
@@ -191,9 +182,9 @@ function main()
     # Driver configuration parameters
     FT = Float32                        # floating type precision
     poly_order = 5                      # discontinuous Galerkin polynomial order
-    n_horz = 15                         # horizontal element number
-    n_vert = 8                          # vertical element number
-    days = 1                            # experiment day number
+    n_horz = 5                          # horizontal element number
+    n_vert = 5                          # vertical element number
+    days = 100                          # experiment day number
     timestart = FT(0)                   # start time (seconds)
     timeend = FT(days * 24 * 60 * 60)   # end time (seconds)
 
@@ -212,7 +203,7 @@ function main()
         timeend,
         driver_config,
         ode_solver_type = ode_solver_type,
-        Courant_number = 0.05,
+        Courant_number = 0.14,
         init_on_cpu = true,
         CFL_direction = HorizontalDirection(),
     )
@@ -222,7 +213,7 @@ function main()
 
     # Set up user-defined callbacks
     # TODO: This callback needs to live somewhere else
-    filterorder = 14
+    filterorder = 10
     filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
     cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do
         Filters.apply!(

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -49,7 +49,7 @@ gpu = [
   { file = "test/DGmethods/advection_diffusion/pseudo1D_heat_eqn.jl", slurmargs = ["--ntasks=3"], args = ["--integration-testing"] },
   { file = "test/DGmethods/advection_diffusion/periodic_3D_hyperdiffusion.jl", slurmargs = ["--ntasks=3"], args = ["--integration-testing"] },
   { file = "examples/Atmos/dry_rayleigh_benard.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = [] },
-  { file = "experiments/AtmosGCM/heldsuarez.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "experiments/AtmosGCM/heldsuarez.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = [] },
   { file = "experiments/AtmosLES/risingbubble.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "experiments/AtmosLES/surfacebubble.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = [] },
   { file = "experiments/AtmosLES/dycoms.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -153,7 +153,7 @@ end
             LT = StaticArrays.lowertriangletype(T)
             N = length(LT)
             retexpr = :(
-                array[($(offset + 1)):($(offset + N))] .=     $T(val).lowertriangle
+                array[($(offset + 1)):($(offset + N))] .= $T(val).lowertriangle
             )
             offset += N
         elseif T <: StaticArray


### PR DESCRIPTION
# Description

This updates the Held-Suarez experiment file with some modified settings that results in a stable simulation (tested to 365 days) with a 3x speedup in terms of WCT compared to the previous settings with the same resolution.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
