### PR TITLE
Add turbulence models to Held-Suarez for 1.5x speedup of simulation

### DIFF
--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -28,44 +28,29 @@ end
 function init_heldsuarez!(bl, state, aux, coords, t)
     FT = eltype(state)
 
-    # Parameters need to set initial state
-    T_ref = bl.data_config.T_ref
-    temp_profile = IsothermalProfile(T_ref)
-
-    # Calculate the initial state variables
-    T, p = temp_profile(bl.orientation, bl.param_set, aux)
-    thermo_state = PhaseDry_given_pT(p, T, bl.param_set)
-    ρ = air_density(thermo_state)
-    e_int = internal_energy(thermo_state)
-    e_pot = gravitational_potential(bl.orientation, aux)
-
-    # Set initial state with random perturbation
+    # Set initial state to reference state with random perturbation
     rnd = FT(1.0 + rand(Uniform(-1e-3, 1e-3)))
-    state.ρ = ρ
+    state.ρ = aux.ref_state.ρ
     state.ρu = SVector{3, FT}(0, 0, 0)
-    state.ρe = rnd * state.ρ * (e_int + e_pot)
+    state.ρe = rnd * aux.ref_state.ρe
 
     nothing
 end
 
 function config_heldsuarez(FT, poly_order, resolution)
-    exp_name = "HeldSuarez"
+    # Set up a reference state for linearization of equations
+    T_sfc::FT = 290 # surface temperature of reference state (K)
+    ΔT::FT = 60     # temperature drop between surface and top of atmosphere (K)
+    H_t::FT = 8e3   # height sclae over which temperature drops (m)
+    temp_profile_ref = DecayingTemperatureProfile(T_sfc, ΔT, H_t)
+    ref_state = HydrostaticState(temp_profile_ref, FT(0))
 
-    # Parameters
-    T_ref::FT = 255
-    Rh_ref::FT = 0
-    domain_height::FT = 30e3
-    turb_visc::FT = 0 # no visc. here
-
-    # Set up a reference state for linearization
-    temp_profile_ref = IsothermalProfile(T_ref)
-    ref_state = HydrostaticState(temp_profile_ref, Rh_ref)
-
-    # Rayleigh sponge to dampen flow at the top of the domain
-    z_sponge = FT(15e3) # height at which sponge begins
-    α_relax = FT(1 / 60 / 15) # sponge relaxation rate in (1/seconds)
-    u_relax = SVector(FT(0), FT(0), FT(0)) # relaxation velocity
-    exp_sponge = 2 # sponge exponent for squared-sinusoid profile
+    # Set up a Rayleigh sponge to dampen flow at the top of the domain
+    domain_height::FT = 30e3               # distance between surface and top of atmosphere (m)
+    z_sponge::FT = 12e3                    # height at which sponge begins (m)
+    α_relax::FT = 1 / 60 / 15              # sponge relaxation rate (1/s)
+    exp_sponge = 2                         # sponge exponent for squared-sinusoid profile
+    u_relax = SVector(FT(0), FT(0), FT(0)) # relaxation velocity (m/s)
     sponge = RayleighSponge{FT}(
         domain_height,
         z_sponge,
@@ -75,11 +60,16 @@ function config_heldsuarez(FT, poly_order, resolution)
     )
 
     # Set up the atmosphere model
