### PR TITLE
Remove `FT` from ParameterSet

### DIFF
--- a/Parameters/EarthParameters.jl
+++ b/Parameters/EarthParameters.jl
@@ -1,74 +1,47 @@
 import CLIMA
 
 # Properties of dry air
-CLIMA.Parameters.Planet.molmass_dryair(ps::EarthParameterSet{FT}) where {FT} =
-    FT(28.97e-3)
-CLIMA.Parameters.Planet.R_d(ps::EarthParameterSet{FT}) where {FT} =
-    gas_constant(FT) / molmass_dryair(ps)
-CLIMA.Parameters.Planet.kappa_d(ps::EarthParameterSet{FT}) where {FT} =
-    FT(2 / 7)
-CLIMA.Parameters.Planet.cp_d(ps::EarthParameterSet{FT}) where {FT} =
-    R_d(ps) / kappa_d(ps)
-CLIMA.Parameters.Planet.cv_d(ps::EarthParameterSet{FT}) where {FT} =
-    cp_d(ps) - R_d(ps)
+CLIMA.Parameters.Planet.molmass_dryair(ps::EarthParameterSet) = 28.97e-3
+CLIMA.Parameters.Planet.R_d(ps::EarthParameterSet)            = gas_constant() / molmass_dryair(ps)
+CLIMA.Parameters.Planet.kappa_d(ps::EarthParameterSet)        = 2 / 7
+CLIMA.Parameters.Planet.cp_d(ps::EarthParameterSet)           = R_d(ps) / kappa_d(ps)
+CLIMA.Parameters.Planet.cv_d(ps::EarthParameterSet)           = cp_d(ps) - R_d(ps)
 
 # Properties of water
-CLIMA.Parameters.Planet.ρ_cloud_liq(ps::EarthParameterSet{FT}) where {FT} =
-    FT(1e3)
-CLIMA.Parameters.Planet.ρ_cloud_ice(ps::EarthParameterSet{FT}) where {FT} =
-    FT(916.7)
-CLIMA.Parameters.Planet.molmass_water(ps::EarthParameterSet{FT}) where {FT} =
-    FT(18.01528e-3)
-CLIMA.Parameters.Planet.molmass_ratio(ps::EarthParameterSet{FT}) where {FT} =
-    molmass_dryair(ps) / molmass_water(ps)
-CLIMA.Parameters.Planet.R_v(ps::EarthParameterSet{FT}) where {FT} =
-    gas_constant(FT) / molmass_water(ps)
-CLIMA.Parameters.Planet.cp_v(ps::EarthParameterSet{FT}) where {FT} = FT(1859)
-CLIMA.Parameters.Planet.cp_l(ps::EarthParameterSet{FT}) where {FT} = FT(4181)
-CLIMA.Parameters.Planet.cp_i(ps::EarthParameterSet{FT}) where {FT} = FT(2100)
-CLIMA.Parameters.Planet.cv_v(ps::EarthParameterSet{FT}) where {FT} =
-    cp_v(ps) - R_v(ps)
-CLIMA.Parameters.Planet.cv_l(ps::EarthParameterSet{FT}) where {FT} = cp_l(ps)
-CLIMA.Parameters.Planet.cv_i(ps::EarthParameterSet{FT}) where {FT} = cp_i(ps)
-CLIMA.Parameters.Planet.T_freeze(ps::EarthParameterSet{FT}) where {FT} =
-    FT(273.15)
-CLIMA.Parameters.Planet.T_min(ps::EarthParameterSet{FT}) where {FT} = FT(150.0)
-CLIMA.Parameters.Planet.T_max(ps::EarthParameterSet{FT}) where {FT} = FT(1000.0)
-CLIMA.Parameters.Planet.T_icenuc(ps::EarthParameterSet{FT}) where {FT} =
-    FT(233.00)
-CLIMA.Parameters.Planet.T_triple(ps::EarthParameterSet{FT}) where {FT} =
-    FT(273.16)
-CLIMA.Parameters.Planet.T_0(ps::EarthParameterSet{FT}) where {FT} = T_triple(ps)
-CLIMA.Parameters.Planet.LH_v0(ps::EarthParameterSet{FT}) where {FT} =
-    FT(2.5008e6)
-CLIMA.Parameters.Planet.LH_s0(ps::EarthParameterSet{FT}) where {FT} =
-    FT(2.8344e6)
-CLIMA.Parameters.Planet.LH_f0(ps::EarthParameterSet{FT}) where {FT} =
-    LH_s0(ps) - LH_v0(ps)
-CLIMA.Parameters.Planet.e_int_v0(ps::EarthParameterSet{FT}) where {FT} =
-    LH_v0(ps) - R_v(ps) * T_0(ps)
-CLIMA.Parameters.Planet.e_int_i0(ps::EarthParameterSet{FT}) where {FT} =
-    LH_f0(ps)
-CLIMA.Parameters.Planet.press_triple(ps::EarthParameterSet{FT}) where {FT} =
-    FT(611.657)
+CLIMA.Parameters.Planet.ρ_cloud_liq(ps::EarthParameterSet)    = 1e3
+CLIMA.Parameters.Planet.ρ_cloud_ice(ps::EarthParameterSet)    = 916.7
+CLIMA.Parameters.Planet.molmass_water(ps::EarthParameterSet)  = 18.01528e-3
+CLIMA.Parameters.Planet.molmass_ratio(ps::EarthParameterSet)  = molmass_dryair(ps) / molmass_water(ps)
+CLIMA.Parameters.Planet.R_v(ps::EarthParameterSet)            = gas_constant() / molmass_water(ps)
+CLIMA.Parameters.Planet.cp_v(ps::EarthParameterSet)           = 1859
+CLIMA.Parameters.Planet.cp_l(ps::EarthParameterSet)           = 4181
+CLIMA.Parameters.Planet.cp_i(ps::EarthParameterSet)           = 2100
+CLIMA.Parameters.Planet.cv_v(ps::EarthParameterSet)           = cp_v(ps) - R_v(ps)
+CLIMA.Parameters.Planet.cv_l(ps::EarthParameterSet)           = cp_l(ps)
+CLIMA.Parameters.Planet.cv_i(ps::EarthParameterSet)           = cp_i(ps)
+CLIMA.Parameters.Planet.T_freeze(ps::EarthParameterSet)       = 273.15
+CLIMA.Parameters.Planet.T_min(ps::EarthParameterSet)          = 150.0
+CLIMA.Parameters.Planet.T_max(ps::EarthParameterSet)          = 1000.0
+CLIMA.Parameters.Planet.T_icenuc(ps::EarthParameterSet)       = 233.00
+CLIMA.Parameters.Planet.T_triple(ps::EarthParameterSet)       = 273.16
+CLIMA.Parameters.Planet.T_0(ps::EarthParameterSet)            = T_triple(ps)
+CLIMA.Parameters.Planet.LH_v0(ps::EarthParameterSet)          = 2.5008e6
+CLIMA.Parameters.Planet.LH_s0(ps::EarthParameterSet)          = 2.8344e6
+CLIMA.Parameters.Planet.LH_f0(ps::EarthParameterSet)          = LH_s0(ps) - LH_v0(ps)
+CLIMA.Parameters.Planet.e_int_v0(ps::EarthParameterSet)       = LH_v0(ps) - R_v(ps) * T_0(ps)
+CLIMA.Parameters.Planet.e_int_i0(ps::EarthParameterSet)       = LH_f0(ps)
+CLIMA.Parameters.Planet.press_triple(ps::EarthParameterSet)   = 611.657
 
 # Properties of sea water
-CLIMA.Parameters.Planet.ρ_ocean(ps::EarthParameterSet{FT}) where {FT} =
-    FT(1.035e3)
-CLIMA.Parameters.Planet.cp_ocean(ps::EarthParameterSet{FT}) where {FT} =
-    FT(3989.25)
+CLIMA.Parameters.Planet.ρ_ocean(ps::EarthParameterSet)        = 1.035e3
+CLIMA.Parameters.Planet.cp_ocean(ps::EarthParameterSet)       = 3989.25
 
 # Planetary parameters
-CLIMA.Parameters.Planet.planet_radius(ps::EarthParameterSet{FT}) where {FT} =
-    FT(6.371e6)
-CLIMA.Parameters.Planet.day(ps::EarthParameterSet{FT}) where {FT} = FT(86400)
-CLIMA.Parameters.Planet.Omega(ps::EarthParameterSet{FT}) where {FT} =
-    FT(7.2921159e-5)
-CLIMA.Parameters.Planet.grav(ps::EarthParameterSet{FT}) where {FT} = FT(9.81)
-CLIMA.Parameters.Planet.year_anom(ps::EarthParameterSet{FT}) where {FT} =
-    FT(365.26) * day(ps)
-CLIMA.Parameters.Planet.orbit_semimaj(ps::EarthParameterSet{FT}) where {FT} =
-    FT(1 * astro_unit(FT))
-CLIMA.Parameters.Planet.TSI(ps::EarthParameterSet{FT}) where {FT} = FT(1362)
-CLIMA.Parameters.Planet.MSLP(ps::EarthParameterSet{FT}) where {FT} =
-    FT(1.01325e5)
+CLIMA.Parameters.Planet.planet_radius(ps::EarthParameterSet)  = 6.371e6
+CLIMA.Parameters.Planet.day(ps::EarthParameterSet)            = 86400
+CLIMA.Parameters.Planet.Omega(ps::EarthParameterSet)          = 7.2921159e-5
+CLIMA.Parameters.Planet.grav(ps::EarthParameterSet)           = 9.81
+CLIMA.Parameters.Planet.year_anom(ps::EarthParameterSet)      = 365.26 * day(ps)
+CLIMA.Parameters.Planet.orbit_semimaj(ps::EarthParameterSet)  = 1 * astro_unit()
+CLIMA.Parameters.Planet.TSI(ps::EarthParameterSet)            = 1362
+CLIMA.Parameters.Planet.MSLP(ps::EarthParameterSet)           = 1.01325e5

--- a/Parameters/EarthParameters.jl
+++ b/Parameters/EarthParameters.jl
@@ -2,46 +2,50 @@ import CLIMA
 
 # Properties of dry air
 CLIMA.Parameters.Planet.molmass_dryair(ps::EarthParameterSet) = 28.97e-3
