### PR TITLE
Move GCM driver test from AzureCI to SlurmCI

### DIFF
--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -30,6 +30,7 @@ cpu_gpu = [
   { file = "test/DGmethods_old/sphere/advection_sphere_lsrk.jl", slurmargs = ["--ntasks=2"], args = [] },
   { file = "test/DGmethods_old/sphere/advection_sphere_ssp33.jl", slurmargs = ["--ntasks=2"], args = [] },
   { file = "test/DGmethods_old/sphere/advection_sphere_ssp34.jl", slurmargs = ["--ntasks=2"], args = [] },
+  { file = "test/Driver/gcm_driver_test.jl", slurmargs = ["--ntasks=1"], args = [] },
   { file = "test/LinearSolvers/poisson.jl", slurmargs = ["--ntasks=2"], args = [] },
   { file = "test/LinearSolvers/columnwiselu.jl", slurmargs = ["--ntasks=1"], args = []},
   { file = "test/LinearSolvers/bandedsystem.jl", slurmargs = ["--ntasks=3", "--time=02:00:00"], args = [] },

--- a/test/Driver/runtests.jl
+++ b/test/Driver/runtests.jl
@@ -2,7 +2,9 @@ using MPI, Test
 include("../testhelpers.jl")
 
 @testset "Driver" begin
-    tests = [(1, "driver_test.jl"), (1, "gcm_driver_test.jl")]
+    tests = [
+        (1, "driver_test.jl"),
+    ]
 
     runmpi(tests, @__FILE__)
 end


### PR DESCRIPTION
# Description

Closes #879.

Running with code coverage causes this test to take over an hour -- without code coverage it completes in two minutes. This moves the test to SlurmCI until code coverage slowdowns are sorted.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
