### PR TITLE
Remove PlanetParameters from top layer (tests, experiments, examples)

### DIFF
--- a/docs/src/Atmos/EDMFEquations.md
+++ b/docs/src/Atmos/EDMFEquations.md
@@ -147,7 +147,7 @@
 
 This document is concerned with defining the set of equations solved in the atmospheric turbulence convection model: the EDMF equations. Color-coding is used to indicate:
 
- - $\paramT{Constant parameters that are fixed in space and time (e.g., those defined in PlanetParameters.jl)}$
+ - $\paramT{Constant parameters that are fixed in space and time (e.g., those defined in CLIMAParameters.jl)}$
 
  - $\simparamT{Single column (SC) inputs (e.g., variables that are fed into the SC model from the dynamical core (e.g., horizontal velocity))}$
 

--- a/docs/src/Atmos/Microphysics.md
+++ b/docs/src/Atmos/Microphysics.md
@@ -263,8 +263,14 @@ The values of ``a_{vent}`` and ``b_{vent}`` are chosen so that at ``q_{tot} = 15
 ```@example rain_evaporation
 using CLIMA.Microphysics
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 using Plots
+using CLIMA.UniversalConstants
+using CLIMA.Parameters
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
+
+param_set = ParameterSet()
 
 # eq. 5c in Smolarkiewicz and Grabowski 1996
 # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
@@ -287,8 +293,8 @@ end
 
 # example values
 T, p = 273.15 + 15, 90000.
-ϵ = 1. / molmass_ratio
-p_sat = saturation_vapor_pressure(T, Liquid())
+ϵ = 1. / molmass_ratio(param_set)
+p_sat = saturation_vapor_pressure(T, Liquid(), param_set)
 q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1.))
 q_rain_range = range(1e-8, stop=5e-3, length=100)
 q_tot = 15e-3
@@ -296,7 +302,7 @@ q_vap = 0.15 * q_sat
 q_ice = 0.
 q_liq = q_tot - q_vap - q_ice
 q = PhasePartition(q_tot, q_liq, q_ice)
-R = gas_constant_air(q)
+R = gas_constant_air(q, param_set)
 ρ = p / R / T
 
 plot(q_rain_range * 1e3,  [conv_q_rai_to_q_vap(q_rai, q, T, p, ρ) for q_rai in q_rain_range], xlabel="q_rain [g/kg]", ylabel="rain evaporation rate [1/s]", title="Rain evaporation", label="CLIMA")

--- a/examples/DGmethods_old/ex_003_acoustic_wave.jl
+++ b/examples/DGmethods_old/ex_003_acoustic_wave.jl
@@ -49,13 +49,12 @@ using CLIMA.GenericCallbacks
 
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
-# We will depend on MoistThermodynamics's default Parameters:
-include(joinpath(clima_dir, "..", "Parameters", "EarthParameters.jl"))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 
 # Though not required, here we are explicit about which values we read out the
-# `PlanetParameters` and `MoistThermodynamics`
-using CLIMA.PlanetParameters: planet_radius, grav, MSLP
+# `MoistThermodynamics`
 using CLIMA.MoistThermodynamics:
     air_temperature,
     air_pressure,
@@ -232,14 +231,14 @@ end
 function auxiliary_state_initialization!(T0, aux, x, y, z)
     @inbounds begin
         FT = eltype(aux)
-        p0 = FT(MSLP)
+        p0 = FT(MSLP(param_set))
 
         ## Convert to Spherical coordinates
         (r, _, _) = cartesian_to_spherical(FT, x, y, z)
 
         ## Calculate the geopotential ϕ
-        h = r - FT(planet_radius) # height above the planet surface
-        ϕ = FT(grav) * h
+        h = r - FT(planet_radius(param_set)) # height above the planet surface
+        ϕ = FT(grav(param_set)) * h
 
         ## Pressure assuming hydrostatic balance
         P_ref = p0 * exp(-ϕ / (gas_constant_air(FT) * T0))
@@ -269,10 +268,10 @@ end
 function initialcondition!(domain_height, Q, x, y, z, aux, _...)
     @inbounds begin
         FT = eltype(Q)
-        p0 = FT(MSLP)
+        p0 = FT(MSLP(param_set))
 
         (r, λ, φ) = cartesian_to_spherical(FT, x, y, z)
-        h = r - FT(planet_radius)
+        h = r - FT(planet_radius(param_set))
 
         ## Get the reference pressure from the previously defined reference state
         ρ_ref, ρe_ref, ϕ = aux[_a_ρ_ref], aux[_a_ρe_ref], aux[_a_ϕ]
@@ -354,9 +353,9 @@ function setupDG(
 
     ## Create the element grid in the vertical direction
     Rrange = range(
-        FT(planet_radius),
+        FT(planet_radius(param_set)),
         length = Ne_vertical + 1,
-        stop = planet_radius + domain_height,
+        stop = FT(planet_radius(param_set)) + domain_height,
     )
 
     ## Set up the mesh topology for the sphere

--- a/experiments/OceanBoxGCM/ocean_gyre.jl
+++ b/experiments/OceanBoxGCM/ocean_gyre.jl
@@ -4,14 +4,22 @@ using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
-using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
+
+using CLIMA.Parameters
+using CLIMA.UniversalConstants
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
+param_set = ParameterSet()
+
 
 function config_simple_box(FT, N, resolution, dimensions)
     prob = OceanGyre{FT}(dimensions...)
 
-    cʰ = sqrt(grav * prob.H) # m/s
+    _grav = grav(param_set)
+    cʰ = sqrt(_grav * prob.H) # m/s
     model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
 
     config = CLIMA.OceanBoxGCMConfiguration("ocean_gyre", N, resolution, model)

--- a/test/Common/MoistThermodynamics/runtests.jl
+++ b/test/Common/MoistThermodynamics/runtests.jl
@@ -13,8 +13,8 @@ float_types = [Float32, Float64]
 using CLIMA
 using CLIMA.Parameters
 const clima_dir = dirname(pathof(CLIMA))
-# We will depend on MoistThermodynamics's default Parameters:
-include(joinpath(clima_dir, "..", "Parameters", "EarthParameters.jl"))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+param_set = ParameterSet()
 
 include("testdata.jl")
 

--- a/test/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -11,7 +11,6 @@ using CLIMA.GeneralizedMinimalResidualSolver
 using CLIMA.ColumnwiseLUSolver: ManyColumnLU
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
-using CLIMA.PlanetParameters: planet_radius, day
 using CLIMA.MoistThermodynamics:
     air_density,
     soundspeed_air,
@@ -37,9 +36,11 @@ using CLIMA.Atmos:
     gravitational_potential
 using CLIMA.VariableTemplates: flattenednames
 
-using CLIMA.Parameters
+using CLIMA.Parameters: planet_radius
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
@@ -102,9 +103,10 @@ function run(
 
     setup = AcousticWaveSetup{FT}()
 
+    _planet_radius = FT(planet_radius(param_set))
     vert_range = grid1d(
-        FT(planet_radius),
-        FT(planet_radius + setup.domain_height),
+        _planet_radius,
+        FT(_planet_radius + setup.domain_height),
         nelem = numelem_vert,
     )
     topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)

--- a/test/DGmethods/Euler/isentropicvortex_imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex_imex.jl
@@ -10,7 +10,6 @@ using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
-using CLIMA.PlanetParameters: kappa_d
 using CLIMA.MoistThermodynamics:
     air_density, total_energy, internal_energy, soundspeed_air
 using CLIMA.Atmos:
@@ -28,9 +27,11 @@ using CLIMA.Atmos:
 using CLIMA.VariableTemplates: @vars, Vars, flattenednames
 import CLIMA.Atmos: atmos_init_aux!, vars_aux
 
-using CLIMA.Parameters
+using CLIMA.Parameters: kappa_d
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
@@ -353,9 +354,11 @@ function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
     end
     u = u∞ .+ SVector(δu_x, δu_y, 0)
 
-    T = T∞ * (1 - kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    _kappa_d = FT(kappa_d(param_set))
+
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
     # adiabatic/isentropic relation
-    p = p∞ * (T / T∞)^(FT(1) / kappa_d)
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
     ρ = air_density(T, p, bl.param_set)
 
     state.ρ = ρ

--- a/test/DGmethods/Euler/isentropicvortex_multirate.jl
+++ b/test/DGmethods/Euler/isentropicvortex_multirate.jl
@@ -10,7 +10,6 @@ using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
-using CLIMA.PlanetParameters: kappa_d
 using CLIMA.MoistThermodynamics:
     air_density, total_energy, internal_energy, soundspeed_air
 using CLIMA.Atmos:
@@ -28,10 +27,11 @@ using CLIMA.Atmos:
 using CLIMA.VariableTemplates: @vars, Vars, flattenednames
 import CLIMA.Atmos: atmos_init_aux!, vars_aux
 
-using CLIMA.Parameters
+using CLIMA.Parameters: kappa_d
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
-
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
@@ -360,9 +360,11 @@ function isentropicvortex_initialcondition!(bl, state, aux, coords, t, setup)
     end
     u = u∞ .+ SVector(δu_x, δu_y, 0)
 
-    T = T∞ * (1 - kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    _kappa_d = FT(kappa_d(param_set))
+
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
     # adiabatic/isentropic relation
-    p = p∞ * (T / T∞)^(FT(1) / kappa_d)
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
     ρ = air_density(T, p, bl.param_set)
 
     state.ρ = ρ

--- a/test/DGmethods/compressible_Navier_Stokes/density_current_model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/density_current_model.jl
@@ -14,7 +14,6 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 using CLIMA.SubgridScaleParameters
 using LinearAlgebra
 using StaticArrays
@@ -24,8 +23,10 @@ using Random
 using CLIMA.Atmos: vars_state, vars_aux
 
 using CLIMA.Parameters
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 if !@isdefined integration_testing
@@ -68,10 +69,11 @@ function Initialise_Density_Current!(
     t,
 )
     FT = eltype(state)
-    R_gas::FT = R_d
-    c_p::FT = cp_d
-    c_v::FT = cv_d
-    p0::FT = MSLP
+    R_gas::FT = R_d(param_set)
+    c_p::FT = cp_d(param_set)
+    c_v::FT = cv_d(param_set)
+    p0::FT = MSLP(param_set)
+    _grav::FT = grav(param_set)
     # initialise with dry domain
     q_tot::FT = 0
     q_liq::FT = 0
@@ -90,7 +92,7 @@ function Initialise_Density_Current!(
     end
     qvar = PhasePartition(q_tot)
     θ = θ_ref + Δθ # potential temperature
-    π_exner = FT(1) - grav / (c_p * θ) * x3 # exner pressure
+    π_exner = FT(1) - _grav / (c_p * θ) * x3 # exner pressure
     ρ = p0 / (R_gas * θ) * (π_exner)^(c_v / R_gas) # density
 
     ts = LiquidIcePotTempSHumEquil(θ, ρ, q_tot, bl.param_set)

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -11,7 +11,6 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates
@@ -19,8 +18,10 @@ using CLIMA.VTK
 using Test
 
 using CLIMA.Parameters
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 if !@isdefined integration_testing

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -11,15 +11,16 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates
 using CLIMA.VTK
 
 using CLIMA.Parameters
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 if !@isdefined integration_testing

--- a/test/DGmethods/courant.jl
+++ b/test/DGmethods/courant.jl
@@ -12,7 +12,6 @@ using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry, courant
 using CLIMA.DGmethods.NumericalFluxes:
     Rusanov, CentralNumericalFluxGradient, CentralNumericalFluxDiffusive
 using CLIMA.Courant
-using CLIMA.PlanetParameters: kappa_d
 using CLIMA.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
@@ -32,9 +31,11 @@ using CLIMA.Atmos:
 using CLIMA.Atmos
 using CLIMA.ODESolvers
 
-using CLIMA.Parameters
+using CLIMA.Parameters: kappa_d
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 using CLIMA.MoistThermodynamics:
@@ -62,7 +63,7 @@ function initialcondition!(bl, state, aux, coords, t)
     u = u∞
     T = FT(T∞)
     # adiabatic/isentropic relation
-    p = FT(p∞) * (T / FT(T∞))^(FT(1) / FT(kappa_d))
+    p = FT(p∞) * (T / FT(T∞))^(FT(1) / FT(kappa_d(param_set)))
     ρ = air_density(T, p, bl.param_set)
 
     state.ρ = ρ

--- a/test/DGmethods/horizontal_integral_test.jl
+++ b/test/DGmethods/horizontal_integral_test.jl
@@ -16,7 +16,13 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
+
+using CLIMA.Parameters
+using CLIMA.UniversalConstants
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
+param_set = ParameterSet()
 
 function run_test1(mpicomm, dim, Ne, N, FT, ArrayType)
   warpfun = (ξ1, ξ2, ξ3) -> begin

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -13,8 +13,14 @@ using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
 using CLIMA.MoistThermodynamics
 using CLIMA.ODESolvers
-using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
+
+using CLIMA.Parameters: grav, MSLP
+using CLIMA.UniversalConstants
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
+param_set = ParameterSet()
 
 function init_sin_test!(bl, state, aux, (x, y, z), t)
     FT = eltype(state)
@@ -22,11 +28,12 @@ function init_sin_test!(bl, state, aux, (x, y, z), t)
     z = FT(z)
 
     # These constants are those used by Stevens et al. (2005)
+    _grav = FT(grav(param_set))
     qref = FT(9.0e-3)
     q_pt_sfc = PhasePartition(qref)
-    Rm_sfc = FT(gas_constant_air(q_pt_sfc))
+    Rm_sfc = FT(gas_constant_air(q_pt_sfc, param_set))
     T_sfc = FT(292.5)
-    P_sfc = FT(MSLP)
+    P_sfc = FT(MSLP(param_set))
 
     # Specify moisture profiles
     q_liq = FT(0)
@@ -55,7 +62,7 @@ function init_sin_test!(bl, state, aux, (x, y, z), t)
     v = FT(5 + 2 * sin(2 * π * ((x / 1500) + (y / 1500))))
 
     # Pressure
-    H = Rm_sfc * T_sfc / grav
+    H = Rm_sfc * T_sfc / _grav
     p = P_sfc * exp(-z / H)
 
     # Density, Temperature
@@ -63,7 +70,7 @@ function init_sin_test!(bl, state, aux, (x, y, z), t)
     ρ = air_density(ts)
 
     e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))
-    e_pot = grav * z
+    e_pot = _grav * z
     E = ρ * total_energy(e_kin, e_pot, ts)
 
     state.ρ = ρ

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -4,17 +4,18 @@ using Test
 using CLIMA
 using CLIMA.Atmos
 using CLIMA.ConfigTypes
-using CLIMA.PlanetParameters
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
 using CLIMA.Grids
 using CLIMA.ODESolvers
 using CLIMA.GenericCallbacks: EveryXSimulationSteps
 using CLIMA.Mesh.Filters
+
 using CLIMA.Parameters
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 Base.@kwdef struct AcousticWaveSetup{FT}
@@ -39,7 +40,7 @@ function (setup::AcousticWaveSetup)(bl, state, aux, coords, t)
     Δp = setup.γ * f * g
     p = aux.ref_state.p + Δp
 
-    ts = PhaseDry_given_pT(p, setup.T_ref)
+    ts = PhaseDry_given_pT(p, setup.T_ref, param_set)
     q_pt = PhasePartition(ts)
     e_pot = gravitational_potential(bl.orientation, aux)
     e_int = internal_energy(ts)

--- a/test/Mesh/interpolation.jl
+++ b/test/Mesh/interpolation.jl
@@ -20,7 +20,6 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 using CLIMA.TicToc
 using LinearAlgebra
 using StaticArrays
@@ -30,8 +29,10 @@ using CLIMA.VTK
 using CLIMA.Atmos: vars_state, vars_aux
 
 using CLIMA.Parameters
+using CLIMA.UniversalConstants
 const clima_dir = dirname(pathof(CLIMA))
 include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
 param_set = ParameterSet()
 
 
@@ -76,7 +77,7 @@ function (setup::TestSphereSetup)(bl, state, aux, coords, t)
 
     z = altitude(bl.orientation, aux)
 
-    scale_height = R_d * setup.T_initial / grav
+    scale_height = R_d * setup.T_initial / FT(grav(param_set))
     p = setup.p_ground * exp(-z / scale_height)
     e_int = internal_energy(setup.T_initial, bl.param_set)
     e_pot = gravitational_potential(bl.orientation, aux)
@@ -279,9 +280,10 @@ function run_cubed_sphere_interpolation_test()
         CLIMA.Mesh.Grids.vgeoid.x3id
         _ρ, _ρu, _ρv, _ρw = 1, 2, 3, 4
         #-------------------------
+        _planet_radius = FT(planet_radius)
         vert_range = grid1d(
-            FT(planet_radius),
-            FT(planet_radius + domain_height),
+            _planet_radius,
+            FT(_planet_radius + domain_height),
             nelem = numelem_vert,
         )
 
@@ -329,9 +331,10 @@ function run_cubed_sphere_interpolation_test()
         x2 = @view grid.vgeo[:, _y, :]
         x3 = @view grid.vgeo[:, _z, :]
 
-        xmax = FT(planet_radius)
-        ymax = FT(planet_radius)
-        zmax = FT(planet_radius)
+        _planet_radius = FT(planet_radius(param_set))
+        xmax = _planet_radius
+        ymax = _planet_radius
+        zmax = _planet_radius
 
         fcn(x, y, z) = sin.(x) .* cos.(y) .* cos.(z) # sample function
 

--- a/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
@@ -4,15 +4,22 @@ using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
-using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
 import CLIMA.DGmethods: vars_state
 
+using CLIMA.Parameters: grav
+using CLIMA.UniversalConstants
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
+param_set = ParameterSet()
+
 function config_simple_box(FT, N, resolution, dimensions)
     prob = HomogeneousBox{FT}(dimensions...)
 
-    cʰ = sqrt(grav * prob.H) # m/s
+    _grav = FT(grav(param_set))
+    cʰ = sqrt(_grav * prob.H) # m/s
     model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
 
     config =

--- a/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
@@ -4,14 +4,21 @@ using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
-using CLIMA.PlanetParameters
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
+
+using CLIMA.Parameters
+using CLIMA.UniversalConstants
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
+param_set = ParameterSet()
 
 function config_simple_box(FT, N, resolution, dimensions)
     prob = OceanGyre{FT}(dimensions...)
 
-    cʰ = sqrt(grav * prob.H) # m/s
+    _grav = FT(grav(param_set))
+    cʰ = sqrt(_grav * prob.H) # m/s
     model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
 
     config = CLIMA.OceanBoxGCMConfiguration("ocean_gyre", N, resolution, model)

--- a/test/Ocean/ShallowWater/GyreInABox.jl
+++ b/test/Ocean/ShallowWater/GyreInABox.jl
@@ -13,10 +13,16 @@ using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates
 using CLIMA.VTK
-using CLIMA.PlanetParameters: grav
 import CLIMA.ShallowWater: shallow_init_state!, shallow_init_aux!, vars_state, vars_aux,
                     shallow_boundary_state!, TurbulenceClosure, LinearDrag,
                     ConstantViscosity, AdvectionTerm, NonLinearAdvection
+
+using CLIMA.Parameters
+using CLIMA.UniversalConstants
+const clima_dir = dirname(pathof(CLIMA))
+include(joinpath(clima_dir, "..", "Parameters", "Parameters.jl"))
+using CLIMA.Parameters.Planet
+param_set = ParameterSet()
 
 struct GyreInABox{T} <: SWProblem
   τₒ::T
@@ -90,7 +96,7 @@ function gyre_init_state!(p::GyreInABox, T::LinearDrag, state,
   ϵ  = γ / (Lˣ * β)
 
   uˢ(ϵ) = (τₒ * D(ϵ)) / (H * γ * π)
-  hˢ(ϵ) = (fₒ * Lˣ * uˢ(ϵ)) / grav
+  hˢ(ϵ) = (fₒ * Lˣ * uˢ(ϵ)) / FT(grav(param_set))
 
   u = uˢ(ϵ) * 𝒰(coords[1]/Lˣ, coords[2]/Lʸ, ϵ)
   v = uˢ(ϵ) * 𝒱(coords[1]/Lˣ, coords[2]/Lʸ, ϵ)
@@ -124,7 +130,7 @@ function gyre_init_state!(p::GyreInABox, V::ConstantViscosity, state, aux,
   ν  = V.ν
 
   δᵐ = (ν / β)^(1/3)
-  C  = τₒ / (grav*H) * (fₒ/β)
+  C  = τₒ / (FT(grav(param_set))*H) * (fₒ/β)
 
   state.η = η_munk(coords[1], coords[2], Lˣ, Lʸ, δᵐ, C)
   state.U = @SVector zeros(T, 3)


### PR DESCRIPTION
# Description

 - Removes PlanetParameters from several examples
 - Removes use of `EarthParameters`, which was a MoistThermodynamics copy to allow for default behavior within moist thermo


<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