-CLIMA.Parameters.Planet.R_d(ps::EarthParameterSet)            = gas_constant() / molmass_dryair(ps)
-CLIMA.Parameters.Planet.kappa_d(ps::EarthParameterSet)        = 2 / 7
-CLIMA.Parameters.Planet.cp_d(ps::EarthParameterSet)           = R_d(ps) / kappa_d(ps)
-CLIMA.Parameters.Planet.cv_d(ps::EarthParameterSet)           = cp_d(ps) - R_d(ps)
+CLIMA.Parameters.Planet.R_d(ps::EarthParameterSet) =
+    gas_constant() / molmass_dryair(ps)
+CLIMA.Parameters.Planet.kappa_d(ps::EarthParameterSet) = 2 / 7
+CLIMA.Parameters.Planet.cp_d(ps::EarthParameterSet) = R_d(ps) / kappa_d(ps)
+CLIMA.Parameters.Planet.cv_d(ps::EarthParameterSet) = cp_d(ps) - R_d(ps)
 
 # Properties of water
-CLIMA.Parameters.Planet.ρ_cloud_liq(ps::EarthParameterSet)    = 1e3
-CLIMA.Parameters.Planet.ρ_cloud_ice(ps::EarthParameterSet)    = 916.7
-CLIMA.Parameters.Planet.molmass_water(ps::EarthParameterSet)  = 18.01528e-3
-CLIMA.Parameters.Planet.molmass_ratio(ps::EarthParameterSet)  = molmass_dryair(ps) / molmass_water(ps)
-CLIMA.Parameters.Planet.R_v(ps::EarthParameterSet)            = gas_constant() / molmass_water(ps)
-CLIMA.Parameters.Planet.cp_v(ps::EarthParameterSet)           = 1859
-CLIMA.Parameters.Planet.cp_l(ps::EarthParameterSet)           = 4181
-CLIMA.Parameters.Planet.cp_i(ps::EarthParameterSet)           = 2100
-CLIMA.Parameters.Planet.cv_v(ps::EarthParameterSet)           = cp_v(ps) - R_v(ps)
-CLIMA.Parameters.Planet.cv_l(ps::EarthParameterSet)           = cp_l(ps)
-CLIMA.Parameters.Planet.cv_i(ps::EarthParameterSet)           = cp_i(ps)
-CLIMA.Parameters.Planet.T_freeze(ps::EarthParameterSet)       = 273.15
-CLIMA.Parameters.Planet.T_min(ps::EarthParameterSet)          = 150.0
-CLIMA.Parameters.Planet.T_max(ps::EarthParameterSet)          = 1000.0
-CLIMA.Parameters.Planet.T_icenuc(ps::EarthParameterSet)       = 233.00
-CLIMA.Parameters.Planet.T_triple(ps::EarthParameterSet)       = 273.16
-CLIMA.Parameters.Planet.T_0(ps::EarthParameterSet)            = T_triple(ps)
-CLIMA.Parameters.Planet.LH_v0(ps::EarthParameterSet)          = 2.5008e6
-CLIMA.Parameters.Planet.LH_s0(ps::EarthParameterSet)          = 2.8344e6
-CLIMA.Parameters.Planet.LH_f0(ps::EarthParameterSet)          = LH_s0(ps) - LH_v0(ps)
-CLIMA.Parameters.Planet.e_int_v0(ps::EarthParameterSet)       = LH_v0(ps) - R_v(ps) * T_0(ps)
-CLIMA.Parameters.Planet.e_int_i0(ps::EarthParameterSet)       = LH_f0(ps)
-CLIMA.Parameters.Planet.press_triple(ps::EarthParameterSet)   = 611.657
+CLIMA.Parameters.Planet.ρ_cloud_liq(ps::EarthParameterSet) = 1e3
+CLIMA.Parameters.Planet.ρ_cloud_ice(ps::EarthParameterSet) = 916.7
+CLIMA.Parameters.Planet.molmass_water(ps::EarthParameterSet) = 18.01528e-3
+CLIMA.Parameters.Planet.molmass_ratio(ps::EarthParameterSet) =
+    molmass_dryair(ps) / molmass_water(ps)
+CLIMA.Parameters.Planet.R_v(ps::EarthParameterSet) =
+    gas_constant() / molmass_water(ps)
+CLIMA.Parameters.Planet.cp_v(ps::EarthParameterSet) = 1859
+CLIMA.Parameters.Planet.cp_l(ps::EarthParameterSet) = 4181
+CLIMA.Parameters.Planet.cp_i(ps::EarthParameterSet) = 2100
+CLIMA.Parameters.Planet.cv_v(ps::EarthParameterSet) = cp_v(ps) - R_v(ps)
+CLIMA.Parameters.Planet.cv_l(ps::EarthParameterSet) = cp_l(ps)
+CLIMA.Parameters.Planet.cv_i(ps::EarthParameterSet) = cp_i(ps)
+CLIMA.Parameters.Planet.T_freeze(ps::EarthParameterSet) = 273.15
+CLIMA.Parameters.Planet.T_min(ps::EarthParameterSet) = 150.0
+CLIMA.Parameters.Planet.T_max(ps::EarthParameterSet) = 1000.0
+CLIMA.Parameters.Planet.T_icenuc(ps::EarthParameterSet) = 233.00
+CLIMA.Parameters.Planet.T_triple(ps::EarthParameterSet) = 273.16
+CLIMA.Parameters.Planet.T_0(ps::EarthParameterSet) = T_triple(ps)
+CLIMA.Parameters.Planet.LH_v0(ps::EarthParameterSet) = 2.5008e6
+CLIMA.Parameters.Planet.LH_s0(ps::EarthParameterSet) = 2.8344e6
+CLIMA.Parameters.Planet.LH_f0(ps::EarthParameterSet) = LH_s0(ps) - LH_v0(ps)
+CLIMA.Parameters.Planet.e_int_v0(ps::EarthParameterSet) =
+    LH_v0(ps) - R_v(ps) * T_0(ps)
+CLIMA.Parameters.Planet.e_int_i0(ps::EarthParameterSet) = LH_f0(ps)
+CLIMA.Parameters.Planet.press_triple(ps::EarthParameterSet) = 611.657
 
 # Properties of sea water
-CLIMA.Parameters.Planet.ρ_ocean(ps::EarthParameterSet)        = 1.035e3
-CLIMA.Parameters.Planet.cp_ocean(ps::EarthParameterSet)       = 3989.25
+CLIMA.Parameters.Planet.ρ_ocean(ps::EarthParameterSet) = 1.035e3
+CLIMA.Parameters.Planet.cp_ocean(ps::EarthParameterSet) = 3989.25
 
 # Planetary parameters
-CLIMA.Parameters.Planet.planet_radius(ps::EarthParameterSet)  = 6.371e6
-CLIMA.Parameters.Planet.day(ps::EarthParameterSet)            = 86400
-CLIMA.Parameters.Planet.Omega(ps::EarthParameterSet)          = 7.2921159e-5
-CLIMA.Parameters.Planet.grav(ps::EarthParameterSet)           = 9.81
-CLIMA.Parameters.Planet.year_anom(ps::EarthParameterSet)      = 365.26 * day(ps)
-CLIMA.Parameters.Planet.orbit_semimaj(ps::EarthParameterSet)  = 1 * astro_unit()
-CLIMA.Parameters.Planet.TSI(ps::EarthParameterSet)            = 1362
-CLIMA.Parameters.Planet.MSLP(ps::EarthParameterSet)           = 1.01325e5
+CLIMA.Parameters.Planet.planet_radius(ps::EarthParameterSet) = 6.371e6
+CLIMA.Parameters.Planet.day(ps::EarthParameterSet) = 86400
+CLIMA.Parameters.Planet.Omega(ps::EarthParameterSet) = 7.2921159e-5
+CLIMA.Parameters.Planet.grav(ps::EarthParameterSet) = 9.81
+CLIMA.Parameters.Planet.year_anom(ps::EarthParameterSet) = 365.26 * day(ps)
+CLIMA.Parameters.Planet.orbit_semimaj(ps::EarthParameterSet) = 1 * astro_unit()
+CLIMA.Parameters.Planet.TSI(ps::EarthParameterSet) = 1362
+CLIMA.Parameters.Planet.MSLP(ps::EarthParameterSet) = 1.01325e5

--- a/Parameters/Planet.jl
+++ b/Parameters/Planet.jl
@@ -6,46 +6,50 @@ struct ParameterSet <: CLIMA.Parameters.AbstractParameterSet end
 
 # Properties of dry air
 CLIMA.Parameters.Planet.molmass_dryair(ps::ParameterSet) = 28.97e-3
-CLIMA.Parameters.Planet.R_d(ps::ParameterSet)            = gas_constant() / molmass_dryair(ps)
-CLIMA.Parameters.Planet.kappa_d(ps::ParameterSet)        = 2 / 7
-CLIMA.Parameters.Planet.cp_d(ps::ParameterSet)           = R_d(ps) / kappa_d(ps)
-CLIMA.Parameters.Planet.cv_d(ps::ParameterSet)           = cp_d(ps) - R_d(ps)
+CLIMA.Parameters.Planet.R_d(ps::ParameterSet) =
+    gas_constant() / molmass_dryair(ps)
+CLIMA.Parameters.Planet.kappa_d(ps::ParameterSet) = 2 / 7
+CLIMA.Parameters.Planet.cp_d(ps::ParameterSet) = R_d(ps) / kappa_d(ps)
+CLIMA.Parameters.Planet.cv_d(ps::ParameterSet) = cp_d(ps) - R_d(ps)
 
 # Properties of water
