### PR TITLE
Update turbulence models and add documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ pages = Any[
         "Atmos/SurfaceFluxes.md",
         "Atmos/EDMFEquations.md",
         "Microphysics" => "Atmos/Microphysics.md",
+        "Atmos/Model/turbulence.md",
     ],
     "ODESolvers" => "ODESolvers.md",
     "LinearSolvers" => "LinearSolvers.md",

--- a/examples/Atmos/dry_rayleigh_benard.jl
+++ b/examples/Atmos/dry_rayleigh_benard.jl
@@ -120,7 +120,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
     # Set up the model
     model = AtmosModel{FT}(
         AtmosLESConfigType;
-        turbulence = SmagorinskyLilly{FT}(C_smag),
+        turbulence = Vreman(C_smag),
         source = (Gravity(),),
         boundarycondition = (
             AtmosBC(

--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -88,8 +88,8 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
         HydrostaticState(DryAdiabaticProfile(typemin(FT), FT(300)), FT(0))
     model = AtmosModel{FT}(
         AtmosLESConfigType;
-        turbulence = SmagorinskyLilly{FT}(C_smag),
-        hyperdiffusion = StandardHyperDiffusion{FT}(60),
+        turbulence = SmagorinskyLilly(C_smag),
+        hyperdiffusion = StandardHyperDiffusion(60),
         source = (Gravity(),),
         ref_state = ref_state,
         init_state = init_risingbubble!,

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -10,7 +10,6 @@ using ..Parameters
 using ..MoistThermodynamics
 using ..PlanetParameters
 import ..MoistThermodynamics: internal_energy
-using ..SubgridScaleParameters
 using ..MPIStateArrays: MPIStateArray
 using ..Mesh.Grids: VerticalDirection, HorizontalDirection, min_node_distance
 
@@ -352,8 +351,7 @@ end
     aux::Vars,
     t::Real,
 )
-    ν, τ = turbulence_tensors(atmos.turbulence, state, diffusive, aux, t)
-    D_t = (ν isa Real ? ν : diag(ν)) * inv_Pr_turb
+    ν, D_t, τ = turbulence_tensors(atmos.turbulence, state, diffusive, aux, t)
     d_h_tot = -D_t .* diffusive.∇h_tot
     flux_diffusive!(atmos, flux, state, τ, d_h_tot)
     flux_diffusive!(atmos.moisture, flux, state, diffusive, aux, t, D_t)

--- a/src/Atmos/Model/bc_energy.jl
+++ b/src/Atmos/Model/bc_energy.jl
@@ -62,8 +62,7 @@ function atmos_energy_normal_boundary_flux_diffusive!(
 )
 
     # TODO: figure out a better way...
-    ν, _ = turbulence_tensors(atmos.turbulence, state⁻, diff⁻, aux⁻, t)
-    D_t = (ν isa Real ? ν : diag(ν)) * inv_Pr_turb
+    ν, D_t, _ = turbulence_tensors(atmos.turbulence, state⁻, diff⁻, aux⁻, t)
     d_h_tot = -D_t .* diff⁻.∇h_tot
     nd_h_tot = dot(n⁻, d_h_tot)
     # both sides involve projections of normals, so signs are consistent

--- a/src/Atmos/Model/remainder.jl
+++ b/src/Atmos/Model/remainder.jl
@@ -45,14 +45,7 @@ function hyperdiffusive!(
     aux::Vars,
     t::Real,
 )
-    hyperdiffusive!(
-        rem.main.hyperdiffusion,
-        hyperdiffusive,
-        hypertransform,
-        state,
-        aux,
-        t,
-    )
+    hyperdiffusive!(rem.main, hyperdiffusive, hypertransform, state, aux, t)
 end
 function flux_diffusive!(
     rem::RemainderModel,
@@ -129,7 +122,6 @@ end
 
 init_aux!(rem::RemainderModel, aux::Vars, geom::LocalGeometry) = nothing
 init_state!(rem::RemainderModel, state::Vars, aux::Vars, coords, t) = nothing
-
 
 function flux_nondiffusive!(
     rem::RemainderModel,

--- a/src/Diagnostics/atmos_default.jl
+++ b/src/Diagnostics/atmos_default.jl
@@ -156,14 +156,13 @@ function compute_horzsums!(
         hs.ρq_tot += MH * state.moisture.ρq_tot
     end
 
-    ν, _ = turbulence_tensors(
+    ν, D_t, _ = turbulence_tensors(
         atmos.turbulence,
         state,
         diffusive_flux,
         aux,
         currtime,
     )
-    D_t = (ν isa Real ? ν : diag(ν)) * inv_Pr_turb
 
     # TODO: temporary fix
     if isa(atmos.moisture, EquilMoist)


### PR DESCRIPTION
# Description

Update eddy-viscosity turbulence models, add documentation, allow diffusivity to be imported from turbulence.jl (allows tracer gradient dependent diffusivities, upgrade from current reliance on turbulent Prandtl numbers in `AtmosModel.jl`). Update example file to use Vreman model. 
```
	modified: src/Atmos/Model/AtmosModel.jl
	new file: docs/src/Atmos/Model/turbulence.md
	modified: src/Atmos/Model/turbulence.jl
	modified: examples/Atmos/dry_rayleigh_benard.jl
        modified: experiments/AtmosLES/risingbubble.jl
        modified: src/Diagnostics/atmos_default.jl
        modified: src/Atmos/Model/bc_energy.jl
        modified: src/Atmos/Model/remainder.jl
        modified: docs/make.jl
```
<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
