### PR TITLE
Add instructions for precompiling JuliaFormatter

### DIFF
--- a/.dev/hooks/pre-commit.sysimage
+++ b/.dev/hooks/pre-commit.sysimage
@@ -1,0 +1,41 @@
+#!/usr/bin/env -S julia -J.git/hooks/JuliaFormatterSysimage.so
+#
+# Called by git-commit with no arguments.  This checks to make sure that all
+# .jl files are indented correctly before a commit is made.
+#
+# To enable this hook, make this file executable and copy it in
+# $GIT_DIR/hooks.
+
+toplevel_directory = chomp(read(`git rev-parse --show-toplevel`, String))
+
+using Pkg
+Pkg.activate(joinpath(toplevel_directory, ".dev"))
+Pkg.instantiate()
+
+using JuliaFormatter
+
+include(joinpath(toplevel_directory, ".dev", "clima_formatter_options.jl"))
+
+needs_format = false
+
+for diffoutput in split.(readlines(`git diff --name-status --cached`))
+    status = diffoutput[1]
+    filename = diffoutput[end]
+    (!startswith(status, "D") && endswith(filename, ".jl")) || continue
+
+    a = read(`git show :$filename`, String)
+    b = format_text(a; clima_formatter_options...)
+
+    if a != b
+        fullfilename = joinpath(toplevel_directory, filename)
+
+        @error """File $filename needs to be indented with:
+            julia -J$(joinpath(toplevel_directory, ".git/hooks", "JuliaFormatterSysimage.so")) $(joinpath(toplevel_directory, ".dev", "climaformat.jl"))  $fullfilename
+        and added to the git index via
+            git add $fullfilename
+        """
+        global needs_format = true
+    end
+end
+
+exit(needs_format ? 1 : 0)

--- a/.dev/precompile.jl
+++ b/.dev/precompile.jl
@@ -1,0 +1,5 @@
+using JuliaFormatter
+
+include("clima_formatter_options.jl")
+
+format(@__FILE__; clima_formatter_options...)


### PR DESCRIPTION
Add procedure for using the [`PackageCompier`](https://github.com/JuliaLang/PackageCompiler.jl) to speeds up the `JuliaFormatter`.

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)