-CLIMA.Parameters.Planet.ρ_cloud_liq(ps::ParameterSet)    = 1e3
-CLIMA.Parameters.Planet.ρ_cloud_ice(ps::ParameterSet)    = 916.7
-CLIMA.Parameters.Planet.molmass_water(ps::ParameterSet)  = 18.01528e-3
-CLIMA.Parameters.Planet.molmass_ratio(ps::ParameterSet)  = molmass_dryair(ps) / molmass_water(ps)
-CLIMA.Parameters.Planet.R_v(ps::ParameterSet)            = gas_constant() / molmass_water(ps)
-CLIMA.Parameters.Planet.cp_v(ps::ParameterSet)           = 1859
-CLIMA.Parameters.Planet.cp_l(ps::ParameterSet)           = 4181
-CLIMA.Parameters.Planet.cp_i(ps::ParameterSet)           = 2100
-CLIMA.Parameters.Planet.cv_v(ps::ParameterSet)           = cp_v(ps) - R_v(ps)
-CLIMA.Parameters.Planet.cv_l(ps::ParameterSet)           = cp_l(ps)
-CLIMA.Parameters.Planet.cv_i(ps::ParameterSet)           = cp_i(ps)
-CLIMA.Parameters.Planet.T_freeze(ps::ParameterSet)       = 273.15
-CLIMA.Parameters.Planet.T_min(ps::ParameterSet)          = 150.0
-CLIMA.Parameters.Planet.T_max(ps::ParameterSet)          = 1000.0
-CLIMA.Parameters.Planet.T_icenuc(ps::ParameterSet)       = 233.00
-CLIMA.Parameters.Planet.T_triple(ps::ParameterSet)       = 273.16
-CLIMA.Parameters.Planet.T_0(ps::ParameterSet)            = T_triple(ps)
-CLIMA.Parameters.Planet.LH_v0(ps::ParameterSet)          = 2.5008e6
-CLIMA.Parameters.Planet.LH_s0(ps::ParameterSet)          = 2.8344e6
-CLIMA.Parameters.Planet.LH_f0(ps::ParameterSet)          = LH_s0(ps) - LH_v0(ps)
-CLIMA.Parameters.Planet.e_int_v0(ps::ParameterSet)       = LH_v0(ps) - R_v(ps) * T_0(ps)
-CLIMA.Parameters.Planet.e_int_i0(ps::ParameterSet)       = LH_f0(ps)
-CLIMA.Parameters.Planet.press_triple(ps::ParameterSet)   = 611.657
+CLIMA.Parameters.Planet.ρ_cloud_liq(ps::ParameterSet) = 1e3
+CLIMA.Parameters.Planet.ρ_cloud_ice(ps::ParameterSet) = 916.7
+CLIMA.Parameters.Planet.molmass_water(ps::ParameterSet) = 18.01528e-3
+CLIMA.Parameters.Planet.molmass_ratio(ps::ParameterSet) =
+    molmass_dryair(ps) / molmass_water(ps)
+CLIMA.Parameters.Planet.R_v(ps::ParameterSet) =
+    gas_constant() / molmass_water(ps)
+CLIMA.Parameters.Planet.cp_v(ps::ParameterSet) = 1859
+CLIMA.Parameters.Planet.cp_l(ps::ParameterSet) = 4181
+CLIMA.Parameters.Planet.cp_i(ps::ParameterSet) = 2100
+CLIMA.Parameters.Planet.cv_v(ps::ParameterSet) = cp_v(ps) - R_v(ps)
+CLIMA.Parameters.Planet.cv_l(ps::ParameterSet) = cp_l(ps)
+CLIMA.Parameters.Planet.cv_i(ps::ParameterSet) = cp_i(ps)
+CLIMA.Parameters.Planet.T_freeze(ps::ParameterSet) = 273.15
+CLIMA.Parameters.Planet.T_min(ps::ParameterSet) = 150.0
+CLIMA.Parameters.Planet.T_max(ps::ParameterSet) = 1000.0
+CLIMA.Parameters.Planet.T_icenuc(ps::ParameterSet) = 233.00
+CLIMA.Parameters.Planet.T_triple(ps::ParameterSet) = 273.16
+CLIMA.Parameters.Planet.T_0(ps::ParameterSet) = T_triple(ps)
+CLIMA.Parameters.Planet.LH_v0(ps::ParameterSet) = 2.5008e6
+CLIMA.Parameters.Planet.LH_s0(ps::ParameterSet) = 2.8344e6
+CLIMA.Parameters.Planet.LH_f0(ps::ParameterSet) = LH_s0(ps) - LH_v0(ps)
+CLIMA.Parameters.Planet.e_int_v0(ps::ParameterSet) =
+    LH_v0(ps) - R_v(ps) * T_0(ps)
+CLIMA.Parameters.Planet.e_int_i0(ps::ParameterSet) = LH_f0(ps)
+CLIMA.Parameters.Planet.press_triple(ps::ParameterSet) = 611.657
 
 # Properties of sea water
-CLIMA.Parameters.Planet.ρ_ocean(ps::ParameterSet)        = 1.035e3
-CLIMA.Parameters.Planet.cp_ocean(ps::ParameterSet)       = 3989.25
+CLIMA.Parameters.Planet.ρ_ocean(ps::ParameterSet) = 1.035e3
+CLIMA.Parameters.Planet.cp_ocean(ps::ParameterSet) = 3989.25
 
 # Planetary parameters
-CLIMA.Parameters.Planet.planet_radius(ps::ParameterSet)  = 6.371e6
-CLIMA.Parameters.Planet.day(ps::ParameterSet)            = 86400
-CLIMA.Parameters.Planet.Omega(ps::ParameterSet)          = 7.2921159e-5
-CLIMA.Parameters.Planet.grav(ps::ParameterSet)           = 9.81
-CLIMA.Parameters.Planet.year_anom(ps::ParameterSet)      = 365.26 * day(ps)
-CLIMA.Parameters.Planet.orbit_semimaj(ps::ParameterSet)  = 1 * astro_unit()
-CLIMA.Parameters.Planet.TSI(ps::ParameterSet)            = 1362
-CLIMA.Parameters.Planet.MSLP(ps::ParameterSet)           = 1.01325e5
+CLIMA.Parameters.Planet.planet_radius(ps::ParameterSet) = 6.371e6
+CLIMA.Parameters.Planet.day(ps::ParameterSet) = 86400
+CLIMA.Parameters.Planet.Omega(ps::ParameterSet) = 7.2921159e-5
+CLIMA.Parameters.Planet.grav(ps::ParameterSet) = 9.81
+CLIMA.Parameters.Planet.year_anom(ps::ParameterSet) = 365.26 * day(ps)
+CLIMA.Parameters.Planet.orbit_semimaj(ps::ParameterSet) = 1 * astro_unit()
+CLIMA.Parameters.Planet.TSI(ps::ParameterSet) = 1362
+CLIMA.Parameters.Planet.MSLP(ps::ParameterSet) = 1.01325e5

--- a/Parameters/Planet.jl
+++ b/Parameters/Planet.jl
@@ -2,65 +2,50 @@
 
 import CLIMA
 
-struct ParameterSet{FT} <: CLIMA.Parameters.AbstractParameterSet{FT} end
+struct ParameterSet <: CLIMA.Parameters.AbstractParameterSet end
 
 # Properties of dry air
-CLIMA.Parameters.Planet.molmass_dryair(ps::ParameterSet{FT}) where {FT} =
-    FT(28.97e-3)
-CLIMA.Parameters.Planet.R_d(ps::ParameterSet{FT}) where {FT} =
-    gas_constant(FT) / molmass_dryair(ps)
-CLIMA.Parameters.Planet.kappa_d(ps::ParameterSet{FT}) where {FT} = FT(2 / 7)
-CLIMA.Parameters.Planet.cp_d(ps::ParameterSet{FT}) where {FT} =
-    R_d(ps) / kappa_d(ps)
-CLIMA.Parameters.Planet.cv_d(ps::ParameterSet{FT}) where {FT} =
-    cp_d(ps) - R_d(ps)
+CLIMA.Parameters.Planet.molmass_dryair(ps::ParameterSet) = 28.97e-3
+CLIMA.Parameters.Planet.R_d(ps::ParameterSet)            = gas_constant() / molmass_dryair(ps)
+CLIMA.Parameters.Planet.kappa_d(ps::ParameterSet)        = 2 / 7
+CLIMA.Parameters.Planet.cp_d(ps::ParameterSet)           = R_d(ps) / kappa_d(ps)
+CLIMA.Parameters.Planet.cv_d(ps::ParameterSet)           = cp_d(ps) - R_d(ps)
 
 # Properties of water
-CLIMA.Parameters.Planet.ρ_cloud_liq(ps::ParameterSet{FT}) where {FT} = FT(1e3)
-CLIMA.Parameters.Planet.ρ_cloud_ice(ps::ParameterSet{FT}) where {FT} = FT(916.7)
-CLIMA.Parameters.Planet.molmass_water(ps::ParameterSet{FT}) where {FT} =
-    FT(18.01528e-3)
-CLIMA.Parameters.Planet.molmass_ratio(ps::ParameterSet{FT}) where {FT} =
-    molmass_dryair(ps) / molmass_water(ps)
-CLIMA.Parameters.Planet.R_v(ps::ParameterSet{FT}) where {FT} =
-    gas_constant(FT) / molmass_water(ps)
-CLIMA.Parameters.Planet.cp_v(ps::ParameterSet{FT}) where {FT} = FT(1859)
-CLIMA.Parameters.Planet.cp_l(ps::ParameterSet{FT}) where {FT} = FT(4181)
-CLIMA.Parameters.Planet.cp_i(ps::ParameterSet{FT}) where {FT} = FT(2100)
-CLIMA.Parameters.Planet.cv_v(ps::ParameterSet{FT}) where {FT} =
-    cp_v(ps) - R_v(ps)
-CLIMA.Parameters.Planet.cv_l(ps::ParameterSet{FT}) where {FT} = cp_l(ps)
-CLIMA.Parameters.Planet.cv_i(ps::ParameterSet{FT}) where {FT} = cp_i(ps)
-CLIMA.Parameters.Planet.T_freeze(ps::ParameterSet{FT}) where {FT} = FT(273.15)
-CLIMA.Parameters.Planet.T_min(ps::ParameterSet{FT}) where {FT} = FT(150.0)
-CLIMA.Parameters.Planet.T_max(ps::ParameterSet{FT}) where {FT} = FT(1000.0)
-CLIMA.Parameters.Planet.T_icenuc(ps::ParameterSet{FT}) where {FT} = FT(233.00)
-CLIMA.Parameters.Planet.T_triple(ps::ParameterSet{FT}) where {FT} = FT(273.16)
-CLIMA.Parameters.Planet.T_0(ps::ParameterSet{FT}) where {FT} = T_triple(ps)
-CLIMA.Parameters.Planet.LH_v0(ps::ParameterSet{FT}) where {FT} = FT(2.5008e6)
-CLIMA.Parameters.Planet.LH_s0(ps::ParameterSet{FT}) where {FT} = FT(2.8344e6)
-CLIMA.Parameters.Planet.LH_f0(ps::ParameterSet{FT}) where {FT} =
-    LH_s0(ps) - LH_v0(ps)
-CLIMA.Parameters.Planet.e_int_v0(ps::ParameterSet{FT}) where {FT} =
-    LH_v0(ps) - R_v(ps) * T_0(ps)
-CLIMA.Parameters.Planet.e_int_i0(ps::ParameterSet{FT}) where {FT} = LH_f0(ps)
-CLIMA.Parameters.Planet.press_triple(ps::ParameterSet{FT}) where {FT} =
-    FT(611.657)
+CLIMA.Parameters.Planet.ρ_cloud_liq(ps::ParameterSet)    = 1e3
+CLIMA.Parameters.Planet.ρ_cloud_ice(ps::ParameterSet)    = 916.7
+CLIMA.Parameters.Planet.molmass_water(ps::ParameterSet)  = 18.01528e-3
+CLIMA.Parameters.Planet.molmass_ratio(ps::ParameterSet)  = molmass_dryair(ps) / molmass_water(ps)
+CLIMA.Parameters.Planet.R_v(ps::ParameterSet)            = gas_constant() / molmass_water(ps)
+CLIMA.Parameters.Planet.cp_v(ps::ParameterSet)           = 1859
+CLIMA.Parameters.Planet.cp_l(ps::ParameterSet)           = 4181
+CLIMA.Parameters.Planet.cp_i(ps::ParameterSet)           = 2100
+CLIMA.Parameters.Planet.cv_v(ps::ParameterSet)           = cp_v(ps) - R_v(ps)
+CLIMA.Parameters.Planet.cv_l(ps::ParameterSet)           = cp_l(ps)
+CLIMA.Parameters.Planet.cv_i(ps::ParameterSet)           = cp_i(ps)
+CLIMA.Parameters.Planet.T_freeze(ps::ParameterSet)       = 273.15
+CLIMA.Parameters.Planet.T_min(ps::ParameterSet)          = 150.0
+CLIMA.Parameters.Planet.T_max(ps::ParameterSet)          = 1000.0
+CLIMA.Parameters.Planet.T_icenuc(ps::ParameterSet)       = 233.00
+CLIMA.Parameters.Planet.T_triple(ps::ParameterSet)       = 273.16
+CLIMA.Parameters.Planet.T_0(ps::ParameterSet)            = T_triple(ps)
+CLIMA.Parameters.Planet.LH_v0(ps::ParameterSet)          = 2.5008e6
+CLIMA.Parameters.Planet.LH_s0(ps::ParameterSet)          = 2.8344e6
+CLIMA.Parameters.Planet.LH_f0(ps::ParameterSet)          = LH_s0(ps) - LH_v0(ps)
+CLIMA.Parameters.Planet.e_int_v0(ps::ParameterSet)       = LH_v0(ps) - R_v(ps) * T_0(ps)
+CLIMA.Parameters.Planet.e_int_i0(ps::ParameterSet)       = LH_f0(ps)
+CLIMA.Parameters.Planet.press_triple(ps::ParameterSet)   = 611.657
 
 # Properties of sea water
