### PR TITLE
Fix CoastlineFreeSlip boundary conditions for HydrostaticBoussinesqModel

### DIFF
--- a/experiments/OceanBoxGCM/ocean_gyre.jl
+++ b/experiments/OceanBoxGCM/ocean_gyre.jl
@@ -1,32 +1,34 @@
 using Test
 using CLIMA
-using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
-
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
+using CLIMA.HydrostaticBoussinesq
 
 using CLIMAParameters
 using CLIMAParameters.Planet: grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function config_simple_box(FT, N, resolution, dimensions)
-    prob = OceanGyre{FT}(dimensions...)
+function config_simple_box(FT, N, resolution, dimensions; BC = nothing)
+    if BC == nothing
+        problem = OceanGyre{FT}(dimensions...)
+    else
+        problem = OceanGyre{FT}(dimensions...; BC = BC)
+    end
 
     _grav::FT = grav(param_set)
-
-    cʰ = sqrt(_grav * prob.H) # m/s
-    model = HydrostaticBoussinesqModel{FT}(param_set, prob, cʰ = cʰ)
+    cʰ = sqrt(_grav * problem.H) # m/s
+    model = HydrostaticBoussinesqModel{FT}(param_set, problem, cʰ = cʰ)
 
     config = CLIMA.OceanBoxGCMConfiguration("ocean_gyre", N, resolution, model)
 
     return config
 end
 
-function run_ocean_gyre(; imex::Bool = false)
+function run_ocean_gyre(; imex::Bool = false, BC = nothing)
     CLIMA.init()
 
     FT = Float64
@@ -58,7 +60,7 @@ function run_ocean_gyre(; imex::Bool = false)
             CLIMA.ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
     end
 
-    driver_config = config_simple_box(FT, N, resolution, dimensions)
+    driver_config = config_simple_box(FT, N, resolution, dimensions; BC = BC)
 
     grid = driver_config.grid
     vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
@@ -71,7 +73,7 @@ function run_ocean_gyre(; imex::Bool = false)
         driver_config,
         init_on_cpu = true,
         # ode_dt = dt,
-        Courant_number = 0.25,
+        Courant_number = 0.4,
         ode_solver_type = solver_type,
         modeldata = modeldata,
     )
@@ -86,6 +88,54 @@ function run_ocean_gyre(; imex::Bool = false)
 
     result = CLIMA.invoke!(solver_config)
 
+    @test true
 end
 
