### PR TITLE
Improve implicit time stepper interface

### DIFF
--- a/src/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -319,11 +319,6 @@ function dostep!(
 
         # solves
         # Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_linear!(Q_tt)
-        α = dt * RKA_implicit[istage, istage]
-        linearoperator! = function (LQ, Q)
-            rhs_linear!(LQ, Q, p, stagetime; increment = false)
-            @. LQ = Q - α * LQ
-        end
         linearsolve!(
             implicitoperator!,
             linearsolver,

--- a/src/ODESolvers/LowStorageRungeKuttaMethod.jl
+++ b/src/ODESolvers/LowStorageRungeKuttaMethod.jl
@@ -76,10 +76,10 @@ end
 
 """
     dostep!(Q, lsrk::LowStorageRungeKutta2N, p, time::Real,
-                       dt::Real, [slow_δ, slow_rv_dQ, slow_scaling])
+            [slow_δ, slow_rv_dQ, slow_scaling])
 
 Use the 2N low storage Runge--Kutta method `lsrk` to step `Q` forward in time
-from the current time `time` to final time `time + dt`.
+from the current time `time` to final time `time + getdt(lsrk)`.
 
 If the optional parameter `slow_δ !== nothing` then `slow_rv_dQ * slow_δ` is
 added as an additionall ODE right-hand side source. If the optional parameter
@@ -91,11 +91,12 @@ function dostep!(
     lsrk::LowStorageRungeKutta2N,
     p,
     time,
-    dt,
     slow_δ = nothing,
     slow_rv_dQ = nothing,
     in_slow_scaling = nothing,
 )
+    dt = lsrk.dt
+
     RKA, RKB, RKC = lsrk.RKA, lsrk.RKB, lsrk.RKC
     rhs!, dQ = lsrk.rhs!, lsrk.dQ
 

--- a/src/ODESolvers/MultirateInfinitesimalStepMethod.jl
+++ b/src/ODESolvers/MultirateInfinitesimalStepMethod.jl
@@ -148,7 +148,8 @@ mutable struct MultirateInfinitesimalStep{
     end
 end
 
-function dostep!(Q, mis::MultirateInfinitesimalStep, p, time, dt)
+function dostep!(Q, mis::MultirateInfinitesimalStep, p, time)
+    dt = mis.dt
     FT = eltype(dt)
     α = mis.α
     β = mis.β
@@ -199,8 +200,9 @@ function dostep!(Q, mis::MultirateInfinitesimalStep, p, time, dt)
         # TODO: we want to be able to write
         #   solve!(Q, fastsolver, p; numberofsteps = mis.nsubsteps)  #(1c)
         # especially if we want to use StormerVerlet, but need some way to pass in `offset`
+        updatedt!(fastsolver, dτ)
         for k in 1:(mis.nsubsteps)
-            dostep!(Q, fastsolver, p, τ, dτ, FT(1), realview(offset))  #(1c)
+            dostep!(Q, fastsolver, p, τ, FT(1), realview(offset))  #(1c)
             τ += dτ
         end
     end

--- a/src/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
+++ b/src/ODESolvers/StrongStabilityPreservingRungeKuttaMethod.jl
@@ -90,10 +90,10 @@ end
 
 """
     ODESolvers.dostep!(Q, ssp::StrongStabilityPreservingRungeKutta, p,
-                       time::Real, dt::Real, [slow_δ, slow_rv_dQ, slow_scaling])
+                       time::Real, [slow_δ, slow_rv_dQ, slow_scaling])
 
 Use the strong stability preserving Runge--Kutta method `ssp` to step `Q`
-forward in time from the current time `time` to final time `time + dt`.
+forward in time from the current time `time` to final time `time + getdt(ssp)`.
 
 If the optional parameter `slow_δ !== nothing` then `slow_rv_dQ * slow_δ` is
 added as an additional ODE right-hand side source. If the optional parameter
@@ -105,11 +105,11 @@ function dostep!(
     ssp::StrongStabilityPreservingRungeKutta,
     p,
     time,
-    dt,
     slow_δ = nothing,
     slow_rv_dQ = nothing,
     in_slow_scaling = nothing,
 )
+    dt = ssp.dt
 
     RKA, RKB, RKC = ssp.RKA, ssp.RKB, ssp.RKC
     rhs! = ssp.rhs!


### PR DESCRIPTION
Some cleanup for the ARK routines:
- fixed some long comments
- remove some dead code
- remove `dt` from `dostep!` to force the use of `updatedt!` in order to catch better whether `dt` with implicit solvers can really be changed

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