-CLIMA.Parameters.Planet.ρ_ocean(ps::ParameterSet{FT}) where {FT} = FT(1.035e3)
-CLIMA.Parameters.Planet.cp_ocean(ps::ParameterSet{FT}) where {FT} = FT(3989.25)
+CLIMA.Parameters.Planet.ρ_ocean(ps::ParameterSet)        = 1.035e3
+CLIMA.Parameters.Planet.cp_ocean(ps::ParameterSet)       = 3989.25
 
 # Planetary parameters
-CLIMA.Parameters.Planet.planet_radius(ps::ParameterSet{FT}) where {FT} =
-    FT(6.371e6)
-CLIMA.Parameters.Planet.day(ps::ParameterSet{FT}) where {FT} = FT(86400)
-CLIMA.Parameters.Planet.Omega(ps::ParameterSet{FT}) where {FT} =
-    FT(7.2921159e-5)
-CLIMA.Parameters.Planet.grav(ps::ParameterSet{FT}) where {FT} = FT(9.81)
-CLIMA.Parameters.Planet.year_anom(ps::ParameterSet{FT}) where {FT} =
-    FT(365.26) * day(ps)
-CLIMA.Parameters.Planet.orbit_semimaj(ps::ParameterSet{FT}) where {FT} =
-    FT(1 * astro_unit(FT))
-CLIMA.Parameters.Planet.TSI(ps::ParameterSet{FT}) where {FT} = FT(1362)
-CLIMA.Parameters.Planet.MSLP(ps::ParameterSet{FT}) where {FT} = FT(1.01325e5)
+CLIMA.Parameters.Planet.planet_radius(ps::ParameterSet)  = 6.371e6
+CLIMA.Parameters.Planet.day(ps::ParameterSet)            = 86400
+CLIMA.Parameters.Planet.Omega(ps::ParameterSet)          = 7.2921159e-5
+CLIMA.Parameters.Planet.grav(ps::ParameterSet)           = 9.81
+CLIMA.Parameters.Planet.year_anom(ps::ParameterSet)      = 365.26 * day(ps)
+CLIMA.Parameters.Planet.orbit_semimaj(ps::ParameterSet)  = 1 * astro_unit()
+CLIMA.Parameters.Planet.TSI(ps::ParameterSet)            = 1362
+CLIMA.Parameters.Planet.MSLP(ps::ParameterSet)           = 1.01325e5

--- a/examples/Atmos/dry_rayleigh_benard.jl
+++ b/examples/Atmos/dry_rayleigh_benard.jl
@@ -20,6 +20,7 @@ using CLIMA.VariableTemplates
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 # ------------------- Description ---------------------------------------- #
 # 1) Dry Rayleigh Benard Convection (re-entrant channel configuration)
@@ -127,7 +128,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
         ),
         init_state = init_problem!,
         data_config = data_config,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
     ode_solver =
         CLIMA.ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -22,6 +22,8 @@ const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 using CLIMA.Parameters.Planet
 
+param_set = ParameterSet()
+
 struct HeldSuarezDataConfig{FT}
     p_sfc::FT
     T_init::FT
@@ -34,7 +36,7 @@ function init_heldsuarez!(bl, state, aux, coords, t)
     # Parameters need to set initial state
     T_init = bl.data_config.T_init
     p_sfc = bl.data_config.p_sfc
-    scale_height = R_d(bl.param_set) * T_init / grav(bl.param_set)
+    scale_height = FT(R_d(bl.param_set)) * T_init / FT(grav(bl.param_set))
 
     # Calculate the initial state variables
     z = altitude(bl.orientation, aux)
@@ -56,8 +58,6 @@ end
 function config_heldsuarez(FT, poly_order, resolution)
     exp_name = "HeldSuarez"
 
-    param_set = ParameterSet{FT}()
-
     # Parameters
     p_sfc::FT = MSLP(param_set)
     T_init::FT = 255
@@ -67,7 +67,7 @@ function config_heldsuarez(FT, poly_order, resolution)
     turb_visc::FT = 0 # no visc. here
 
     # Set up a reference state for linearization
-    Γ = FT(0.7 * grav(param_set) / cp_d(param_set)) # lapse rate
+    Γ = FT(0.7 * FT(grav(param_set)) / FT(cp_d(param_set))) # lapse rate
     T_sfc = FT(300.0)
     T_min = FT(200.0)
     temp_profile_ref = LinearTemperatureProfile(T_min, T_sfc, Γ)
@@ -124,11 +124,11 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
     coord = aux.coord
     e_int = internal_energy(bl.moisture, bl.orientation, state, aux)
     T = air_temperature(e_int, bl.param_set)
-    _R_d = R_d(bl.param_set)
-    _day = day(bl.param_set)
-    _grav = grav(bl.param_set)
-    _cp_d = cp_d(bl.param_set)
-    _cv_d = cv_d(bl.param_set)
+    _R_d = FT(R_d(bl.param_set))
+    _day = FT(day(bl.param_set))
+    _grav = FT(grav(bl.param_set))
+    _cp_d = FT(cp_d(bl.param_set))
+    _cv_d = FT(cv_d(bl.param_set))
 
     # Held-Suarez parameters
     k_a = FT(1 / (40 * _day))
@@ -165,8 +165,7 @@ end
 function config_diagnostics(FT, driver_config)
     interval = 100 # in time steps
 
