### PR TITLE
Use `@test`, not `@assert` in TDMA tests

### DIFF
--- a/test/Atmos/Parameterizations/TurbulenceConvection/TDMA.jl
+++ b/test/Atmos/Parameterizations/TurbulenceConvection/TDMA.jl
@@ -6,51 +6,50 @@ using CLIMA.TurbulenceConvection.TriDiagSolvers
 TDMA = TriDiagSolvers
 
 @testset "TriDiagSolvers" begin
-  N = 2:10
-  for n in N
-    dl = rand(n-1)
-    du = rand(n-1)
-    d = rand(n);
+    N = 2:10
+    for n in N
+        dl = rand(n - 1)
+        du = rand(n - 1)
+        d = rand(n)
 
-    A = Array(Tridiagonal(dl, d, du))
-    b = rand(length(d))
+        A = Array(Tridiagonal(dl, d, du))
+        b = rand(length(d))
 
-    x_correct = inv(A)*b
+        x_correct = inv(A) * b
 
-    xtemp = zeros(n)
-    gamma = zeros(n-1)
-    beta = zeros(n)
-    x_TDMA = zeros(n)
+        xtemp = zeros(n)
+        gamma = zeros(n - 1)
+        beta = zeros(n)
+        x_TDMA = zeros(n)
 
-    solve_tridiag!(x_TDMA, b, dl, d, du, n, xtemp, gamma, beta)
-    tol = eps(Float32)
+        solve_tridiag!(x_TDMA, b, dl, d, du, n, xtemp, gamma, beta)
+        tol = eps(Float32)
 
-    err = [abs(x-y) for (x, y) in zip(x_correct, x_TDMA)]
-    # @show eps(Float64)
-    # @show "Full", err
-    if !all([x<tol for x in err])
-        @show tol
-        @show "Full", err
+        err = [abs(x - y) for (x, y) in zip(x_correct, x_TDMA)]
+        # @show eps(Float64)
+        # @show "Full", err
+        if !all([x < tol for x in err])
+            @show tol
+            @show "Full", err
+        end
+        @test all([x < tol for x in err])
+
+        init_β_γ!(beta, gamma, dl, d, du, n)
+        solve_tridiag_stored!(x_TDMA, b, dl, beta, gamma, n, xtemp)
+
+        err = [abs(x - y) for (x, y) in zip(x_correct, x_TDMA)]
+        # @show "Stored", err
+        @test all([x < tol for x in err])
+
+        dl_mod = zeros(n)
+        dl_mod[2:end] = dl
+        du_mod = zeros(n)
+        du_mod[1:(end - 1)] = du
+        TDMA.solve_tridiag_old(n, b, dl_mod, d, du_mod)
+        x_TDMA = b
+        err = [abs(x - y) for (x, y) in zip(x_correct, x_TDMA)]
+        # @show "old", err
+        @test all([x < tol for x in err])
+
     end
-    @assert all([x<tol for x in err])
-
-    init_β_γ!(beta, gamma, dl, d, du, n)
-    solve_tridiag_stored!(x_TDMA, b, dl, beta, gamma, n, xtemp)
-
-    err = [abs(x-y) for (x, y) in zip(x_correct, x_TDMA)]
-    # @show "Stored", err
-    @assert all([x<tol for x in err])
-
-    dl_mod = zeros(n)
-    dl_mod[2:end] = dl
-    du_mod = zeros(n)
-    du_mod[1:end-1] = du
-    TDMA.solve_tridiag_old(n, b, dl_mod, d, du_mod)
-    x_TDMA = b
-    err = [abs(x-y) for (x, y) in zip(x_correct, x_TDMA)]
-    # @show "old", err
-    @assert all([x<tol for x in err])
-
-  end
 end
-


### PR DESCRIPTION
# Description

Changes are a bit obscured by formatting. Essentially, all 3 `@test` lines were `@assert`s.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