+    exp_name = "HeldSuarez"
+    T_ref::FT = 255        # reference temperature for Held-Suarez forcing (K)
+    τ_hyper::FT = 4 * 3600 # hyperdiffusion time scale in (s)
+    c_smag::FT = 0.21      # Smagorinsky coefficient
     model = AtmosModel{FT}(
         AtmosGCMConfigType,
         param_set;
         ref_state = ref_state,
-        turbulence = ConstantViscosityWithDivergence(turb_visc),
+        turbulence = SmagorinskyLilly(c_smag),
+        hyperdiffusion = StandardHyperDiffusion(τ_hyper),
         moisture = DryModel(),
         source = (Gravity(), Coriolis(), held_suarez_forcing!, sponge),
         init_state = init_heldsuarez!,
@@ -136,15 +126,15 @@ function held_suarez_forcing!(
     T_equator = FT(315)
     T_min = FT(200)
     σ_b = FT(7 / 10)
-    λ = longitude(bl, aux)
-    φ = latitude(bl, aux)
-    z = altitude(bl, aux)
-    scale_height = _R_d * T_ref / _grav
-    σ = exp(-z / scale_height)
 
-    # TODO: use
-    #  p = air_pressure(T, ρ)
-    #  σ = p/p0
+    # Held-Suarez forcing
+    φ = latitude(bl.orientation, aux)
+    p = air_pressure(T, ρ, bl.param_set)
+
+    #TODO: replace _p0 with dynamic surfce pressure in Δσ calculations to account
+    #for topography, but leave unchanged for calculations of σ involved in T_equil
+    _p0 = 1.01325e5
+    σ = p / _p0
     exner_p = σ^(_R_d / _cp_d)
     Δσ = (σ - σ_b) / (1 - σ_b)
     height_factor = max(0, Δσ)
@@ -169,7 +159,7 @@ function config_diagnostics(FT, driver_config)
         FT(-90.0) FT(-180.0) _planet_radius
         FT(90.0) FT(180.0) FT(_planet_radius + info.domain_height)
     ]
-    resolution = (FT(10), FT(10), FT(1000))
+    resolution = (FT(10), FT(10), FT(1000)) # in (deg, deg, m)
     interpol =
         CLIMA.InterpolationConfiguration(driver_config, boundaries, resolution)
 
@@ -186,39 +176,32 @@ function main()
     CLIMA.init()
 
     # Driver configuration parameters
-    FT = Float32                        # floating type precision
-    poly_order = 5                      # discontinuous Galerkin polynomial order
-    n_horz = 5                          # horizontal element number
-    n_vert = 5                          # vertical element number
-    days = 100                          # experiment day number
-    timestart = FT(0)                   # start time (seconds)
-    timeend = FT(days * 24 * 60 * 60)   # end time (seconds)
+    FT = Float32                             # floating type precision
+    poly_order = 5                           # discontinuous Galerkin polynomial order
+    n_horz = 5                               # horizontal element number
+    n_vert = 5                               # vertical element number
+    n_days = 120                             # experiment day number
+    timestart = FT(0)                        # start time (s)
+    timeend = FT(n_days * day(param_set))    # end time (s)
 
     # Set up driver configuration
     driver_config = config_heldsuarez(FT, poly_order, (n_horz, n_vert))
-
-    # Set up ODE solver configuration
-    ode_solver_type = CLIMA.IMEXSolverType(
-        linear_solver = ManyColumnLU,
-        solver_method = ARK2GiraldoKellyConstantinescu,
-    )
 
     # Set up experiment
     solver_config = CLIMA.SolverConfiguration(
         timestart,
         timeend,
         driver_config,
-        ode_solver_type = ode_solver_type,
-        Courant_number = 0.14,
+        Courant_number = 0.2,
         init_on_cpu = true,
         CFL_direction = HorizontalDirection(),
+        diffdir = HorizontalDirection(),
     )
 
     # Set up diagnostics
     dgn_config = config_diagnostics(FT, driver_config)
 
     # Set up user-defined callbacks
-    # TODO: This callback needs to live somewhere else
     filterorder = 10
     filter = ExponentialFilter(solver_config.dg.grid, 0, filterorder)
     cbfilter = GenericCallbacks.EveryXSimulationSteps(1) do

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -4,6 +4,7 @@ export NoReferenceState,
     HydrostaticState,
     IsothermalProfile,
     LinearTemperatureProfile,
+    DecayingTemperatureProfile,
     DryAdiabaticProfile
 
 using CLIMAParameters.Planet: R_d, MSLP, cp_d, grav
@@ -194,4 +195,46 @@ function (profile::LinearTemperatureProfile)(
         p *= exp(-(z - z_top) / H_min)
     end
     return (T, p)
+end
+
+"""
+    DecayingTemperatureProfile{F} <: TemperatureProfile
+
+A virtual temperature profile that decays smoothly with height `z`, dropping by a specified temperature difference `ΔTv` over a height scale `H_t`.
+
+```math
+Tv(z) = \\max(Tv{\\text{surface}} − ΔTv \\tanh(z/H_{\\text{t}})
+```
+
+# Fields
+
+$(DocStringExtensions.FIELDS)
+"""
+struct DecayingTemperatureProfile{FT} <: TemperatureProfile
+    "virtual temperature at surface (K)"
+    Tv_surface::FT
+    "virtual temperature drop from surface to top of the atmosphere (K)"
+    ΔTv::FT
+    "height scale over which virtual temperature drops (m)"
+    H_t::FT
+end
+
+function (profile::DecayingTemperatureProfile)(
+    orientation::Orientation,
+    param_set::AbstractParameterSet,
+    aux::Vars,
+)
+    z = altitude(orientation, param_set, aux)
+    Tv = profile.Tv_surface - profile.ΔTv * tanh(z / profile.H_t)
+    FT = typeof(z)
+    _R_d::FT = R_d(param_set)
+    _grav::FT = grav(param_set)
+    _MSLP::FT = MSLP(param_set)
+
+    ΔTv_p = profile.ΔTv / profile.Tv_surface
+    H_surface = _R_d * profile.Tv_surface / _grav
+    p = -z - profile.H_t * ΔTv_p * log(cosh(z / profile.H_t) - atanh(ΔTv_p))
+    p /= H_surface * (1 - ΔTv_p^2)
+    p = _MSLP * exp(p)
+    return (Tv, p)
 end


### PR DESCRIPTION
# Description

Added the Smagorinksy-Lilly SGS model and 4-th-order hyperdiffusion to the Held-Suarez driver. 
I also simplified some of the code in the driver file. All in all, with these parameters we get a nice speedup.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