-    param_set = ParameterSet{FT}()
-    _planet_radius = planet_radius(param_set)
+    _planet_radius = FT(planet_radius(param_set))
 
     info = driver_config.config_info
     boundaries = [

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -72,6 +72,8 @@ const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 using CLIMA.Parameters.Planet
 
+param_set = ParameterSet()
+
 import CLIMA.DGmethods: vars_state, vars_aux
 import CLIMA.Atmos: source!, atmos_source!, altitude
 import CLIMA.Atmos: flux_diffusive!, thermo_state
@@ -197,7 +199,7 @@ function atmos_source!(
     FT = eltype(state)
     ρ = state.ρ
     z = altitude(atmos.orientation, aux)
-    _e_int_v0 = e_int_v0(atmos.param_set)
+    _e_int_v0 = FT(e_int_v0(atmos.param_set))
 
     # Establish thermodynamic state
     TS = thermo_state(atmos, state, aux)
@@ -278,7 +280,7 @@ function init_bomex!(bl, state, aux, (x, y, z), t)
     Rm_sfc = gas_constant_air(q_pt_sfc, bl.param_set) # Moist gas constant
     θ_liq_sfc = FT(299.1) # Prescribed θ_liq at surface
     T_sfc = FT(300.4) # Surface temperature
-    _grav = grav(bl.param_set)
+    _grav = FT(grav(bl.param_set))
 
     # Initialise speeds [u = Eastward, v = Northward, w = Vertical]
     u::FT = 0
@@ -358,7 +360,6 @@ end
 
 function config_bomex(FT, N, resolution, xmax, ymax, zmax)
 
-    param_set = ParameterSet{FT}()
     ics = init_bomex!     # Initial conditions
 
     C_smag = FT(0.18)     # Smagorinsky coefficient
@@ -372,7 +373,7 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax)
     ∂qt∂t_peak = FT(-1.2e-8)  # Moisture tendency (energy source)
     zl_moisture = FT(300)     # Low altitude limit for piecewise function (moisture source)
     zh_moisture = FT(500)     # High altitude limit for piecewise function (moisture source)
-    ∂θ∂t_peak = FT(-2 / day(param_set))  # Potential temperature tendency (energy source)
+    ∂θ∂t_peak = FT(-2 / FT(day(param_set)))  # Potential temperature tendency (energy source)
 
     z_sponge = FT(2400)     # Start of sponge layer
     α_max = FT(0.75)        # Strength of sponge layer (timescale)

--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -17,6 +17,7 @@ using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 using CLIMA.Parameters.Planet
+param_set = ParameterSet()
 
 # ------------------------ Description ------------------------- #
 # 1) Dry Rising Bubble (circular potential temperature perturbation)
@@ -93,7 +94,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         source = (Gravity(),),
         ref_state = ref_state,
         init_state = init_risingbubble!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
 
     # Problem configuration

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -21,6 +21,7 @@ using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 using CLIMA.Parameters.Planet
+param_set = ParameterSet()
 
 # -------------------- Surface Driven Bubble ----------------- #
 # Rising thermals driven by a prescribed surface heat flux.
@@ -101,7 +102,7 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
         ),
         moisture = EquilMoist{FT}(),
         init_state = init_surfacebubble!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
     config = CLIMA.AtmosLESConfiguration(
         "SurfaceDrivenBubble",

--- a/experiments/OceanBoxGCM/homogeneous_box.jl
+++ b/experiments/OceanBoxGCM/homogeneous_box.jl
@@ -14,12 +14,12 @@ using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 using CLIMA.Parameters.Planet
+param_set = ParameterSet()
 
 function config_simple_box(FT, N, resolution, dimensions)
     prob = HomogeneousBox{FT}(dimensions...)
-    param_set = ParameterSet{FT}()
 
-    cʰ = sqrt(grav(param_set) * prob.H) # m/s
+    cʰ = sqrt(FT(grav(param_set)) * prob.H) # m/s
     model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
 
     config =

--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -62,10 +62,7 @@ include("isentropic.jl")
 The specific gas constant of moist air given
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
-gas_constant_air(
-    q::PhasePartition{FT},
-    param_set::PS = MTPS(),
-) where {FT, PS} =
+gas_constant_air(q::PhasePartition{FT}, param_set::PS = MTPS()) where {FT, PS} =
     FT(R_d) *
     (1 + (FT(molmass_ratio) - 1) * q.tot - FT(molmass_ratio) * (q.liq + q.ice))
 
@@ -175,10 +172,7 @@ The isobaric specific heat capacity of moist
 air where, optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
-cp_m(
-    q::PhasePartition{FT},
-    param_set::PS = MTPS(),
-) where {FT <: Real, PS} =
+cp_m(q::PhasePartition{FT}, param_set::PS = MTPS()) where {FT <: Real, PS} =
     FT(cp_d) +
     (FT(cp_v) - FT(cp_d)) * q.tot +
     (FT(cp_l) - FT(cp_v)) * q.liq +
@@ -203,10 +197,7 @@ The isochoric specific heat capacity of moist
 air where optionally,
  - `q` [`PhasePartition`](@ref). Without this argument, the results are for dry air.
 """
-cv_m(
-    q::PhasePartition{FT},
-    param_set::PS = MTPS(),
-) where {FT <: Real, PS} =
+cv_m(q::PhasePartition{FT}, param_set::PS = MTPS()) where {FT <: Real, PS} =
     FT(cv_d) +
     (FT(cv_v) - FT(cv_d)) * q.tot +
     (FT(cv_l) - FT(cv_v)) * q.liq +
@@ -1367,12 +1358,13 @@ air_temperature_from_liquid_ice_pottemp_given_pressure(
     θ_liq_ice::FT,
     p::FT,
     param_set::PS,
-) where {FT <: Real, PS} = air_temperature_from_liquid_ice_pottemp_given_pressure(
-    θ_liq_ice,
-    p,
-    q_pt_0(FT),
-    param_set,
-)
+) where {FT <: Real, PS} =
+    air_temperature_from_liquid_ice_pottemp_given_pressure(
+        θ_liq_ice,
+        p,
+        q_pt_0(FT),
+        param_set,
+    )
 
 """
     virtual_pottemp(T, ρ[, q::PhasePartition])
@@ -1426,11 +1418,8 @@ function liquid_ice_pottemp_sat(
     q_v_sat = q_vap_saturation(T, ρ, q, param_set)
     return liquid_ice_pottemp(T, ρ, PhasePartition(q_v_sat), param_set)
 end
-liquid_ice_pottemp_sat(
-    T::FT,
-    ρ::FT,
-    param_set::PS = MTPS(),
-) where {FT, PS} = liquid_ice_pottemp_sat(T, ρ, q_pt_0(FT), param_set)
+liquid_ice_pottemp_sat(T::FT, ρ::FT, param_set::PS = MTPS()) where {FT, PS} =
+    liquid_ice_pottemp_sat(T, ρ, q_pt_0(FT), param_set)
 
 """
     liquid_ice_pottemp_sat(T, ρ, q_tot)

--- a/src/Common/MoistThermodynamics/MoistThermodynamics.jl
+++ b/src/Common/MoistThermodynamics/MoistThermodynamics.jl
@@ -50,7 +50,6 @@ export vapor_specific_humidity
 
 # The default ParameterSet for Moist Thermodynamics:
 const MTPS = EarthParameterSet
-const APS = AbstractParameterSet
 
 include("states.jl")
 include("isentropic.jl")
@@ -65,12 +64,12 @@ The specific gas constant of moist air given
 """
 gas_constant_air(
     q::PhasePartition{FT},
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} =
+    param_set::PS = MTPS(),
+) where {FT, PS} =
     FT(R_d) *
     (1 + (FT(molmass_ratio) - 1) * q.tot - FT(molmass_ratio) * (q.liq + q.ice))
 
-gas_constant_air(::Type{FT}, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+gas_constant_air(::Type{FT}, param_set::PS = MTPS()) where {FT, PS} =
     gas_constant_air(q_pt_0(FT), param_set)
 
 """
@@ -107,9 +106,9 @@ air_pressure(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = gas_constant_air(q, param_set) * ρ * T
-air_pressure(T::FT, ρ::FT, param_set::APS{FT}) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = gas_constant_air(q, param_set) * ρ * T
+air_pressure(T::FT, ρ::FT, param_set::PS) where {FT <: Real, PS} =
     air_pressure(T, ρ, q_pt_0(FT), param_set)
 
 """
@@ -141,9 +140,9 @@ air_density(
     T::FT,
     p::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = p / (gas_constant_air(q, param_set) * T)
-air_density(T::FT, p::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = p / (gas_constant_air(q, param_set) * T)
+air_density(T::FT, p::FT, param_set::PS = MTPS()) where {FT, PS} =
     air_density(T, p, q_pt_0(FT), param_set)
 
 """
@@ -178,14 +177,14 @@ air where, optionally,
 """
 cp_m(
     q::PhasePartition{FT},
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     FT(cp_d) +
     (FT(cp_v) - FT(cp_d)) * q.tot +
     (FT(cp_l) - FT(cp_v)) * q.liq +
     (FT(cp_i) - FT(cp_v)) * q.ice
 
-cp_m(::Type{FT}, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+cp_m(::Type{FT}, param_set::PS = MTPS()) where {FT <: Real, PS} =
     cp_m(q_pt_0(FT), param_set)
 
 """
@@ -206,14 +205,14 @@ air where optionally,
 """
 cv_m(
     q::PhasePartition{FT},
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     FT(cv_d) +
     (FT(cv_v) - FT(cv_d)) * q.tot +
     (FT(cv_l) - FT(cv_v)) * q.liq +
     (FT(cv_i) - FT(cv_v)) * q.ice
 
-cv_m(::Type{FT}, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+cv_m(::Type{FT}, param_set::PS = MTPS()) where {FT <: Real, PS} =
     cv_m(q_pt_0(FT), param_set)
 
 """
@@ -240,15 +239,15 @@ The function returns a tuple of
 """
 function gas_constants(
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     R_gas = gas_constant_air(q, param_set)
     cp = cp_m(q, param_set)
     cv = cv_m(q, param_set)
     γ = cp / cv
     return (R_gas, cp, cv, γ)
 end
-gas_constants(param_set::APS{FT}) where {FT <: Real} =
+gas_constants(param_set::PS) where {FT <: Real, PS} =
     gas_constants(q_pt_0(FT), param_set)
 
 """
@@ -278,15 +277,15 @@ and, optionally,
 function air_temperature(
     e_int::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     T_0 +
     (
         e_int - (q.tot - q.liq) * FT(e_int_v0) +
         q.ice * (FT(e_int_v0) + FT(e_int_i0))
     ) / cv_m(q, param_set)
 end
-air_temperature(e_int::FT, param_set::APS{FT}) where {FT <: Real} =
+air_temperature(e_int::FT, param_set::PS) where {FT <: Real, PS} =
     air_temperature(e_int, q_pt_0(FT), param_set)
 
 """
@@ -311,11 +310,11 @@ and, optionally,
 internal_energy(
     T::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     cv_m(q, param_set) * (T - FT(T_0)) + (q.tot - q.liq) * FT(e_int_v0) -
     q.ice * (FT(e_int_v0) + FT(e_int_i0))
-internal_energy(T::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+internal_energy(T::FT, param_set::PS = MTPS()) where {FT, PS} =
     internal_energy(T, q_pt_0(FT), param_set)
 
 """
@@ -361,8 +360,8 @@ internal_energy_sat(
     T::FT,
     ρ::FT,
     q_tot::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     internal_energy(T, PhasePartition_equil(T, ρ, q_tot, param_set), param_set)
 
 """
@@ -397,16 +396,16 @@ function total_energy(
     e_pot::FT,
     T::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     return e_kin + e_pot + internal_energy(T, q, param_set)
 end
 total_energy(
     e_kin::FT,
     e_pot::FT,
     T::FT,
-    param_set::APS{FT},
-) where {FT <: Real} = total_energy(e_kin, e_pot, T, q_pt_0(FT), param_set)
+    param_set::PS,
+) where {FT <: Real, PS} = total_energy(e_kin, e_pot, T, q_pt_0(FT), param_set)
 
 """
     total_energy(e_kin, e_pot, ts::ThermodynamicState)
@@ -431,13 +430,13 @@ and, optionally,
 function soundspeed_air(
     T::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     γ = cp_m(q, param_set) / cv_m(q, param_set)
     R_m = gas_constant_air(q, param_set)
     return sqrt(γ * R_m * T)
 end
-soundspeed_air(T::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+soundspeed_air(T::FT, param_set::PS = MTPS()) where {FT, PS} =
     soundspeed_air(T, q_pt_0(FT), param_set)
 
 """
@@ -455,7 +454,7 @@ soundspeed_air(ts::ThermodynamicState) =
 The specific latent heat of vaporization where
  - `T` temperature
 """
-latent_heat_vapor(T::FT, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+latent_heat_vapor(T::FT, param_set::PS = MTPS()) where {FT <: Real, PS} =
     latent_heat_generic(T, FT(LH_v0), FT(cp_v) - FT(cp_l), param_set)
 
 """
@@ -473,7 +472,7 @@ latent_heat_vapor(ts::ThermodynamicState) =
 The specific latent heat of sublimation where
  - `T` temperature
 """
-latent_heat_sublim(T::FT, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+latent_heat_sublim(T::FT, param_set::PS = MTPS()) where {FT <: Real, PS} =
     latent_heat_generic(T, FT(LH_s0), FT(cp_v) - FT(cp_i), param_set)
 
 """
@@ -491,7 +490,7 @@ latent_heat_sublim(ts::ThermodynamicState) =
 The specific latent heat of fusion where
  - `T` temperature
 """
-latent_heat_fusion(T::FT, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
+latent_heat_fusion(T::FT, param_set::PS = MTPS()) where {FT <: Real, PS} =
     latent_heat_generic(T, FT(LH_f0), FT(cp_l) - FT(cp_i), param_set)
 
 """
@@ -500,7 +499,7 @@ latent_heat_fusion(T::FT, param_set::APS{FT} = MTPS{FT}()) where {FT <: Real} =
 The specific latent heat of fusion
 given a thermodynamic state `ts`.
 """
-latent_heat_fusion(ts::ThermodynamicState{FT}) where {FT <: Real} =
+latent_heat_fusion(ts::ThermodynamicState{FT}) where {FT <: Real, PS} =
     latent_heat_fusion(air_temperature(ts), ts.param_set)
 
 """
@@ -520,8 +519,8 @@ latent_heat_generic(
     T::FT,
     LH_0::FT,
     Δcp::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = LH_0 + Δcp * (T - FT(T_0))
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = LH_0 + Δcp * (T - FT(T_0))
 
 
 """
@@ -586,8 +585,8 @@ the triple point pressure `press_triple`.
 saturation_vapor_pressure(
     T::FT,
     ::Liquid,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     saturation_vapor_pressure(T, FT(LH_v0), FT(cp_v) - FT(cp_l), param_set)
 
 function saturation_vapor_pressure(
@@ -607,8 +606,8 @@ end
 saturation_vapor_pressure(
     T::FT,
     ::Ice,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     saturation_vapor_pressure(T, FT(LH_s0), FT(cp_v) - FT(cp_i), param_set)
 
 saturation_vapor_pressure(
@@ -625,8 +624,8 @@ function saturation_vapor_pressure(
     T::FT,
     LH_0::FT,
     Δcp::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
 
     return FT(press_triple) *
            (T / FT(T_triple))^(Δcp / FT(R_v)) *
@@ -651,9 +650,9 @@ and, optionally,
 function q_vap_saturation_generic(
     T::FT,
     ρ::FT,
-    param_set::APS{FT} = MTPS{FT}();
+    param_set::PS = MTPS();
     phase::Phase = Liquid(),
-) where {FT <: Real}
+) where {FT <: Real, PS}
     p_v_sat = saturation_vapor_pressure(T, phase, param_set)
     return q_vap_saturation_from_pressure(T, ρ, p_v_sat, param_set)
 end
@@ -685,8 +684,8 @@ function q_vap_saturation(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
 
     # get phase partitioning
     _liquid_frac = liquid_fraction(T, q, param_set)
@@ -704,7 +703,7 @@ function q_vap_saturation(
     return q_vap_saturation_from_pressure(T, ρ, p_v_sat, param_set)
 
 end
-q_vap_saturation(T::FT, ρ::FT, param_set::APS{FT}) where {FT <: Real} =
+q_vap_saturation(T::FT, ρ::FT, param_set::PS) where {FT <: Real, PS} =
     q_vap_saturation(T, ρ, q_pt_0(FT), param_set)
 
 """
@@ -732,8 +731,8 @@ q_vap_saturation_from_pressure(
     T::FT,
     ρ::FT,
     p_v_sat::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = p_v_sat / (ρ * FT(R_v) * T)
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = p_v_sat / (ρ * FT(R_v) * T)
 
 """
     saturation_excess(T, ρ, q::PhasePartition)
@@ -752,8 +751,8 @@ saturation_excess(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT},
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = max(0, q.tot - q_vap_saturation(T, ρ, q, param_set))
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = max(0, q.tot - q_vap_saturation(T, ρ, q, param_set))
 
 """
     saturation_excess(ts::ThermodynamicState)
@@ -785,8 +784,8 @@ is a function that is 1 above `T_freeze` and goes to zero below `T_freeze`.
 function liquid_fraction(
     T::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     q_c = q.liq + q.ice     # condensate specific humidity
     if q_c > 0
         return q.liq / q_c
@@ -796,7 +795,7 @@ function liquid_fraction(
         return FT(T > FT(T_freeze))
     end
 end
-liquid_fraction(T::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+liquid_fraction(T::FT, param_set::PS = MTPS()) where {FT, PS} =
     liquid_fraction(T, q_pt_0(FT), param_set)
 
 """
@@ -823,8 +822,8 @@ function PhasePartition_equil(
     T::FT,
     ρ::FT,
     q_tot::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     _liquid_frac = liquid_fraction(T, param_set)                      # fraction of condensate that is liquid
     q_c = saturation_excess(T, ρ, PhasePartition(q_tot), param_set) # condensate specific humidity
     q_liq = _liquid_frac * q_c                             # liquid specific humidity
@@ -854,8 +853,8 @@ function ∂e_int_∂T(
     e_int::FT,
     ρ::FT,
     q_tot::FT,
-    param_set::APS{FT},
-) where {FT <: Real}
+    param_set::PS,
+) where {FT <: Real, PS}
     cvm = cv_m(PhasePartition_equil(T, ρ, q_tot, param_set), param_set)
     q_vap_sat = q_vap_saturation(T, ρ, param_set)
     λ = liquid_fraction(T, param_set)
@@ -893,8 +892,8 @@ function saturation_adjustment(
     q_tot::FT,
     maxiter::Int,
     tol::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     T_1 =
         max(FT(T_min), air_temperature(e_int, PhasePartition(q_tot), param_set)) # Assume all vapor
     q_v_sat = q_vap_saturation(T_1, ρ, param_set)
@@ -966,8 +965,8 @@ function saturation_adjustment_SecantMethod(
     q_tot::FT,
     maxiter::Int,
     tol::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     T_1 =
         max(FT(T_min), air_temperature(e_int, PhasePartition(q_tot), param_set)) # Assume all vapor
     q_v_sat = q_vap_saturation(T_1, ρ, param_set)
@@ -1023,8 +1022,8 @@ function saturation_adjustment_q_tot_θ_liq_ice(
     q_tot::FT,
     maxiter::Int,
     tol::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     T_1 = max(
         FT(T_min),
         air_temperature_from_liquid_ice_pottemp(
@@ -1087,8 +1086,8 @@ function saturation_adjustment_q_tot_θ_liq_ice_given_pressure(
     q_tot::FT,
     maxiter::Int,
     tol::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     T_1 = air_temperature_from_liquid_ice_pottemp_given_pressure(
         θ_liq_ice,
         p,
@@ -1138,10 +1137,8 @@ with specific latent heat evaluated at reference temperature `T_0`.
 """
 latent_heat_liq_ice(
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = FT(LH_v0) * q.liq + FT(LH_s0) * q.ice
-latent_heat_liq_ice(param_set::APS{FT}) where {FT} =
-    latent_heat_liq_ice(q_pt_0(FT), param_set)
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = FT(LH_v0) * q.liq + FT(LH_s0) * q.ice
 
 
 """
@@ -1157,8 +1154,8 @@ function liquid_ice_pottemp_given_pressure(
     T::FT,
     p::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     # liquid-ice potential temperature, approximating latent heats
     # of phase transitions as constants
     return dry_pottemp_given_pressure(T, p, q, param_set) *
@@ -1179,14 +1176,14 @@ liquid_ice_pottemp(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = liquid_ice_pottemp_given_pressure(
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = liquid_ice_pottemp_given_pressure(
     T,
     air_pressure(T, ρ, q, param_set),
     q,
     param_set,
 )
-liquid_ice_pottemp(T::FT, ρ::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+liquid_ice_pottemp(T::FT, ρ::FT, param_set::PS = MTPS()) where {FT, PS} =
     liquid_ice_pottemp(T, ρ, q_pt_0(FT), param_set)
 
 """
@@ -1216,9 +1213,9 @@ dry_pottemp(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = T / exner(T, ρ, q, param_set)
-dry_pottemp(T::FT, ρ::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = T / exner(T, ρ, q, param_set)
+dry_pottemp(T::FT, ρ::FT, param_set::PS = MTPS()) where {FT, PS} =
     dry_pottemp(T, ρ, q_pt_0(FT), param_set)
 
 """
@@ -1235,13 +1232,13 @@ dry_pottemp_given_pressure(
     T::FT,
     p::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = T / exner_given_pressure(p, q, param_set)
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = T / exner_given_pressure(p, q, param_set)
 dry_pottemp_given_pressure(
     T::FT,
     p::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} = dry_pottemp_given_pressure(T, p, q_pt_0(FT), param_set)
+    param_set::PS = MTPS(),
+) where {FT, PS} = dry_pottemp_given_pressure(T, p, q_pt_0(FT), param_set)
 
 """
     dry_pottemp(ts::ThermodynamicState)
@@ -1268,8 +1265,8 @@ function air_temperature_from_liquid_ice_pottemp(
     θ_liq_ice::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
 
     cvm = cv_m(q, param_set)
     cpm = cp_m(q, param_set)
@@ -1283,8 +1280,8 @@ end
 air_temperature_from_liquid_ice_pottemp(
     θ_liq_ice::FT,
     ρ::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} =
+    param_set::PS = MTPS(),
+) where {FT, PS} =
     air_temperature_from_liquid_ice_pottemp(θ_liq_ice, ρ, q_pt_0(FT), param_set)
 
 """
@@ -1310,8 +1307,8 @@ function air_temperature_from_liquid_ice_pottemp_non_linear(
     maxiter::Int,
     tol::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     sol = find_zero(
         T ->
             T - air_temperature_from_liquid_ice_pottemp_given_pressure(
@@ -1337,8 +1334,8 @@ air_temperature_from_liquid_ice_pottemp_non_linear(
     ρ::FT,
     maxiter::Int,
     tol::FT,
-    param_set::APS{FT},
-) where {FT <: Real} = air_temperature_from_liquid_ice_pottemp_non_linear(
+    param_set::PS,
+) where {FT <: Real, PS} = air_temperature_from_liquid_ice_pottemp_non_linear(
     θ_liq_ice,
     ρ,
     maxiter,
@@ -1361,16 +1358,16 @@ function air_temperature_from_liquid_ice_pottemp_given_pressure(
     θ_liq_ice::FT,
     p::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     return θ_liq_ice * exner_given_pressure(p, q, param_set) +
            latent_heat_liq_ice(q, param_set) / cp_m(q, param_set)
 end
 air_temperature_from_liquid_ice_pottemp_given_pressure(
     θ_liq_ice::FT,
     p::FT,
-    param_set::APS{FT},
-) where {FT <: Real} = air_temperature_from_liquid_ice_pottemp_given_pressure(
+    param_set::PS,
+) where {FT <: Real, PS} = air_temperature_from_liquid_ice_pottemp_given_pressure(
     θ_liq_ice,
     p,
     q_pt_0(FT),
@@ -1391,10 +1388,10 @@ virtual_pottemp(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     gas_constant_air(q, param_set) / FT(R_d) * dry_pottemp(T, ρ, q, param_set)
-virtual_pottemp(T::FT, ρ::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+virtual_pottemp(T::FT, ρ::FT, param_set::PS = MTPS()) where {FT, PS} =
     virtual_pottemp(T, ρ, q_pt_0(FT), param_set)
 
 """
@@ -1424,16 +1421,16 @@ function liquid_ice_pottemp_sat(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     q_v_sat = q_vap_saturation(T, ρ, q, param_set)
     return liquid_ice_pottemp(T, ρ, PhasePartition(q_v_sat), param_set)
 end
 liquid_ice_pottemp_sat(
     T::FT,
     ρ::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} = liquid_ice_pottemp_sat(T, ρ, q_pt_0(FT), param_set)
+    param_set::PS = MTPS(),
+) where {FT, PS} = liquid_ice_pottemp_sat(T, ρ, q_pt_0(FT), param_set)
 
 """
     liquid_ice_pottemp_sat(T, ρ, q_tot)
@@ -1448,8 +1445,8 @@ liquid_ice_pottemp_sat(
     T::FT,
     ρ::FT,
     q_tot::FT,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} = liquid_ice_pottemp(
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} = liquid_ice_pottemp(
     T,
     ρ,
     PhasePartition_equil(T, ρ, q_tot, param_set),
@@ -1479,15 +1476,15 @@ and, optionally,
 function exner_given_pressure(
     p::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     # gas constant and isobaric specific heat of moist air
     _R_m = gas_constant_air(q, param_set)
     _cp_m = cp_m(q, param_set)
 
     return (p / FT(MSLP))^(_R_m / _cp_m)
 end
-exner_given_pressure(p::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+exner_given_pressure(p::FT, param_set::PS = MTPS()) where {FT, PS} =
     exner_given_pressure(p, q_pt_0(FT), param_set)
 
 """
@@ -1503,10 +1500,10 @@ exner(
     T::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real} =
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS} =
     exner_given_pressure(air_pressure(T, ρ, q, param_set), q, param_set)
-exner(T::FT, ρ::FT, param_set::APS{FT} = MTPS{FT}()) where {FT} =
+exner(T::FT, ρ::FT, param_set::PS = MTPS()) where {FT, PS} =
     exner(T, ρ, q_pt_0(FT), param_set)
 
 """
@@ -1536,8 +1533,8 @@ function relative_humidity(
     p::FT,
     e_int::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT <: Real}
+    param_set::PS = MTPS(),
+) where {FT <: Real, PS}
     q_vap = q.tot - q.liq - q.ice
     p_vap =
         q_vap *
@@ -1555,8 +1552,8 @@ relative_humidity(
     p::FT,
     e_int::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} = relative_humidity(T, p, e_int, q_pt_0(FT), param_set)
+    param_set::PS = MTPS(),
+) where {FT, PS} = relative_humidity(T, p, e_int, q_pt_0(FT), param_set)
 
 
 """

--- a/src/Common/MoistThermodynamics/isentropic.jl
+++ b/src/Common/MoistThermodynamics/isentropic.jl
@@ -25,8 +25,8 @@ air_pressure_given_θ(
     θ::FT,
     Φ::FT,
     ::DryAdiabaticProcess,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} = FT(MSLP) * (1 - Φ / (θ * FT(cp_d)))^(FT(cp_d) / FT(R_d))
+    param_set::PS = MTPS(),
+) where {FT, PS} = FT(MSLP) * (1 - Φ / (θ * FT(cp_d)))^(FT(cp_d) / FT(R_d))
 
 """
     air_pressure(T::FT, T∞::FT, p∞::FT, ::DryAdiabaticProcess)
@@ -42,8 +42,8 @@ air_pressure(
     T∞::FT,
     p∞::FT,
     ::DryAdiabaticProcess,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} = p∞ * (T / T∞)^(FT(1) / FT(kappa_d))
+    param_set::PS = MTPS(),
+) where {FT, PS} = p∞ * (T / T∞)^(FT(1) / FT(kappa_d))
 
 """
     air_temperature(p::FT, θ::FT, Φ::FT, ::DryAdiabaticProcess)
@@ -57,5 +57,5 @@ air_temperature(
     p::FT,
     θ::FT,
     ::DryAdiabaticProcess,
-    param_set::APS{FT} = MTPS{FT}(),
-) where {FT} = (p / FT(MSLP))^(FT(R_d) / FT(cp_d)) * θ
+    param_set::PS = MTPS(),
+) where {FT, PS} = (p / FT(MSLP))^(FT(R_d) / FT(cp_d)) * θ

--- a/src/Common/MoistThermodynamics/states.jl
+++ b/src/Common/MoistThermodynamics/states.jl
@@ -66,7 +66,7 @@ may be needed).
 
 $(DocStringExtensions.FIELDS)
 """
-struct PhaseEquil{FT, PS <: APS{FT}} <: ThermodynamicState{FT}
+struct PhaseEquil{FT, PS} <: ThermodynamicState{FT}
     "parameter set (e.g., planet parameters)"
     param_set::PS
     "internal energy"
@@ -85,7 +85,7 @@ function PhaseEquil(
     maxiter::Int = 3,
     tol::FT = FT(1e-1),
     sat_adjust::Function = saturation_adjustment,
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: Real, PS}
     # TODO: Remove these safety nets, or at least add warnings
     # waiting on fix: github.com/vchuravy/GPUifyLoops.jl/issues/104
@@ -99,7 +99,7 @@ function PhaseEquil(
     q_tot::FT,
     sat_adjust::Function,
 ) where {FT <: Real, PS}
-    return PhaseEquil(e_int, ρ, q_tot, 3, FT(1e-1), sat_adjust, MTPS{FT}())
+    return PhaseEquil(e_int, ρ, q_tot, 3, FT(1e-1), sat_adjust, MTPS())
 end
 function PhaseEquil(
     e_int::FT,
@@ -116,7 +116,7 @@ function PhaseEquil(
         maxiter,
         tol,
         saturation_adjustment,
-        MTPS{FT}(),
+        MTPS(),
     )
 end
 
@@ -133,7 +133,7 @@ A dry thermodynamic state (`q_tot = 0`).
 
 $(DocStringExtensions.FIELDS)
 """
-struct PhaseDry{FT, PS <: APS{FT}} <: ThermodynamicState{FT}
+struct PhaseDry{FT, PS} <: ThermodynamicState{FT}
     "parameter set (e.g., planet parameters)"
     param_set::PS
     "internal energy"
@@ -141,7 +141,7 @@ struct PhaseDry{FT, PS <: APS{FT}} <: ThermodynamicState{FT}
     "density of dry air"
     ρ::FT
 end
-PhaseDry(e_int::FT, ρ::FT, param_set::PS = MTPS{FT}()) where {FT, PS} =
+PhaseDry(e_int::FT, ρ::FT, param_set::PS = MTPS()) where {FT, PS} =
     PhaseDry{FT, PS}(param_set, e_int, ρ)
 
 """
@@ -155,7 +155,7 @@ Constructs a [`PhaseDry`](@ref) thermodynamic state from:
 function PhaseDry_given_pT(
     p::FT,
     T::FT,
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: Real, PS}
     e_int = internal_energy(T, param_set)
     ρ = air_density(T, p, param_set)
@@ -180,7 +180,7 @@ function LiquidIcePotTempSHumEquil(
     q_tot::FT,
     maxiter::Int = 30,
     tol::FT = FT(1e-1),
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: Real, PS}
     T = saturation_adjustment_q_tot_θ_liq_ice(
         θ_liq_ice,
@@ -220,7 +220,7 @@ function LiquidIcePotTempSHumEquil_given_pressure(
     q_tot::FT,
     maxiter::Int = 30,
     tol::FT = FT(1e-1),
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: Real, PS}
     T = saturation_adjustment_q_tot_θ_liq_ice_given_pressure(
         θ_liq_ice,
@@ -262,7 +262,7 @@ function TemperatureSHumEquil(
     T::FT,
     p::FT,
     q_tot::FT,
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: Real, PS}
     ρ = air_density(T, p, PhasePartition(q_tot), param_set)
     q = PhasePartition_equil(T, ρ, q_tot, param_set)
@@ -285,7 +285,7 @@ be computed directly).
 $(DocStringExtensions.FIELDS)
 
 """
-struct PhaseNonEquil{FT, PS <: APS{FT}} <: ThermodynamicState{FT}
+struct PhaseNonEquil{FT, PS} <: ThermodynamicState{FT}
     "parameter set (e.g., planet parameters)"
     param_set::PS
     "internal energy"
@@ -299,7 +299,7 @@ function PhaseNonEquil(
     e_int::FT,
     ρ::FT,
     q::PhasePartition{FT} = q_pt_0(FT),
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT, PS}
     return PhaseNonEquil{FT, PS}(param_set, e_int, ρ, q)
 end
@@ -322,7 +322,7 @@ function LiquidIcePotTempSHumNonEquil(
     q_pt::PhasePartition{FT},
     maxiter::Int = 5,
     tol::FT = FT(1e-1),
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: Real, PS}
     T = air_temperature_from_liquid_ice_pottemp_non_linear(
         θ_liq_ice,
@@ -349,7 +349,7 @@ function LiquidIcePotTempSHumNonEquil_given_pressure(
     θ_liq_ice::FT,
     p::FT,
     q_pt::PhasePartition{FT},
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: Real, PS}
     T = air_temperature_from_liquid_ice_pottemp_given_pressure(
         θ_liq_ice,
@@ -373,7 +373,7 @@ function fixed_lapse_rate_ref_state(
     z::FT,
     T_surface::FT,
     T_min::FT,
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT <: AbstractFloat, PS}
     Γ = FT(grav) / FT(cp_d)
     z_tropopause = (T_surface - T_min) / Γ
@@ -403,7 +403,7 @@ should span the input arguments to all of the constructors.
 function tested_convergence_range(
     n::Int,
     ::Type{FT},
-    param_set::PS = MTPS{FT}(),
+    param_set::PS = MTPS(),
 ) where {FT, PS}
     n_RS1 = 10
     n_RS2 = 20

--- a/src/Common/Parameters/Parameters.jl
+++ b/src/Common/Parameters/Parameters.jl
@@ -7,9 +7,9 @@ module Parameters
 
 export AbstractParameterSet
 export EarthParameterSet
-abstract type AbstractParameterSet{FT <: AbstractFloat} end
+abstract type AbstractParameterSet end
 
-struct EarthParameterSet{FT} <: AbstractParameterSet{FT} end
+struct EarthParameterSet <: AbstractParameterSet end
 
 include("Planet.jl")
 include("Atmos.jl")

--- a/src/Common/PlanetParameters/UniversalConstants.jl
+++ b/src/Common/PlanetParameters/UniversalConstants.jl
@@ -5,12 +5,7 @@ These constants are planet-independent.
 """
 module UniversalConstants
 
-export gas_constant,
-       light_speed,
-       h_Planck,
-       k_Boltzmann,
-       Stefan,
-       astro_unit
+export gas_constant, light_speed, h_Planck, k_Boltzmann, Stefan, astro_unit
 
 """
     gas_constant
@@ -24,34 +19,34 @@ gas_constant() = 8.3144598
 
 Speed of light in vacuum (m/s)
 """
-light_speed()  = 2.99792458e8
+light_speed() = 2.99792458e8
 
 """
     h_Planck
 
 Planck constant (m^2 kg/s)
 """
-h_Planck()     = 6.626e-34
+h_Planck() = 6.626e-34
 
 """
     k_Boltzmann
 
 Boltzmann constant (m^2 kg/s^2/K)
 """
-k_Boltzmann()  = 1.381e-23
+k_Boltzmann() = 1.381e-23
 
 """
     Stefan
 
 Stefan-Boltzmann constant (W/m^2/K^4)
 """
-Stefan()       = 5.670e-8
+Stefan() = 5.670e-8
 
 """
     astro_unit
 
 Astronomical unit (m)
 """
-astro_unit()   = 1.4959787e11
+astro_unit() = 1.4959787e11
 
 end

--- a/src/Common/PlanetParameters/UniversalConstants.jl
+++ b/src/Common/PlanetParameters/UniversalConstants.jl
@@ -17,41 +17,41 @@ export gas_constant,
 
 Universal gas constant (J/mol/K)
 """
-gas_constant(::Type{FT}) where {FT} =     FT(8.3144598)
+gas_constant() = 8.3144598
 
 """
     light_speed
 
 Speed of light in vacuum (m/s)
 """
-light_speed(::Type{FT}) where {FT} =      FT(2.99792458e8)
+light_speed()  = 2.99792458e8
 
 """
     h_Planck
 
 Planck constant (m^2 kg/s)
 """
-h_Planck(::Type{FT}) where {FT} =         FT(6.626e-34)
+h_Planck()     = 6.626e-34
 
 """
     k_Boltzmann
 
 Boltzmann constant (m^2 kg/s^2/K)
 """
-k_Boltzmann(::Type{FT}) where {FT} =      FT(1.381e-23)
+k_Boltzmann()  = 1.381e-23
 
 """
     Stefan
 
 Stefan-Boltzmann constant (W/m^2/K^4)
 """
-Stefan(::Type{FT}) where {FT} =           FT(5.670e-8)
+Stefan()       = 5.670e-8
 
 """
     astro_unit
 
 Astronomical unit (m)
 """
-astro_unit(::Type{FT}) where {FT} =       FT(1.4959787e11)
+astro_unit()   = 1.4959787e11
 
 end

--- a/src/Driver/driver_configs.jl
+++ b/src/Driver/driver_configs.jl
@@ -11,6 +11,7 @@
 using ..Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 abstract type AbstractSolverType end
 
@@ -146,7 +147,7 @@ function AtmosLESConfiguration(
     model = AtmosModel{FT}(
         AtmosLESConfigType;
         init_state = init_LES!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     ),
     mpicomm = MPI.COMM_WORLD,
     boundary = ((0, 0), (0, 0), (1, 2)),
@@ -224,7 +225,7 @@ function AtmosGCMConfiguration(
     model = AtmosModel{FT}(
         AtmosGCMConfigType;
         init_state = init_GCM!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     ),
     mpicomm = MPI.COMM_WORLD,
     meshwarp::Function = cubedshellwarp,

--- a/test/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -40,6 +40,7 @@ using CLIMA.VariableTemplates: flattenednames
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
 
@@ -124,7 +125,7 @@ function run(
         moisture = DryModel(),
         source = Gravity(),
         init_state = setup,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
     linearmodel = AtmosAcousticGravityLinearModel(model)
 

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -29,6 +29,7 @@ using CLIMA.VariableTemplates: flattenednames
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
 
@@ -201,7 +202,7 @@ function run(
         source = nothing,
         boundarycondition = (),
         init_state = isentropicvortex_initialcondition!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
 
     dg = DGModel(
@@ -294,7 +295,7 @@ end
 Base.@kwdef struct IsentropicVortexSetup{FT}
     p∞::FT = 10^5
     T∞::FT = 300
-    ρ∞::FT = air_density(FT(T∞), FT(p∞), ParameterSet{FT}())
+    ρ∞::FT = air_density(FT(T∞), FT(p∞), param_set)
     translation_speed::FT = 150
     translation_angle::FT = pi / 4
     vortex_speed::FT = 50

--- a/test/DGmethods/Euler/isentropicvortex_imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex_imex.jl
@@ -31,6 +31,7 @@ import CLIMA.Atmos: atmos_init_aux!, vars_aux
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
 
@@ -167,7 +168,7 @@ function run(
         source = nothing,
         boundarycondition = (),
         init_state = isentropicvortex_initialcondition!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
 
     linear_model = AtmosAcousticLinearModel(model)
@@ -295,7 +296,7 @@ end
 Base.@kwdef struct IsentropicVortexSetup{FT}
     p∞::FT = 10^5
     T∞::FT = 300
-    ρ∞::FT = air_density(FT(T∞), FT(p∞), ParameterSet{FT}())
+    ρ∞::FT = air_density(FT(T∞), FT(p∞), param_set)
     translation_speed::FT = 150
     translation_angle::FT = pi / 4
     vortex_speed::FT = 50

--- a/test/DGmethods/Euler/isentropicvortex_multirate.jl
+++ b/test/DGmethods/Euler/isentropicvortex_multirate.jl
@@ -32,6 +32,8 @@ using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
 
+param_set = ParameterSet()
+
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
 
 if !@isdefined integration_testing
@@ -164,7 +166,7 @@ function run(
         source = nothing,
         boundarycondition = (),
         init_state = isentropicvortex_initialcondition!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
     # The linear model has the fast time scales
     fast_model = AtmosAcousticLinearModel(model)
@@ -302,7 +304,7 @@ end
 Base.@kwdef struct IsentropicVortexSetup{FT}
     p∞::FT = 10^5
     T∞::FT = 300
-    ρ∞::FT = air_density(FT(T∞), FT(p∞), ParameterSet{FT}())
+    ρ∞::FT = air_density(FT(T∞), FT(p∞), param_set)
     translation_speed::FT = 150
     translation_angle::FT = pi / 4
     vortex_speed::FT = 50

--- a/test/DGmethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current_model.jl
@@ -26,6 +26,7 @@ using CLIMA.Atmos: vars_state, vars_aux
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 if !@isdefined integration_testing
     const integration_testing = parse(
@@ -136,7 +137,7 @@ function run(
         turbulence = AnisoMinDiss{FT}(1),
         source = source,
         init_state = Initialise_Density_Current!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
     # -------------- Define dgbalancelaw --------------------------- #
     dg = DGModel(

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -21,6 +21,7 @@ using Test
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 if !@isdefined integration_testing
     const integration_testing = parse(
@@ -161,7 +162,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
             source = mms2_source!,
             boundarycondition = InitStateBC(),
             init_state = mms2_init_state!,
-            param_set = ParameterSet{FT}(),
+            param_set = param_set,
         )
     else
         model = AtmosModel{FT}(
@@ -173,7 +174,7 @@ function run(mpicomm, ArrayType, dim, topl, warpfun, N, timeend, FT, dt)
             source = mms3_source!,
             boundarycondition = InitStateBC(),
             init_state = mms3_init_state!,
-            param_set = ParameterSet{FT}(),
+            param_set = param_set,
         )
     end
 

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -20,6 +20,7 @@ using CLIMA.VTK
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 if !@isdefined integration_testing
     const integration_testing = parse(
@@ -52,7 +53,7 @@ function run1(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
         AtmosLESConfigType;
         ref_state = HydrostaticState(IsothermalProfile(T_s), RH),
         init_state = init_state!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
 
     dg = DGModel(
@@ -89,7 +90,7 @@ function run2(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
             RH,
         ),
         init_state = init_state!,
-        param_set = ParameterSet{FT}(),
+        param_set = param_set,
     )
 
     dg = DGModel(

--- a/test/DGmethods/courant.jl
+++ b/test/DGmethods/courant.jl
@@ -35,6 +35,7 @@ using CLIMA.ODESolvers
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 using CLIMA.MoistThermodynamics:
     air_density, total_energy, internal_energy, soundspeed_air
@@ -120,7 +121,7 @@ let
                     source = Gravity(),
                     boundarycondition = (),
                     init_state = initialcondition!,
-                    param_set = ParameterSet{FT}(),
+                    param_set = param_set,
                 )
 
                 dg = DGModel(

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -12,6 +12,10 @@ using CLIMA.Grids
 using CLIMA.ODESolvers
 using CLIMA.GenericCallbacks: EveryXSimulationSteps
 using CLIMA.Mesh.Filters
+using CLIMA.Parameters
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 Base.@kwdef struct AcousticWaveSetup{FT}
     domain_height::FT = 10e3
@@ -76,7 +80,7 @@ function main()
         moisture = DryModel(),
         source = Gravity(),
         init_state = setup,
-        param_set = CLIMA.ParameterSet{FT}(),
+        param_set = param_set,
     )
 
     ode_solver = CLIMA.MultirateSolverType(

--- a/test/Mesh/interpolation.jl
+++ b/test/Mesh/interpolation.jl
@@ -32,6 +32,8 @@ using CLIMA.Atmos: vars_state, vars_aux
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
+
 
 using Random
 using Statistics
@@ -130,7 +132,7 @@ function run_brick_interpolation_test()
             turbulence = ConstantViscosityWithDivergence(FT(0)),
             source = (Gravity(),),
             init_state = Initialize_Brick_Interpolation_Test!,
-            param_set = ParameterSet{FT}(),
+            param_set = param_set,
         )
 
         dg = DGModel(
@@ -308,7 +310,7 @@ function run_cubed_sphere_interpolation_test()
             moisture = DryModel(),
             source = nothing,
             init_state = setup,
-            param_set = ParameterSet{FT}(),
+            param_set = param_set,
         )
 
         dg = DGModel(


### PR DESCRIPTION
# Description

Removes `FT` from `ParameterSet`. Trade-offs of including/excluding `FT`:

 - Cannot make a single global instance of `ParameterSet`, since `FT` is needed and is only known within each function. This is especially a problem for drivers without a balance law since they cannot create a local copy.
 - We cannot make generic typed types, e.g., `foo(param_set::PS{FT}) where {FT,PS}`, so it's inconvenient without a single global abstract type for `ParameterSet`.
 - Including `FT` does alleviate needing to use `FT` around functions (e.g., `FT(grav(param_set))`), but the main purpose of `ParameterSet` is really to decide which set of parameters to use, not their float type, so it's not really an orthogonal design to include `FT`.


<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
