### PR TITLE
Remove more use of PlanetParameters

### DIFF
--- a/docs/src/Atmos/EDMFEquations.md
+++ b/docs/src/Atmos/EDMFEquations.md
@@ -147,7 +147,7 @@
 
 This document is concerned with defining the set of equations solved in the atmospheric turbulence convection model: the EDMF equations. Color-coding is used to indicate:
 
- - $\paramT{Constant parameters that are fixed in space and time (e.g., those defined in PlanetParameters.jl)}$
+ - $\paramT{Constant parameters that are fixed in space and time (e.g., those defined in CLIMAParameters.jl)}$
 
  - $\simparamT{Single column (SC) inputs (e.g., variables that are fed into the SC model from the dynamical core (e.g., horizontal velocity))}$
 

--- a/docs/src/Atmos/Microphysics.md
+++ b/docs/src/Atmos/Microphysics.md
@@ -263,14 +263,19 @@ The values of ``a_{vent}`` and ``b_{vent}`` are chosen so that at ``q_{tot} = 15
 ```@example rain_evaporation
 using CLIMA.Microphysics
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
+
+using CLIMAParameters
+using CLIMAParameters.Planet: R_d, planet_radius, grav, MSLP
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
 using Plots
 
 # eq. 5c in Smolarkiewicz and Grabowski 1996
 # https://doi.org/10.1175/1520-0493(1996)124<0487:TTLSLM>2.0.CO;2
 function rain_evap_empirical(q_rai::DT, q::PhasePartition, T::DT, p::DT, ρ::DT) where {DT<:Real}
 
-    q_sat  = q_vap_saturation(T, ρ, q)
+    q_sat  = q_vap_saturation(param_set, T, ρ, q)
     q_vap  = q.tot - q.liq
     rr     = q_rai / (DT(1) - q.tot)
     rv_sat = q_sat / (DT(1) - q.tot)
@@ -288,7 +293,7 @@ end
 # example values
 T, p = 273.15 + 15, 90000.
 ϵ = 1. / molmass_ratio
-p_sat = saturation_vapor_pressure(T, Liquid())
+p_sat = saturation_vapor_pressure(param_set, T, Liquid())
 q_sat = ϵ * p_sat / (p + p_sat * (ϵ - 1.))
 q_rain_range = range(1e-8, stop=5e-3, length=100)
 q_tot = 15e-3
@@ -296,7 +301,7 @@ q_vap = 0.15 * q_sat
 q_ice = 0.
 q_liq = q_tot - q_vap - q_ice
 q = PhasePartition(q_tot, q_liq, q_ice)
-R = gas_constant_air(q)
+R = gas_constant_air(param_set, q)
 ρ = p / R / T
 
 plot(q_rain_range * 1e3,  [conv_q_rai_to_q_vap(q_rai, q, T, p, ρ) for q_rai in q_rain_range], xlabel="q_rain [g/kg]", ylabel="rain evaporation rate [1/s]", title="Rain evaporation", label="CLIMA")

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -1,9 +1,7 @@
-using CLIMA.PlanetParameters
+using ..PlanetParameters
 
 export BoundaryCondition, InitStateBC
 
-
-using CLIMA.PlanetParameters
 export InitStateBC, DYCOMS_BC, RayleighBenardBC
 
 export AtmosBC,

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -8,13 +8,35 @@ vars_aux(::RadiationModel, FT) = @vars()
 vars_integrals(::RadiationModel, FT) = @vars()
 vars_reverse_integrals(::RadiationModel, FT) = @vars()
 
-function atmos_nodal_update_aux!(::RadiationModel, ::AtmosModel, state::Vars, aux::Vars, t::Real) end
+function atmos_nodal_update_aux!(
+    ::RadiationModel,
+    ::AtmosModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
 function preodefun!(::RadiationModel, aux::Vars, state::Vars, t::Real) end
-function integral_set_aux!(::RadiationModel, integ::Vars, state::Vars, aux::Vars) end
+function integral_set_aux!(
+    ::RadiationModel,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+) end
 function integral_load_aux!(::RadiationModel, aux::Vars, integ::Vars) end
-function reverse_integral_set_aux!(::RadiationModel, integ::Vars, state::Vars, aux::Vars) end
+function reverse_integral_set_aux!(
+    ::RadiationModel,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+) end
 function reverse_integral_load_aux!(::RadiationModel, aux::Vars, integ::Vars) end
-function flux_radiation!(::RadiationModel, atmos::AtmosModel, flux::Grad, state::Vars, aux::Vars, t::Real) end
+function flux_radiation!(
+    ::RadiationModel,
+    atmos::AtmosModel,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
 
-struct NoRadiation <: RadiationModel
-end
+struct NoRadiation <: RadiationModel end

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -1,4 +1,4 @@
-using CLIMA.PlanetParameters
+using ..PlanetParameters
 export RadiationModel, NoRadiation
 
 abstract type RadiationModel end

--- a/test/Atmos/Parameterizations/Microphysics/runtests.jl
+++ b/test/Atmos/Parameterizations/Microphysics/runtests.jl
@@ -2,7 +2,7 @@ using Test
 using CLIMA.Microphysics
 using CLIMA.MicrophysicsParameters
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
+using CLIMA.PlanetParameters: R_d, molmass_ratio, grav
 
 @testset "RainDropFallSpeed" begin
     # two typical rain drop sizes

--- a/test/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -11,7 +11,6 @@ using CLIMA.GeneralizedMinimalResidualSolver
 using CLIMA.ColumnwiseLUSolver: ManyColumnLU
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
-using CLIMA.PlanetParameters: planet_radius, day
 using CLIMA.MoistThermodynamics:
     air_density,
     soundspeed_air,
@@ -38,7 +37,7 @@ using CLIMA.Atmos:
 using CLIMA.VariableTemplates: flattenednames
 
 using CLIMAParameters
-using CLIMAParameters.Planet: planet_radius, day, grav
+using CLIMAParameters.Planet: planet_radius
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
@@ -92,9 +91,10 @@ function run(
 
     setup = AcousticWaveSetup{FT}()
 
+    _planet_radius::FT = planet_radius(param_set)
     vert_range = grid1d(
-        FT(planet_radius),
-        FT(planet_radius + setup.domain_height),
+        _planet_radius,
+        FT(_planet_radius + setup.domain_height),
         nelem = numelem_vert,
     )
     topology = StackedCubedSphereTopology(mpicomm, numelem_horz, vert_range)

--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -12,7 +12,6 @@ using CLIMA.ODESolvers
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
-using CLIMA.PlanetParameters: kappa_d
 using CLIMA.MoistThermodynamics:
     air_density, total_energy, soundspeed_air, PhaseDry_given_pT
 using CLIMA.Atmos:
@@ -321,9 +320,10 @@ function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
     end
     u = u∞ .+ SVector(δu_x, δu_y, 0)
 
-    T = T∞ * (1 - kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    _kappa_d::FT = kappa_d(param_set)
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
     # adiabatic/isentropic relation
-    p = p∞ * (T / T∞)^(FT(1) / kappa_d)
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
     ts = PhaseDry_given_pT(p, T, bl.param_set)
     ρ = air_density(ts)
 

--- a/test/DGmethods/Euler/isentropicvortex_imex.jl
+++ b/test/DGmethods/Euler/isentropicvortex_imex.jl
@@ -10,7 +10,6 @@ using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
-using CLIMA.PlanetParameters: kappa_d
 using CLIMA.MoistThermodynamics:
     air_density, total_energy, internal_energy, soundspeed_air
 using CLIMA.Atmos:
@@ -343,9 +342,10 @@ function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
     end
     u = u∞ .+ SVector(δu_x, δu_y, 0)
 
-    T = T∞ * (1 - kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    _kappa_d::FT = kappa_d(param_set)
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
     # adiabatic/isentropic relation
-    p = p∞ * (T / T∞)^(FT(1) / kappa_d)
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
     ρ = air_density(T, p, bl.param_set)
 
     state.ρ = ρ

--- a/test/DGmethods/Euler/isentropicvortex_multirate.jl
+++ b/test/DGmethods/Euler/isentropicvortex_multirate.jl
@@ -10,7 +10,6 @@ using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
 using CLIMA.MPIStateArrays: euclidean_distance
-using CLIMA.PlanetParameters: kappa_d
 using CLIMA.MoistThermodynamics:
     air_density, total_energy, internal_energy, soundspeed_air
 using CLIMA.Atmos:
@@ -349,10 +348,11 @@ function isentropicvortex_initialcondition!(bl, state, aux, coords, t, setup)
         δu_y = vortex_speed * x[1] / R * exp(-(r / R)^2 / 2)
     end
     u = u∞ .+ SVector(δu_x, δu_y, 0)
+    _kappa_d::FT = kappa_d(param_set)
 
-    T = T∞ * (1 - kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
     # adiabatic/isentropic relation
-    p = p∞ * (T / T∞)^(FT(1) / kappa_d)
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
     ρ = air_density(T, p, bl.param_set)
 
     state.ρ = ρ

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -11,7 +11,6 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates

--- a/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -11,14 +11,12 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters: T_min
 using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates
 using CLIMA.VTK
 
 using CLIMAParameters
-using CLIMAParameters.Planet: T_min
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 

--- a/test/DGmethods/courant.jl
+++ b/test/DGmethods/courant.jl
@@ -12,7 +12,6 @@ using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry, courant
 using CLIMA.DGmethods.NumericalFluxes:
     Rusanov, CentralNumericalFluxGradient, CentralNumericalFluxDiffusive
 using CLIMA.Courant
-using CLIMA.PlanetParameters: kappa_d
 using CLIMA.Atmos:
     AtmosModel,
     AtmosAcousticLinearModel,
@@ -58,11 +57,12 @@ function initialcondition!(bl, state, aux, coords, t)
         FT(translation_speed * coords[1]),
         FT(0),
     )
+    _kappa_d::FT = kappa_d(param_set)
 
     u = u∞
     T = FT(T∞)
     # adiabatic/isentropic relation
-    p = FT(p∞) * (T / FT(T∞))^(FT(1) / FT(kappa_d))
+    p = FT(p∞) * (T / FT(T∞))^(FT(1) / _kappa_d)
     ρ = air_density(T, p, bl.param_set)
 
     state.ρ = ρ

--- a/test/DGmethods/horizontal_integral_test.jl
+++ b/test/DGmethods/horizontal_integral_test.jl
@@ -16,7 +16,6 @@ using CLIMA.GenericCallbacks
 using CLIMA.Atmos
 using CLIMA.VariableTemplates
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters
 
 function run_test1(mpicomm, dim, Ne, N, FT, ArrayType)
     warpfun =

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -13,20 +13,26 @@ using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
 using CLIMA.MoistThermodynamics
 using CLIMA.ODESolvers
-using CLIMA.PlanetParameters: grav, MSLP
 using CLIMA.VariableTemplates
+
+using CLIMAParameters
+using CLIMAParameters.Planet: grav, MSLP
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
 
 function init_sin_test!(bl, state, aux, (x, y, z), t)
     FT = eltype(state)
 
     z = FT(z)
+    _grav::FT = grav(param_set)
+    _MSLP::FT = MSLP(param_set)
 
     # These constants are those used by Stevens et al. (2005)
     qref = FT(9.0e-3)
     q_pt_sfc = PhasePartition(qref)
     Rm_sfc = FT(gas_constant_air(q_pt_sfc))
     T_sfc = FT(292.5)
-    P_sfc = FT(MSLP)
+    P_sfc = _MSLP
 
     # Specify moisture profiles
     q_liq = FT(0)
@@ -55,7 +61,7 @@ function init_sin_test!(bl, state, aux, (x, y, z), t)
     v = FT(5 + 2 * sin(2 * π * ((x / 1500) + (y / 1500))))
 
     # Pressure
-    H = Rm_sfc * T_sfc / grav
+    H = Rm_sfc * T_sfc / _grav
     p = P_sfc * exp(-z / H)
 
     # Density, Temperature
@@ -63,7 +69,7 @@ function init_sin_test!(bl, state, aux, (x, y, z), t)
     ρ = air_density(ts)
 
     e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))
-    e_pot = grav * z
+    e_pot = _grav * z
     E = ρ * total_energy(e_kin, e_pot, ts)
 
     state.ρ = ρ

--- a/test/Driver/driver_test.jl
+++ b/test/Driver/driver_test.jl
@@ -3,23 +3,28 @@ using Test
 
 using CLIMA
 using CLIMA.Atmos
-using CLIMA.PlanetParameters: grav, MSLP
 using CLIMA.MoistThermodynamics
-using CLIMA.PlanetParameters: grav, MSLP
 using CLIMA.VariableTemplates
 using CLIMA.Grids
+
+using CLIMAParameters
+using CLIMAParameters.Planet: grav, MSLP
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
 
 function init_test!(bl, state, aux, (x, y, z), t)
     FT = eltype(state)
 
     z = FT(z)
+    _grav::FT = grav(param_set)
+    _MSLP::FT = MSLP(param_set)
 
     # These constants are those used by Stevens et al. (2005)
     qref = FT(9.0e-3)
     q_pt_sfc = PhasePartition(qref)
     Rm_sfc = FT(gas_constant_air(q_pt_sfc))
     T_sfc = FT(290.4)
-    P_sfc = FT(MSLP)
+    P_sfc = _MSLP
 
     # Specify moisture profiles
     q_liq = FT(0)
@@ -33,7 +38,7 @@ function init_test!(bl, state, aux, (x, y, z), t)
     u, v, w = ugeo, vgeo, FT(0)
 
     # Pressure
-    H = Rm_sfc * T_sfc / grav
+    H = Rm_sfc * T_sfc / _grav
     p = P_sfc * exp(-z / H)
 
     # Density, Temperature
@@ -41,7 +46,7 @@ function init_test!(bl, state, aux, (x, y, z), t)
     ρ = air_density(ts)
 
     e_kin = FT(1 / 2) * FT((u^2 + v^2 + w^2))
-    e_pot = grav * z
+    e_pot = _grav * z
     E = ρ * total_energy(e_kin, e_pot, ts)
 
     state.ρ = ρ

--- a/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
@@ -4,15 +4,20 @@ using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
-using CLIMA.PlanetParameters: grav
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
 import CLIMA.DGmethods: vars_state
 
+using CLIMAParameters
+using CLIMAParameters.Planet: grav
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
 function config_simple_box(FT, N, resolution, dimensions)
     prob = HomogeneousBox{FT}(dimensions...)
 
-    cʰ = sqrt(grav * prob.H) # m/s
+    _grav::FT = grav(param_set)
+    cʰ = sqrt(_grav * prob.H) # m/s
     model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
 
     config =

--- a/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
@@ -4,14 +4,19 @@ using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
-using CLIMA.PlanetParameters: grav
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
+
+using CLIMAParameters
+using CLIMAParameters.Planet: grav
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
 
 function config_simple_box(FT, N, resolution, dimensions)
     prob = OceanGyre{FT}(dimensions...)
 
-    cʰ = sqrt(grav * prob.H) # m/s
+    _grav::FT = grav(param_set)
+    cʰ = sqrt(_grav * prob.H) # m/s
     model = HydrostaticBoussinesqModel{FT}(prob, cʰ = cʰ)
 
     config = CLIMA.OceanBoxGCMConfiguration("ocean_gyre", N, resolution, model)

--- a/test/Ocean/ShallowWater/GyreDriver.jl
+++ b/test/Ocean/ShallowWater/GyreDriver.jl
@@ -27,7 +27,7 @@ const Lˣ = 1e6
 const Lʸ = 1e6
 const timeend = 100 * 24 * 60 * 60
 const H = 1000
-const c = sqrt(grav * H)
+const c = sqrt(grav(param_set) * H)
 
 if stommel
     gyre = "stommel"

--- a/test/Ocean/ShallowWater/GyreInABox.jl
+++ b/test/Ocean/ShallowWater/GyreInABox.jl
@@ -13,9 +13,17 @@ using LinearAlgebra
 using StaticArrays
 using Logging, Printf, Dates
 using CLIMA.VTK
-import CLIMA.ShallowWater: shallow_init_state!, shallow_init_aux!, vars_state, vars_aux,
-                    shallow_boundary_state!, TurbulenceClosure, LinearDrag,
-                    ConstantViscosity, AdvectionTerm, NonLinearAdvection
+import CLIMA.ShallowWater:
+    shallow_init_state!,
+    shallow_init_aux!,
+    vars_state,
+    vars_aux,
+    shallow_boundary_state!,
+    TurbulenceClosure,
+    LinearDrag,
+    ConstantViscosity,
+    AdvectionTerm,
+    NonLinearAdvection
 
 using CLIMAParameters
 using CLIMAParameters.Planet: grav
@@ -23,119 +31,164 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 struct GyreInABox{T} <: SWProblem
-  τₒ::T
-  fₒ::T # value includes τₒ, g, and ρ
-  β::T
-  Lˣ::T
-  Lʸ::T
-  H::T
+    τₒ::T
+    fₒ::T # value includes τₒ, g, and ρ
+    β::T
+    Lˣ::T
+    Lʸ::T
+    H::T
 end
 
-function null_init_state!(::GyreInABox, ::TurbulenceClosure, state,
-                          aux, coord, t)
-  T = eltype(state.U)
-  state.U = @SVector zeros(T, 3)
-  state.η = 0
-  return nothing
+function null_init_state!(
+    ::GyreInABox,
+    ::TurbulenceClosure,
+    state,
+    aux,
+    coord,
+    t,
+)
+    T = eltype(state.U)
+    state.U = @SVector zeros(T, 3)
+    state.η = 0
+    return nothing
 end
 
-η_lsw(x, y, t) =            cos(π*x) * cos(π*y) * cos(√2*π*t)
-u_lsw(x, y, t) = 2^(-0.5) * sin(π*x) * cos(π*y) * sin(√2*π*t)
-v_lsw(x, y, t) = 2^(-0.5) * cos(π*x) * sin(π*y) * sin(√2*π*t)
+η_lsw(x, y, t) = cos(π * x) * cos(π * y) * cos(√2 * π * t)
+u_lsw(x, y, t) = 2^(-0.5) * sin(π * x) * cos(π * y) * sin(√2 * π * t)
+v_lsw(x, y, t) = 2^(-0.5) * cos(π * x) * sin(π * y) * sin(√2 * π * t)
 
-function lsw_init_state!(p::GyreInABox, ::TurbulenceClosure, state,
-                         aux, coords, t)
-  state.U = @SVector [u_lsw(coords[1], coords[2], t),
-                      v_lsw(coords[1], coords[2], t),
-                      0]
+function lsw_init_state!(
+    p::GyreInABox,
+    ::TurbulenceClosure,
+    state,
+    aux,
+    coords,
+    t,
+)
+    state.U = @SVector [
+        u_lsw(coords[1], coords[2], t),
+        v_lsw(coords[1], coords[2], t),
+        0,
+    ]
 
-  state.η = η_lsw(coords[1], coords[2], t)
+    state.η = η_lsw(coords[1], coords[2], t)
 
-  return nothing
+    return nothing
 end
 
 v_lkw(x, y, t) = 0
 u_lkw(x, y, t) = exp(-0.5 * y^2) * exp(-0.5 * (x - t + 5)^2)
 η_lkw(x, y, t) = 1 + u_lkw(x, y, t)
 
-function lkw_init_state!(p::GyreInABox, ::TurbulenceClosure, state,
-                         aux, coords, t)
-  state.U = @SVector [u_lkw(coords[1], coords[2], t),
-                      v_lkw(coords[1], coords[2], t),
-                      0]
+function lkw_init_state!(
+    p::GyreInABox,
+    ::TurbulenceClosure,
+    state,
+    aux,
+    coords,
+    t,
+)
+    state.U = @SVector [
+        u_lkw(coords[1], coords[2], t),
+        v_lkw(coords[1], coords[2], t),
+        0,
+    ]
 
-  state.η = η_lkw(coords[1], coords[2], t)
+    state.η = η_lkw(coords[1], coords[2], t)
 
-  return nothing
+    return nothing
 end
 
-R₋(ϵ)    = (-1 - sqrt(1 + (2 * π * ϵ) ^ 2)) / (2ϵ)
-R₊(ϵ)    = (-1 + sqrt(1 + (2 * π * ϵ) ^ 2)) / (2ϵ)
-D(ϵ)     = (R₊(ϵ) * (exp(R₋(ϵ)) - 1) + R₋(ϵ) * (1 - exp(R₊(ϵ)))) / (exp(R₊(ϵ)) - exp(R₋(ϵ)))
-R₂(x₁,ϵ) = (1 / D(ϵ)) * (((R₊(ϵ) * (exp(R₋(ϵ)) - 1)) * exp(R₊(ϵ) * x₁) + (R₋(ϵ) * (1 - exp(R₊(ϵ)))) * exp(R₋(ϵ) * x₁)) / (exp(R₊(ϵ)) - exp(R₋(ϵ))))
-R₁(x₁,ϵ) = (π / D(ϵ)) * (1 .+ ((exp(R₋(ϵ)) - 1) * exp(R₊(ϵ) * x₁) .+ (1 - exp(R₊(ϵ))) * exp(R₋(ϵ) * x₁)) / (exp(R₊(ϵ)) - exp(R₋(ϵ))))
+R₋(ϵ) = (-1 - sqrt(1 + (2 * π * ϵ)^2)) / (2ϵ)
+R₊(ϵ) = (-1 + sqrt(1 + (2 * π * ϵ)^2)) / (2ϵ)
+D(ϵ) =
+    (R₊(ϵ) * (exp(R₋(ϵ)) - 1) + R₋(ϵ) * (1 - exp(R₊(ϵ)))) /
+    (exp(R₊(ϵ)) - exp(R₋(ϵ)))
+R₂(x₁, ϵ) =
+    (1 / D(ϵ)) * (
+        (
+            (R₊(ϵ) * (exp(R₋(ϵ)) - 1)) * exp(R₊(ϵ) * x₁) +
+            (R₋(ϵ) * (1 - exp(R₊(ϵ)))) * exp(R₋(ϵ) * x₁)
+        ) / (exp(R₊(ϵ)) - exp(R₋(ϵ)))
+    )
+R₁(x₁, ϵ) =
+    (π / D(ϵ)) * (
+        1 .+
+        (
+            (exp(R₋(ϵ)) - 1) * exp(R₊(ϵ) * x₁) .+
+            (1 - exp(R₊(ϵ))) * exp(R₋(ϵ) * x₁)
+        ) / (exp(R₊(ϵ)) - exp(R₋(ϵ)))
+    )
 
-𝒱(x₁,y₁,ϵ)       =  R₂(x₁,ϵ) * sin.(π * y₁)
-𝒰(x₁,y₁,ϵ)       = -R₁(x₁,ϵ) * cos.(π * y₁)
-ℋ(x₁,y₁,ϵ,βᵖ,fₒ,γ) = (R₂(x₁,ϵ) / (π * fₒ)) * γ * cos(π * y₁) + (R₁(x₁,ϵ) / π) * (sin(π * y₁) * (1.0 + βᵖ * (y₁ - 0.5)) + (βᵖ / π) * cos(π * y₁))
+𝒱(x₁, y₁, ϵ) = R₂(x₁, ϵ) * sin.(π * y₁)
+𝒰(x₁, y₁, ϵ) = -R₁(x₁, ϵ) * cos.(π * y₁)
+ℋ(x₁, y₁, ϵ, βᵖ, fₒ, γ) =
+    (R₂(x₁, ϵ) / (π * fₒ)) * γ * cos(π * y₁) +
+    (R₁(x₁, ϵ) / π) *
+    (sin(π * y₁) * (1.0 + βᵖ * (y₁ - 0.5)) + (βᵖ / π) * cos(π * y₁))
 
-function gyre_init_state!(p::GyreInABox, T::LinearDrag, state,
-                             aux, coords, t)
-  FT = eltype(state)
-  τₒ = p.τₒ
-  fₒ = p.fₒ
-  β  = p.β
-  Lˣ = p.Lˣ
-  Lʸ = p.Lʸ
-  H  = p.H
+function gyre_init_state!(p::GyreInABox, T::LinearDrag, state, aux, coords, t)
+    FT = eltype(state)
+    τₒ = p.τₒ
+    fₒ = p.fₒ
+    β = p.β
+    Lˣ = p.Lˣ
+    Lʸ = p.Lʸ
+    H = p.H
 
-  γ  = T.λ
+    γ = T.λ
 
-  βᵖ = β * Lʸ / fₒ
-  ϵ  = γ / (Lˣ * β)
+    βᵖ = β * Lʸ / fₒ
+    ϵ = γ / (Lˣ * β)
 
-  _grav::FT = grav(param_set)
+    _grav::FT = grav(param_set)
 
-  uˢ(ϵ) = (τₒ * D(ϵ)) / (H * γ * π)
-  hˢ(ϵ) = (fₒ * Lˣ * uˢ(ϵ)) / _grav
+    uˢ(ϵ) = (τₒ * D(ϵ)) / (H * γ * π)
+    hˢ(ϵ) = (fₒ * Lˣ * uˢ(ϵ)) / _grav
 
-  u = uˢ(ϵ) * 𝒰(coords[1]/Lˣ, coords[2]/Lʸ, ϵ)
-  v = uˢ(ϵ) * 𝒱(coords[1]/Lˣ, coords[2]/Lʸ, ϵ)
-  h = hˢ(ϵ) * ℋ(coords[1]/Lˣ, coords[2]/Lʸ, ϵ, βᵖ, fₒ, γ)
+    u = uˢ(ϵ) * 𝒰(coords[1] / Lˣ, coords[2] / Lʸ, ϵ)
+    v = uˢ(ϵ) * 𝒱(coords[1] / Lˣ, coords[2] / Lʸ, ϵ)
+    h = hˢ(ϵ) * ℋ(coords[1] / Lˣ, coords[2] / Lʸ, ϵ, βᵖ, fₒ, γ)
 
-  state.U = @SVector [H * u, H * v, 0]
+    state.U = @SVector [H * u, H * v, 0]
 
-  state.η = h
+    state.η = h
 
-  return nothing
+    return nothing
 end
 
-t1(x, δᵐ)    = cos((√3*x)/(2*δᵐ)) + (√3^-1) * sin((√3*x)/(2*δᵐ))
-t2(x, δᵐ)    = 1 - exp((-x)/(2*δᵐ) ) * t1(x, δᵐ)
-t3(y, Lʸ)    = π * sin(π*y/Lʸ)
-t4(x, Lˣ, C) = C * (1-x/Lˣ)
+t1(x, δᵐ) = cos((√3 * x) / (2 * δᵐ)) + (√3^-1) * sin((√3 * x) / (2 * δᵐ))
+t2(x, δᵐ) = 1 - exp((-x) / (2 * δᵐ)) * t1(x, δᵐ)
+t3(y, Lʸ) = π * sin(π * y / Lʸ)
+t4(x, Lˣ, C) = C * (1 - x / Lˣ)
 
 η_munk(x, y, Lˣ, Lʸ, δᵐ, C) = t4(x, Lˣ, C) * t3(y, Lʸ) * t2(x, δᵐ)
 
-function gyre_init_state!(p::GyreInABox, V::ConstantViscosity, state, aux,
-                          coords, t)
-  T = eltype(state.U)
-  _grav::FT = grav(param_set)
+function gyre_init_state!(
+    p::GyreInABox,
+    V::ConstantViscosity,
+    state,
+    aux,
+    coords,
+    t,
+)
+    T = eltype(state.U)
+    _grav::FT = grav(param_set)
 
-  τₒ = p.τₒ
-  fₒ = p.fₒ
-  β  = p.β
-  Lˣ = p.Lˣ
-  Lʸ = p.Lʸ
-  H  = p.H
+    τₒ = p.τₒ
+    fₒ = p.fₒ
+    β = p.β
+    Lˣ = p.Lˣ
+    Lʸ = p.Lʸ
+    H = p.H
 
-  ν  = V.ν
+    ν = V.ν
 
-  δᵐ = (ν / β)^(1/3)
-  C  = τₒ / (_grav*H) * (fₒ/β)
+    δᵐ = (ν / β)^(1 / 3)
+    C = τₒ / (_grav * H) * (fₒ / β)
 
-  state.η = η_munk(coords[1], coords[2], Lˣ, Lʸ, δᵐ, C)
-  state.U = @SVector zeros(T, 3)
+    state.η = η_munk(coords[1], coords[2], Lˣ, Lʸ, δᵐ, C)
+    state.U = @SVector zeros(T, 3)
 
-  return nothing
+    return nothing
 end

--- a/test/runtests_gpu.jl
+++ b/test/runtests_gpu.jl
@@ -5,7 +5,6 @@ ENV["JULIA_LOG_LEVEL"] = "WARN"
 @test CuArrays.functional()
 
 for submodule in [#"Utilities/ParametersType",
-    #"Common/PlanetParameters",
     #"Common/MoistThermodynamics",
     #"Atmos/Parameterizations/SurfaceFluxes",
     #"Mesh",


### PR DESCRIPTION
# Description

Removes more use/references of `PlanetParameters` with CLIMAParameters.jl. This should also partially address #919.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