-run_ocean_gyre(imex = false)
+@testset "$(@__FILE__)" begin
+    boundary_conditions = [
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceNoStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceNoStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceNoStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceNoStressForcing(),
+        ),
+    ]
+
+    for BC in boundary_conditions
+        run_ocean_gyre(imex = false, BC = BC)
+    end
+end

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -58,5 +58,5 @@ gpu = [
   { file = "experiments/AtmosLES/dycoms.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "experiments/AtmosLES/bomex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "experiments/OceanBoxGCM/homogeneous_box.jl", slurmargs = ["--ntasks=3"], args = [] },
-  { file = "experiments/OceanBoxGCM/ocean_gyre.jl", slurmargs = ["--ntasks=4"], args = [] },
+  { file = "experiments/OceanBoxGCM/ocean_gyre.jl", slurmargs = ["--ntasks=3"], args = [] },
 ]

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -156,8 +156,14 @@ function SolverConfiguration(
     # initial Δt specified or computed
     simtime = FT(0) # TODO: needs to be more general to account for restart:
     if ode_dt === nothing
-        ode_dt =
-            calculate_dt(dg, dtmodel, Q, Courant_number, simtime, CFL_direction)
+        ode_dt = CLIMA.DGmethods.calculate_dt(
+            dg,
+            dtmodel,
+            Q,
+            Courant_number,
+            simtime,
+            CFL_direction,
+        )
     end
     numberofsteps = convert(Int, cld(timeend, ode_dt))
     timeend_dt_adjust && (ode_dt = timeend / numberofsteps)

--- a/src/Ocean/HydrostaticBoussinesq/BoundaryConditions.jl
+++ b/src/Ocean/HydrostaticBoussinesq/BoundaryConditions.jl
@@ -1,0 +1,116 @@
+using ..DGmethods.NumericalFluxes:
+    NumericalFluxNonDiffusive, NumericalFluxGradient, NumericalFluxDiffusive
+
+import ..DGmethods: boundary_state!
+
+"""
+    boundary_state!(nf, ::HBModel, args...)
+
+applies boundary conditions for the hyperbolic fluxes
+dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
+"""
+@inline function boundary_state!(nf, ocean::HBModel, args...)
+    boundary_condition = ocean.problem.boundary_condition
+    return ocean_boundary_state!(nf, boundary_condition, ocean, args...)
+end
+
+"""
+    boundary_state!(nf, ::LinearHBModel, args...)
+
+applies boundary conditions for the hyperbolic fluxes
+dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
+"""
+@inline function boundary_state!(nf, linear::LinearHBModel, args...)
+    ocean = linear.ocean
+    boundary_condition = ocean.problem.boundary_condition
+
+    return ocean_boundary_state!(nf, boundary_condition, ocean, args...)
+end
+
+"""
+    ocean_boundary_state!(nf, boundaries::Tuple, ::HBModel,
+                          Q⁺, A⁺, n, Q⁻, A⁻, bctype)
+applies boundary conditions for the first-order and gradient fluxes
+dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
+"""
+@generated function ocean_boundary_state!(
+    nf::Union{NumericalFluxNonDiffusive, NumericalFluxGradient},
+    boundaries::Tuple,
+    ocean,
+    Q⁺,
+    A⁺,
+    n,
+    Q⁻,
+    A⁻,
+    bctype,
+    t,
+    args...,
+)
+    N = fieldcount(boundaries)
+    return quote
+        Base.Cartesian.@nif(
+            $(N + 1),
+            i -> bctype == i, # conditionexpr
+            i -> ocean_boundary_state!(
+                nf,
+                boundaries[i],
+                ocean,
+                Q⁺,
+                A⁺,
+                n,
+                Q⁻,
+                A⁻,
+                t,
+            ), # expr
+            i -> error("Invalid boundary tag")
+        ) # elseexpr
+        return nothing
+    end
+end
+
+"""
+    ocean_boundary_state!(nf, boundaries::Tuple, ::HBModel,
+                          Q⁺, A⁺, D⁺, n, Q⁻, A⁻, D⁻, bctype)
+applies boundary conditions for the second-order fluxes
+dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
+"""
+@generated function ocean_boundary_state!(
+    nf::NumericalFluxDiffusive,
+    boundaries::Tuple,
+    ocean,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n,
+    Q⁻,
+    D⁻,
+    A⁻,
+    bctype,
+    t,
+    args...,
+)
+    N = fieldcount(boundaries)
+    return quote
+        Base.Cartesian.@nif(
+            $(N + 1),
+            i -> bctype == i, # conditionexpr
+            i -> ocean_boundary_state!(
+                nf,
+                boundaries[i],
+                ocean,
+                Q⁺,
+                D⁺,
+                A⁺,
+                n,
+                Q⁻,
+                D⁻,
+                A⁻,
+                t,
+            ), # expr
+            i -> error("Invalid boundary tag")
+        ) # elseexpr
+        return nothing
+    end
+end
+
+include("OceanBoundaryConditions.jl")

--- a/src/Ocean/HydrostaticBoussinesq/Courant.jl
+++ b/src/Ocean/HydrostaticBoussinesq/Courant.jl
@@ -1,4 +1,14 @@
 using Logging, Printf
+using LinearAlgebra: norm
+
+using ..Mesh.Grids:
+    VerticalDirection, HorizontalDirection, EveryDirection, min_node_distance
+using ..DGmethods: courant
+
+import ..Courant:
+    advective_courant, nondiffusive_courant, diffusive_courant, viscous_courant
+
+import ..DGmethods: calculate_dt
 
 """
     advective_courant(::HBModel)

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -1,3 +1,5 @@
+export LinearHBModel
+
 # Linear model for 1D IMEX
 """
     LinearHBModel <: BalanceLaw
@@ -13,19 +15,19 @@ write out the equations here
 
 """
 struct LinearHBModel{M} <: BalanceLaw
-  ocean::M
-  function LinearHBModel(ocean::M) where {M}
-    return new{M}(ocean)
-  end
+    ocean::M
+    function LinearHBModel(ocean::M) where {M}
+        return new{M}(ocean)
+    end
 end
 
 """
     Copy over state, aux, and diff variables from HBModel
 """
-vars_state(lm::LinearHBModel, FT) = vars_state(lm.ocean,FT)
-vars_gradient(lm::LinearHBModel, FT) = vars_gradient(lm.ocean,FT)
-vars_diffusive(lm::LinearHBModel, FT) = vars_diffusive(lm.ocean,FT)
-vars_aux(lm::LinearHBModel, FT) = vars_aux(lm.ocean,FT)
+vars_state(lm::LinearHBModel, FT) = vars_state(lm.ocean, FT)
+vars_gradient(lm::LinearHBModel, FT) = vars_gradient(lm.ocean, FT)
+vars_diffusive(lm::LinearHBModel, FT) = vars_diffusive(lm.ocean, FT)
+vars_aux(lm::LinearHBModel, FT) = vars_aux(lm.ocean, FT)
 vars_integrals(lm::LinearHBModel, FT) = @vars()
 
 """
@@ -55,10 +57,10 @@ this computation is done pointwise at each nodal point
 - `t`: time, not used
 """
 @inline function gradvariables!(m::LinearHBModel, G::Vars, Q::Vars, A, t)
-  G.u = Q.u
-  G.θ = Q.θ
+    G.u = Q.u
+    G.θ = Q.θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -75,15 +77,21 @@ this computation is done pointwise at each nodal point
 - `A`: array of aux variables
 - `t`: time, not used
 """
-@inline function diffusive!(lm::LinearHBModel, D::Vars, G::Grad, Q::Vars,
-                            A::Vars, t)
-  ν = viscosity_tensor(lm.ocean)
-  D.ν∇u = ν * G.u
+@inline function diffusive!(
+    lm::LinearHBModel,
+    D::Vars,
+    G::Grad,
+    Q::Vars,
+    A::Vars,
+    t,
+)
+    ν = viscosity_tensor(lm.ocean)
+    D.ν∇u = ν * G.u
 
-  κ = diffusivity_tensor(lm.ocean, G.θ[3])
-  D.κ∇θ = κ * G.θ
+    κ = diffusivity_tensor(lm.ocean, G.θ[3])
+    D.κ∇θ = κ * G.θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -101,15 +109,22 @@ this computation is done pointwise at each nodal point
 - `t`: time, not used
 
 # computations
-∂ᵗu = -∇∘(ν∇u)
-∂ᵗθ = -∇∘(κ∇θ)
+∂ᵗu = -∇⋅(ν∇u)
+∂ᵗθ = -∇⋅(κ∇θ)
 """
-@inline function flux_diffusive!(lm::LinearHBModel, F::Grad, Q::Vars, D::Vars,
-                                 HD::Vars, A::Vars, t::Real)
-  F.u -= D.ν∇u
-  F.θ -= D.κ∇θ
+@inline function flux_diffusive!(
+    lm::LinearHBModel,
+    F::Grad,
+    Q::Vars,
+    D::Vars,
+    HD::Vars,
+    A::Vars,
+    t::Real,
+)
+    F.u -= D.ν∇u
+    F.θ -= D.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -118,28 +133,6 @@ end
 calculates the wavespeed for rusanov flux
 """
 function wavespeed(lm::LinearHBModel, n⁻, _...)
-  C = abs(SVector(lm.ocean.cʰ, lm.ocean.cʰ, lm.ocean.cᶻ)' * n⁻)
-  return C
-end
-
-"""
-    boundary_state!(nf, ::LinearHBModel, Q⁺, A⁺, Q⁻, A⁻, bctype)
-
-applies boundary conditions for the hyperbolic fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@inline function boundary_state!(nf, lm::LinearHBModel, Q⁺::Vars, A⁺::Vars,
-                                 n⁻, Q⁻::Vars, A⁻::Vars, bctype, t, _...)
-  return ocean_boundary_state!(lm.ocean, lm.ocean.problem, bctype, nf, Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-end
-
-"""
-    boundary_state!(nf, ::LinearHBModel, Q⁺, D⁺, A⁺, Q⁻, D⁻, A⁻, bctype)
-
-applies boundary conditions for the parabolic fluxes
-dispatches to a function in OceanBoundaryConditions.jl based on bytype defined by a problem such as SimpleBoxProblem.jl
-"""
-@inline function boundary_state!(nf, lm::LinearHBModel, Q⁺::Vars, D⁺::Vars, A⁺::Vars,
-                                 n⁻, Q⁻::Vars, D⁻::Vars, A⁻::Vars, bctype, t, _...)
-  return ocean_boundary_state!(lm.ocean, lm.ocean.problem, bctype, nf, Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
+    C = abs(SVector(lm.ocean.cʰ, lm.ocean.cʰ, lm.ocean.cᶻ)' * n⁻)
+    return C
 end

--- a/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
+++ b/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
@@ -1,16 +1,19 @@
+using ..DGmethods.NumericalFluxes:
+    Rusanov, CentralNumericalFluxGradient, CentralNumericalFluxDiffusive
+
 abstract type OceanBoundaryCondition end
 
 """
     Defining dummy structs to dispatch on for boundary conditions.
 """
-struct CoastlineFreeSlip             <: OceanBoundaryCondition end
-struct CoastlineNoSlip               <: OceanBoundaryCondition end
-struct OceanFloorFreeSlip            <: OceanBoundaryCondition end
-struct OceanFloorNoSlip              <: OceanBoundaryCondition end
+struct CoastlineFreeSlip <: OceanBoundaryCondition end
+struct CoastlineNoSlip <: OceanBoundaryCondition end
+struct OceanFloorFreeSlip <: OceanBoundaryCondition end
+struct OceanFloorNoSlip <: OceanBoundaryCondition end
 struct OceanSurfaceNoStressNoForcing <: OceanBoundaryCondition end
-struct OceanSurfaceStressNoForcing   <: OceanBoundaryCondition end
-struct OceanSurfaceNoStressForcing   <: OceanBoundaryCondition end
-struct OceanSurfaceStressForcing     <: OceanBoundaryCondition end
+struct OceanSurfaceStressNoForcing <: OceanBoundaryCondition end
+struct OceanSurfaceNoStressForcing <: OceanBoundaryCondition end
+struct OceanSurfaceStressForcing <: OceanBoundaryCondition end
 
 """
     CoastlineFreeSlip
@@ -19,11 +22,10 @@ applies boundary condition ν∇u = 0 and κ∇θ = 0
 """
 
 """
-    ocean_boundary_state!(::HBModel, ::CoastlineFreeSlip, ::Union{Rusanov, CentralNumericalFluxGradient})
+    ocean_boundary_state!(::HBModel, ::CoastlineFreeSlip, ::Rusanov)
 
 apply free slip boundary conditions for velocity
 apply no penetration boundary for temperature
-nothing needed to do since these are neumann BCs and no gradients here
 
 # Arguments
 - `Q⁺`: state vector at ghost point
@@ -33,11 +35,56 @@ nothing needed to do since these are neumann BCs and no gradients here
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::CoastlineFreeSlip,
-                                       ::Union{Rusanov,
-                                               CentralNumericalFluxGradient},
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  return nothing
+@inline function ocean_boundary_state!(
+    ::Rusanov,
+    ::CoastlineFreeSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    u⁻ = Q⁻.u
+    n = @SVector [n⁻[1], n⁻[2]]
+
+    Q⁺.u = u⁻ - 2 * (n ⋅ u⁻) * n
+
+    return nothing
+end
+
+"""
+    ocean_boundary_state!(::HBModel, ::CoastlineFreeSlip, ::CentralNumericalFluxGradient)
+
+apply free slip boundary conditions for velocity
+apply no penetration boundary for temperature
+
+# Arguments
+- `Q⁺`: state vector at ghost point
+- `A⁺`: auxiliary state vector at ghost point
+- `n⁻`: normal vector, not used
+- `Q⁻`: state vector at interior
+- `A⁻`: auxiliary state vector at interior point
+- `t`:  time, not used
+"""
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxGradient,
+    ::CoastlineFreeSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    u⁻ = Q⁻.u
+    n = @SVector [n⁻[1], n⁻[2]]
+
+    Q⁺.u = u⁻ - (n ⋅ u⁻) * n
+
+    return nothing
 end
 
 """
@@ -57,14 +104,24 @@ sets ghost point to have no numerical flux on the boundary for ν∇u and κ∇�
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::CoastlineFreeSlip,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  D⁺.ν∇u = -D⁻.ν∇u
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::CoastlineFreeSlip,
+    ::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    D⁺.ν∇u = -D⁻.ν∇u
 
-  D⁺.κ∇θ = -D⁻.κ∇θ
+    D⁺.κ∇θ = -D⁻.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -88,12 +145,20 @@ set sets ghost point to have no numerical flux on the boundary for u
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::CoastlineNoSlip,
-                                       ::Rusanov,
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  Q⁺.u = -Q⁻.u
+@inline function ocean_boundary_state!(
+    ::Rusanov,
+    ::CoastlineNoSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    Q⁺.u = -Q⁻.u
 
-  return nothing
+    return nothing
 end
 
 """
@@ -111,13 +176,21 @@ set numerical flux to zero for u
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::CoastlineNoSlip,
-                                       ::CentralNumericalFluxGradient,
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  FT = eltype(Q⁺)
-  Q⁺.u = SVector(-zero(FT), -zero(FT))
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxGradient,
+    ::CoastlineNoSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    FT = eltype(Q⁺)
+    Q⁺.u = SVector(-zero(FT), -zero(FT))
 
-  return nothing
+    return nothing
 end
 
 """
@@ -137,14 +210,24 @@ sets ghost point to have no numerical flux on the boundary for u and κ∇θ
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::CoastlineNoSlip,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  Q⁺.u = -Q⁻.u
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::CoastlineNoSlip,
+    ::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    Q⁺.u = -Q⁻.u
 
-  D⁺.κ∇θ = -D⁻.κ∇θ
+    D⁺.κ∇θ = -D⁻.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -168,12 +251,20 @@ set ghost point to have no numerical flux on the boundary for w
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::OceanFloorFreeSlip,
-                                       ::Rusanov,
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  A⁺.w = -A⁻.w
+@inline function ocean_boundary_state!(
+    ::Rusanov,
+    ::OceanFloorFreeSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    A⁺.w = -A⁻.w
 
-  return nothing
+    return nothing
 end
 
 """
@@ -191,13 +282,21 @@ set numerical flux to zero for w
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::OceanFloorFreeSlip,
-                                       ::CentralNumericalFluxGradient,
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  FT = eltype(Q⁺)
-  A⁺.w = -zero(FT)
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxGradient,
+    ::OceanFloorFreeSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    FT = eltype(Q⁺)
+    A⁺.w = -zero(FT)
 
-  return nothing
+    return nothing
 end
 
 """
@@ -217,15 +316,25 @@ sets ghost point to have no numerical flux on the boundary for ν∇u and κ∇�
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::OceanFloorFreeSlip,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  A⁺.w = -A⁻.w
-  D⁺.ν∇u = -D⁻.ν∇u
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::OceanFloorFreeSlip,
+    ::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    A⁺.w = -A⁻.w
+    D⁺.ν∇u = -D⁻.ν∇u
 
-  D⁺.κ∇θ = -D⁻.κ∇θ
+    D⁺.κ∇θ = -D⁻.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -249,13 +358,21 @@ set sets ghost point to have no numerical flux on the boundary for u and w
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::OceanFloorNoSlip,
-                                       ::Rusanov,
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  Q⁺.u = -Q⁻.u
-  A⁺.w = -A⁻.w
+@inline function ocean_boundary_state!(
+    ::Rusanov,
+    ::OceanFloorNoSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    Q⁺.u = -Q⁻.u
+    A⁺.w = -A⁻.w
 
-  return nothing
+    return nothing
 end
 
 """
@@ -273,14 +390,22 @@ set numerical flux to zero for u and w
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::OceanFloorNoSlip,
-                                       ::CentralNumericalFluxGradient,
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  FT = eltype(Q⁺)
-  Q⁺.u = SVector(-zero(FT), -zero(FT))
-  A⁺.w = -zero(FT)
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxGradient,
+    ::OceanFloorNoSlip,
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    FT = eltype(Q⁺)
+    Q⁺.u = SVector(-zero(FT), -zero(FT))
+    A⁺.w = -zero(FT)
 
-  return nothing
+    return nothing
 end
 
 """
@@ -300,16 +425,26 @@ sets ghost point to have no numerical flux on the boundary for u,w and κ∇θ
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel, ::OceanFloorNoSlip,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::OceanFloorNoSlip,
+    ::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
 
-  Q⁺.u = -Q⁻.u
-  A⁺.w = -A⁻.w
+    Q⁺.u = -Q⁻.u
+    A⁺.w = -A⁻.w
 
-  D⁺.κ∇θ = -D⁻.κ∇θ
+    D⁺.κ∇θ = -D⁻.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -317,15 +452,23 @@ end
 
 applying neumann boundary conditions, so don't need to do anything for these numerical fluxes
 """
-@inline function ocean_boundary_state!(::HBModel, ::Union{
-                                       OceanSurfaceNoStressNoForcing,
-                                       OceanSurfaceStressNoForcing,
-                                       OceanSurfaceNoStressForcing,
-                                       OceanSurfaceStressForcing},
-                                       ::Union{Rusanov,
-                                               CentralNumericalFluxGradient},
-                                       Q⁺, A⁺, n⁻, Q⁻, A⁻, t)
-  return nothing
+@inline function ocean_boundary_state!(
+    ::Union{Rusanov, CentralNumericalFluxGradient},
+    ::Union{
+        OceanSurfaceNoStressNoForcing,
+        OceanSurfaceStressNoForcing,
+        OceanSurfaceNoStressForcing,
+        OceanSurfaceStressForcing,
+    },
+    ::HBModel,
+    Q⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    A⁻,
+    t,
+)
+    return nothing
 end
 
 """
@@ -345,14 +488,23 @@ set ghost point to have no numerical flux on the boundary for ν∇u and κ∇θ
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(::HBModel,
-                                       ::OceanSurfaceNoStressNoForcing,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  D⁺.ν∇u = -D⁻.ν∇u
-  D⁺.κ∇θ = -D⁻.κ∇θ
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::OceanSurfaceNoStressNoForcing,
+    ::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    D⁺.ν∇u = -D⁻.ν∇u
+    D⁺.κ∇θ = -D⁻.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -372,17 +524,26 @@ set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(m::HBModel,
-                                       ::OceanSurfaceStressNoForcing,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  τᶻ = velocity_flux(m.problem, A⁻.y, m.ρₒ)
-  τ = @SMatrix [ -0 -0; -0 -0; τᶻ -0]
-  D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::OceanSurfaceStressNoForcing,
+    m::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    τᶻ = kinematic_stress(m.problem, A⁻.y, m.ρₒ)
+    τ = @SMatrix [-0 -0; -0 -0; τᶻ -0]
+    D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
 
-  D⁺.κ∇θ = -D⁻.κ∇θ
+    D⁺.κ∇θ = -D⁻.κ∇θ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -402,17 +563,26 @@ set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(m::HBModel,
-                                       ::OceanSurfaceNoStressForcing,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  D⁺.ν∇u = -D⁻.ν∇u
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::OceanSurfaceNoStressForcing,
+    m::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    D⁺.ν∇u = -D⁻.ν∇u
 
-  σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
-  σ = @SVector [-0, -0, σᶻ]
-  D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
+    σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
+    σ = @SVector [-0, -0, σᶻ]
+    D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
 
-  return nothing
+    return nothing
 end
 
 """
@@ -432,17 +602,26 @@ set ghost point for numerical flux on the boundary for ν∇u and κ∇θ
 - `A⁻`: auxiliary state vector at interior point
 - `t`:  time, not used
 """
-@inline function ocean_boundary_state!(m::HBModel,
-                                       ::OceanSurfaceStressForcing,
-                                       ::CentralNumericalFluxDiffusive,
-                                       Q⁺, D⁺, A⁺, n⁻, Q⁻, D⁻, A⁻, t)
-  τᶻ = velocity_flux(m.problem, A⁻.y, m.ρₒ)
-  τ = @SMatrix [ -0 -0; -0 -0; τᶻ -0]
-  D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
+@inline function ocean_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    ::OceanSurfaceStressForcing,
+    m::HBModel,
+    Q⁺,
+    D⁺,
+    A⁺,
+    n⁻,
+    Q⁻,
+    D⁻,
+    A⁻,
+    t,
+)
+    τᶻ = kinematic_stress(m.problem, A⁻.y, m.ρₒ)
+    τ = @SMatrix [-0 -0; -0 -0; τᶻ -0]
+    D⁺.ν∇u = -D⁻.ν∇u + 2 * τ
 
-  σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
-  σ = @SVector [-0, -0, σᶻ]
-  D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
+    σᶻ = temperature_flux(m.problem, A⁻.y, Q⁻.θ)
+    σ = @SVector [-0, -0, σᶻ]
+    D⁺.κ∇θ = -D⁻.κ∇θ + 2 * σ
 
-  return nothing
+    return nothing
 end

--- a/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_divergence_free.jl
@@ -1,24 +1,28 @@
 using Test
 using CLIMA
-using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
-import CLIMA.DGmethods: vars_state
+using CLIMA.DGmethods: vars_state
+using CLIMA.HydrostaticBoussinesq
 
 using CLIMAParameters
 using CLIMAParameters.Planet: grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function config_simple_box(FT, N, resolution, dimensions)
-    prob = HomogeneousBox{FT}(dimensions...)
+function config_simple_box(FT, N, resolution, dimensions; BC = nothing)
+    if BC == nothing
+        problem = HomogeneousBox{FT}(dimensions...)
+    else
+        problem = HomogeneousBox{FT}(dimensions...; BC = BC)
+    end
 
     _grav::FT = grav(param_set)
-    cʰ = sqrt(_grav * prob.H) # m/s
-    model = HydrostaticBoussinesqModel{FT}(param_set, prob, cʰ = cʰ)
+    cʰ = sqrt(_grav * problem.H) # m/s
+    model = HydrostaticBoussinesqModel{FT}(param_set, problem, cʰ = cʰ)
 
     config =
         CLIMA.OceanBoxGCMConfiguration("homogeneous_box", N, resolution, model)
@@ -26,7 +30,7 @@ function config_simple_box(FT, N, resolution, dimensions)
     return config
 end
 
-function main(; imex::Bool = false)
+function test_divergence_free(; imex::Bool = false, BC = nothing)
     CLIMA.init()
 
     FT = Float64
@@ -46,16 +50,21 @@ function main(; imex::Bool = false)
     dimensions = (Lˣ, Lʸ, H)
 
     timestart = FT(0)    # s
-    timeend = FT(3600) # s
+    timeend = FT(36000) # s
 
     if imex
-        solver_type = CLIMA.IMEXSolverType(linear_model = LinearHBModel)
+        solver_type = CLIMA.IMEXSolverType(
+            linear_model = LinearHBModel,
+            linear_solver = CLIMA.ColumnwiseLUSolver.SingleColumnLU,
+        )
+        Courant_number = 0.1
     else
         solver_type =
             CLIMA.ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
+        Courant_number = 0.4
     end
 
-    driver_config = config_simple_box(FT, N, resolution, dimensions)
+    driver_config = config_simple_box(FT, N, resolution, dimensions; BC = BC)
 
     grid = driver_config.grid
     vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
@@ -68,8 +77,9 @@ function main(; imex::Bool = false)
         driver_config,
         init_on_cpu = true,
         ode_solver_type = solver_type,
-        ode_dt = 60,
+        ode_dt = 600,
         modeldata = modeldata,
+        Courant_number = Courant_number,
     )
 
     result = CLIMA.invoke!(solver_config)
@@ -87,6 +97,21 @@ function main(; imex::Bool = false)
 end
 
 @testset "$(@__FILE__)" begin
-    main(imex = false)
-    main(imex = true)
+    boundary_conditions = [
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressNoForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressNoForcing(),
+        ),
+    ]
+
+    for BC in boundary_conditions
+        test_divergence_free(imex = false, BC = BC)
+        test_divergence_free(imex = true, BC = BC)
+    end
 end

--- a/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
+++ b/test/Ocean/HydrostaticBoussinesq/test_ocean_gyre.jl
@@ -1,30 +1,34 @@
 using Test
 using CLIMA
-using CLIMA.HydrostaticBoussinesq
 using CLIMA.GenericCallbacks
 using CLIMA.ODESolvers
 using CLIMA.Mesh.Filters
 using CLIMA.VariableTemplates
 using CLIMA.Mesh.Grids: polynomialorder
+using CLIMA.HydrostaticBoussinesq
 
 using CLIMAParameters
 using CLIMAParameters.Planet: grav
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-function config_simple_box(FT, N, resolution, dimensions)
-    prob = OceanGyre{FT}(dimensions...)
+function config_simple_box(FT, N, resolution, dimensions; BC = nothing)
+    if BC == nothing
+        problem = OceanGyre{FT}(dimensions...)
+    else
+        problem = OceanGyre{FT}(dimensions...; BC = BC)
+    end
 
     _grav::FT = grav(param_set)
-    cʰ = sqrt(_grav * prob.H) # m/s
-    model = HydrostaticBoussinesqModel{FT}(param_set, prob, cʰ = cʰ)
+    cʰ = sqrt(_grav * problem.H) # m/s
+    model = HydrostaticBoussinesqModel{FT}(param_set, problem, cʰ = cʰ)
 
     config = CLIMA.OceanBoxGCMConfiguration("ocean_gyre", N, resolution, model)
 
     return config
 end
 
-function main(; imex::Bool = false, Δt = 60)
+function test_ocean_gyre(; imex::Bool = false, BC = nothing, Δt = 60)
     CLIMA.init()
 
     FT = Float64
@@ -44,16 +48,18 @@ function main(; imex::Bool = false, Δt = 60)
     dimensions = (Lˣ, Lʸ, H)
 
     timestart = FT(0)    # s
-    timeend = FT(360) # s
+    timeend = FT(36000) # s
 
     if imex
         solver_type = CLIMA.IMEXSolverType(linear_model = LinearHBModel)
+        Courant_number = 0.1
     else
         solver_type =
             CLIMA.ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
+        Courant_number = 0.4
     end
 
-    driver_config = config_simple_box(FT, N, resolution, dimensions)
+    driver_config = config_simple_box(FT, N, resolution, dimensions; BC = BC)
 
     grid = driver_config.grid
     vert_filter = CutoffFilter(grid, polynomialorder(grid) - 1)
@@ -68,6 +74,7 @@ function main(; imex::Bool = false, Δt = 60)
         ode_solver_type = solver_type,
         ode_dt = FT(Δt),
         modeldata = modeldata,
+        Courant_number = Courant_number,
     )
 
     result = CLIMA.invoke!(solver_config)
@@ -76,6 +83,21 @@ function main(; imex::Bool = false, Δt = 60)
 end
 
 @testset "$(@__FILE__)" begin
-    main(imex = false, Δt = 6)
-    main(imex = true)
+    boundary_conditions = [
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressForcing(),
+        ),
+        (
+            CLIMA.HydrostaticBoussinesq.CoastlineFreeSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanFloorNoSlip(),
+            CLIMA.HydrostaticBoussinesq.OceanSurfaceStressForcing(),
+        ),
+    ]
+
+    for BC in boundary_conditions
+        test_ocean_gyre(imex = false, BC = BC, Δt = 600)
+        test_ocean_gyre(imex = true, BC = BC, Δt = 150)
+    end
 end


### PR DESCRIPTION
# Description

The current implementation didn't properly zero out the normal component of velocity. Updated these to follow equations 1.26 and 1.28 from the numerics section of the design docs. 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
