### PR TITLE
Add `param_set` to `orientations.jl` function args

### DIFF
--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -33,7 +33,7 @@ function init_heldsuarez!(bl, state, aux, coords, t)
     temp_profile = IsothermalProfile(T_ref)
 
     # Calculate the initial state variables
-    T, p = temp_profile(bl.orientation, aux)
+    T, p = temp_profile(bl.orientation, bl.param_set, aux)
     thermo_state = PhaseDry_given_pT(p, T, bl.param_set)
     ρ = air_density(thermo_state)
     e_int = internal_energy(thermo_state)
@@ -127,9 +127,9 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
     T_equator = FT(315)
     T_min = FT(200)
     σ_b = FT(7 / 10)
-    λ = longitude(bl.orientation, aux)
-    φ = latitude(bl.orientation, aux)
-    z = altitude(bl.orientation, aux)
+    λ = longitude(bl, aux)
+    φ = latitude(bl, aux)
+    z = altitude(bl, aux)
     scale_height = _R_d * T_ref / _grav
     σ = exp(-z / scale_height)
 
@@ -145,7 +145,7 @@ function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
     k_v = k_f * height_factor
 
     # Apply Held-Suarez forcing
-    source.ρu -= k_v * projection_tangential(bl.orientation, aux, ρu)
+    source.ρu -= k_v * projection_tangential(bl, aux, ρu)
     source.ρe -= k_T * ρ * _cv_d * (T - T_equil)
     return nothing
 end

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -103,10 +103,10 @@ function atmos_source!(
     u_slope = s.u_slope
     v_geostrophic = s.v_geostrophic
 
-    z = altitude(atmos.orientation, aux)
+    z = altitude(atmos, aux)
     # Note z dependence of eastward geostrophic velocity
     u_geo = SVector(u_geostrophic + u_slope * z, v_geostrophic, 0)
-    ẑ = vertical_unit_vector(atmos.orientation, aux)
+    ẑ = vertical_unit_vector(atmos, aux)
     fkvector = f_coriolis * ẑ
     # Accumulate sources
     source.ρu -= fkvector × (state.ρu .- state.ρ * u_geo)
@@ -150,9 +150,9 @@ function atmos_source!(
     u_slope = s.u_slope
     v_geostrophic = s.v_geostrophic
 
-    z = altitude(atmos.orientation, aux)
+    z = altitude(atmos, aux)
     u_geo = SVector(u_geostrophic + u_slope * z, v_geostrophic, 0)
-    ẑ = vertical_unit_vector(atmos.orientation, aux)
+    ẑ = vertical_unit_vector(atmos, aux)
     # Accumulate sources
     if z_sponge <= z
         r = (z - z_sponge) / (z_max - z_sponge)
@@ -195,7 +195,7 @@ function atmos_source!(
 )
     FT = eltype(state)
     ρ = state.ρ
-    z = altitude(atmos.orientation, aux)
+    z = altitude(atmos, aux)
     _e_int_v0 = FT(e_int_v0(atmos.param_set))
 
     # Establish thermodynamic state
@@ -214,7 +214,7 @@ function atmos_source!(
     w_sub = s.w_sub
     ∂qt∂t_peak = s.∂qt∂t_peak
     ∂θ∂t_peak = s.∂θ∂t_peak
-    k̂ = vertical_unit_vector(atmos.orientation, aux)
+    k̂ = vertical_unit_vector(atmos, aux)
 
     # Thermodynamic state identification
     q_pt = PhasePartition(TS)

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -144,7 +144,7 @@ function flux_radiation!(
     t::Real,
 )
     FT = eltype(flux)
-    z = altitude(atmos.orientation, aux)
+    z = altitude(atmos, aux)
     Δz_i = max(z - m.z_i, -zero(FT))
     # Constants
     upward_flux_from_cloud = m.F_0 * exp(-aux.∫dnz.radiation.attenuation_coeff)
@@ -158,7 +158,7 @@ function flux_radiation!(
         (Δz_i / 4 + m.z_i)
     F_rad =
         upward_flux_from_sfc + upward_flux_from_cloud + free_troposphere_flux
-    ẑ = vertical_unit_vector(atmos.orientation, aux)
+    ẑ = vertical_unit_vector(atmos, aux)
     flux.ρe += F_rad * ẑ
 end
 function preodefun!(m::DYCOMSRadiation, aux::Vars, state::Vars, t::Real) end
@@ -187,7 +187,7 @@ eprint = {https://doi.org/10.1175/MWR2930.1}
 function init_dycoms!(bl, state, aux, (x, y, z), t)
     FT = eltype(state)
 
-    z = altitude(bl.orientation, aux)
+    z = altitude(bl, aux)
 
     # These constants are those used by Stevens et al. (2005)
     qref = FT(9.0e-3)

--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -29,7 +29,7 @@ function advective_courant(
     t,
     direction,
 )
-    k̂ = vertical_unit_vector(m.orientation, aux)
+    k̂ = vertical_unit_vector(m, aux)
     normu = norm_u(state, k̂, direction)
     return Δt * normu / Δx
 end
@@ -44,7 +44,7 @@ function nondiffusive_courant(
     t,
     direction,
 )
-    k̂ = vertical_unit_vector(m.orientation, aux)
+    k̂ = vertical_unit_vector(m, aux)
     normu = norm_u(state, k̂, direction)
     return Δt * (normu + soundspeed(m, m.moisture, state, aux)) / Δx
 end
@@ -60,7 +60,7 @@ function diffusive_courant(
     direction,
 )
     ν, τ = turbulence_tensors(m.turbulence, state, diffusive, aux, t)
-    k̂ = vertical_unit_vector(m.orientation, aux)
+    k̂ = vertical_unit_vector(m, aux)
     normν = norm_ν(ν, k̂, direction)
     return Δt * normν / (Δx * Δx)
 end

--- a/src/Atmos/Model/orientation.jl
+++ b/src/Atmos/Model/orientation.jl
@@ -14,18 +14,26 @@ function vars_aux(m::Orientation, T)
   end
 end
 
+altitude(atmos::AtmosModel, aux::Vars) = altitude(atmos.orientation, atmos.param_set, aux)
+latitude(atmos::AtmosModel, aux::Vars) = latitude(atmos.orientation, aux)
+longitude(atmos::AtmosModel, aux::Vars) = longitude(atmos.orientation, aux)
+vertical_unit_vector(atmos::AtmosModel, aux::Vars) = vertical_unit_vector(atmos.orientation, atmos.param_set, aux)
+projection_normal(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) = projection_normal(atmos.orientation, atmos.param_set, aux, u⃗)
+projection_tangential(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) = projection_tangential(atmos.orientation, atmos.param_set, aux, u⃗)
+
+
 gravitational_potential(::Orientation, aux::Vars) = aux.orientation.Φ
 ∇gravitational_potential(::Orientation, aux::Vars) = aux.orientation.∇Φ
-altitude(orientation::Orientation, aux::Vars) = gravitational_potential(orientation, aux) / grav
-vertical_unit_vector(orientation::Orientation, aux::Vars) = ∇gravitational_potential(orientation, aux) / grav
+altitude(orientation::Orientation, param_set, aux::Vars) = gravitational_potential(orientation, aux) / grav
+vertical_unit_vector(orientation::Orientation, param_set, aux::Vars) = ∇gravitational_potential(orientation, aux) / grav
 
-function projection_normal(orientation::Orientation, aux::Vars, u⃗::AbstractVector)
-  n̂ = vertical_unit_vector(orientation, aux)
+function projection_normal(orientation::Orientation, param_set, aux::Vars, u⃗::AbstractVector)
+  n̂ = vertical_unit_vector(orientation, param_set, aux)
   return n̂ * (n̂' * u⃗)
 end
 
-function projection_tangential(orientation::Orientation, aux::Vars, u⃗::AbstractVector)
-  return u⃗ .- projection_normal(orientation, aux, u⃗)
+function projection_tangential(orientation::Orientation, param_set, aux::Vars, u⃗::AbstractVector)
+  return u⃗ .- projection_normal(orientation, param_set, aux, u⃗)
 end
 
 
@@ -42,7 +50,7 @@ end
 atmos_init_aux!(::NoOrientation, ::AtmosModel, aux::Vars, geom::LocalGeometry) = nothing
 gravitational_potential(::NoOrientation, aux::Vars) = -zero(eltype(aux))
 ∇gravitational_potential(::NoOrientation, aux::Vars) = SVector{3,eltype(aux)}(0,0,0)
-altitude(orientation::NoOrientation, aux::Vars) = -zero(eltype(aux))
+altitude(orientation::NoOrientation, param_set, aux::Vars) = -zero(eltype(aux))
 
 """
     SphericalOrientation <: Orientation

--- a/src/Atmos/Model/orientation.jl
+++ b/src/Atmos/Model/orientation.jl
@@ -1,39 +1,60 @@
 # TODO: add Coriolis vectors
 import ..PlanetParameters: grav, planet_radius
 export Orientation, NoOrientation, FlatOrientation, SphericalOrientation
-export vertical_unit_vector, altitude, latitude, longitude, gravitational_potential, projection_normal, projection_tangential
+export vertical_unit_vector,
+    altitude,
+    latitude,
+    longitude,
+    gravitational_potential,
+    projection_normal,
+    projection_tangential
 
-abstract type Orientation
-end
+abstract type Orientation end
 
 
 function vars_aux(m::Orientation, T)
-  @vars begin
-    Φ::T # gravitational potential
-    ∇Φ::SVector{3,T}
-  end
+    @vars begin
+        Φ::T # gravitational potential
+        ∇Φ::SVector{3, T}
+    end
 end
 
-altitude(atmos::AtmosModel, aux::Vars) = altitude(atmos.orientation, atmos.param_set, aux)
+altitude(atmos::AtmosModel, aux::Vars) =
+    altitude(atmos.orientation, atmos.param_set, aux)
 latitude(atmos::AtmosModel, aux::Vars) = latitude(atmos.orientation, aux)
 longitude(atmos::AtmosModel, aux::Vars) = longitude(atmos.orientation, aux)
-vertical_unit_vector(atmos::AtmosModel, aux::Vars) = vertical_unit_vector(atmos.orientation, atmos.param_set, aux)
-projection_normal(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) = projection_normal(atmos.orientation, atmos.param_set, aux, u⃗)
-projection_tangential(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) = projection_tangential(atmos.orientation, atmos.param_set, aux, u⃗)
+vertical_unit_vector(atmos::AtmosModel, aux::Vars) =
+    vertical_unit_vector(atmos.orientation, atmos.param_set, aux)
+projection_normal(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) =
+    projection_normal(atmos.orientation, atmos.param_set, aux, u⃗)
+projection_tangential(atmos::AtmosModel, aux::Vars, u⃗::AbstractVector) =
+    projection_tangential(atmos.orientation, atmos.param_set, aux, u⃗)
 
 
 gravitational_potential(::Orientation, aux::Vars) = aux.orientation.Φ
 ∇gravitational_potential(::Orientation, aux::Vars) = aux.orientation.∇Φ
-altitude(orientation::Orientation, param_set, aux::Vars) = gravitational_potential(orientation, aux) / grav
-vertical_unit_vector(orientation::Orientation, param_set, aux::Vars) = ∇gravitational_potential(orientation, aux) / grav
+altitude(orientation::Orientation, param_set, aux::Vars) =
+    gravitational_potential(orientation, aux) / grav
+vertical_unit_vector(orientation::Orientation, param_set, aux::Vars) =
+    ∇gravitational_potential(orientation, aux) / grav
 
-function projection_normal(orientation::Orientation, param_set, aux::Vars, u⃗::AbstractVector)
-  n̂ = vertical_unit_vector(orientation, param_set, aux)
-  return n̂ * (n̂' * u⃗)
+function projection_normal(
+    orientation::Orientation,
+    param_set,
+    aux::Vars,
+    u⃗::AbstractVector,
+)
+    n̂ = vertical_unit_vector(orientation, param_set, aux)
+    return n̂ * (n̂' * u⃗)
 end
 
-function projection_tangential(orientation::Orientation, param_set, aux::Vars, u⃗::AbstractVector)
-  return u⃗ .- projection_normal(orientation, param_set, aux, u⃗)
+function projection_tangential(
+    orientation::Orientation,
+    param_set,
+    aux::Vars,
+    u⃗::AbstractVector,
+)
+    return u⃗ .- projection_normal(orientation, param_set, aux, u⃗)
 end
 
 
@@ -42,14 +63,15 @@ end
 
 No gravitional force or potential.
 """
-struct NoOrientation <: Orientation
-end
+struct NoOrientation <: Orientation end
 function vars_aux(m::NoOrientation, T)
-  @vars()
+    @vars()
 end
-atmos_init_aux!(::NoOrientation, ::AtmosModel, aux::Vars, geom::LocalGeometry) = nothing
+atmos_init_aux!(::NoOrientation, ::AtmosModel, aux::Vars, geom::LocalGeometry) =
+    nothing
 gravitational_potential(::NoOrientation, aux::Vars) = -zero(eltype(aux))
-∇gravitational_potential(::NoOrientation, aux::Vars) = SVector{3,eltype(aux)}(0,0,0)
+∇gravitational_potential(::NoOrientation, aux::Vars) =
+    SVector{3, eltype(aux)}(0, 0, 0)
 altitude(orientation::NoOrientation, param_set, aux::Vars) = -zero(eltype(aux))
 
 """
@@ -58,16 +80,22 @@ altitude(orientation::NoOrientation, param_set, aux::Vars) = -zero(eltype(aux))
 Gravity acts towards the origin `(0,0,0)`, and the gravitational potential is relative
 to the surface of the planet.
 """
-struct SphericalOrientation <: Orientation
-end
-function atmos_init_aux!(::SphericalOrientation, ::AtmosModel, aux::Vars, geom::LocalGeometry)
-  normcoord = norm(aux.coord)
-  aux.orientation.Φ = grav * (normcoord - planet_radius)
-  aux.orientation.∇Φ = grav / normcoord .* aux.coord
+struct SphericalOrientation <: Orientation end
+function atmos_init_aux!(
+    ::SphericalOrientation,
+    ::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    normcoord = norm(aux.coord)
+    aux.orientation.Φ = grav * (normcoord - planet_radius)
+    aux.orientation.∇Φ = grav / normcoord .* aux.coord
 end
 # TODO: should we define these for non-spherical orientations?
-latitude(orientation::SphericalOrientation, aux::Vars) = @inbounds asin(aux.coord[3] / norm(aux.coord, 2))
-longitude(orientation::SphericalOrientation, aux::Vars) = @inbounds atan(aux.coord[2], aux.coord[1])
+latitude(orientation::SphericalOrientation, aux::Vars) =
+    @inbounds asin(aux.coord[3] / norm(aux.coord, 2))
+longitude(orientation::SphericalOrientation, aux::Vars) =
+    @inbounds atan(aux.coord[2], aux.coord[1])
 
 
 """
@@ -77,9 +105,14 @@ Gravity acts in the third coordinate, and the gravitational potential is relativ
 `coord[3] == 0`.
 """
 struct FlatOrientation <: Orientation
-  # for Coriolis we could add latitude?
+    # for Coriolis we could add latitude?
 end
-function atmos_init_aux!(::FlatOrientation, ::AtmosModel, aux::Vars, geom::LocalGeometry)
-  aux.orientation.Φ = grav * aux.coord[3]
-  aux.orientation.∇Φ = SVector{3,eltype(aux)}(0,0,grav)
+function atmos_init_aux!(
+    ::FlatOrientation,
+    ::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    aux.orientation.Φ = grav * aux.coord[3]
+    aux.orientation.∇Φ = SVector{3, eltype(aux)}(0, 0, grav)
 end

--- a/src/Atmos/Model/ref_state.jl
+++ b/src/Atmos/Model/ref_state.jl
@@ -99,7 +99,11 @@ struct IsothermalProfile{F} <: TemperatureProfile
     T::F
 end
 
-function (profile::IsothermalProfile)(orientation::Orientation, param_set, aux::Vars)
+function (profile::IsothermalProfile)(
+    orientation::Orientation,
+    param_set,
+    aux::Vars,
+)
     p =
         MSLP *
         exp(-gravitational_potential(orientation, aux) / (R_d * profile.T))
@@ -124,7 +128,11 @@ struct DryAdiabaticProfile{F} <: TemperatureProfile
     θ::F
 end
 
-function (profile::DryAdiabaticProfile)(orientation::Orientation, param_set, aux::Vars)
+function (profile::DryAdiabaticProfile)(
+    orientation::Orientation,
+    param_set,
+    aux::Vars,
+)
     FT = eltype(aux)
     LinearTemperatureProfile(profile.T_min, profile.θ, FT(grav / cp_d))(
         orientation,

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -88,9 +88,9 @@ function atmos_source!(
     t::Real,
 )
     ρ = state.ρ
-    z = altitude(atmos.orientation, aux)
+    z = altitude(atmos, aux)
     w_sub = subsidence_velocity(subsidence, z)
-    k̂ = vertical_unit_vector(atmos.orientation, aux)
+    k̂ = vertical_unit_vector(atmos, aux)
 
     source.ρe -= ρ * w_sub * dot(k̂, diffusive.∇h_tot)
     source.moisture.ρq_tot -= ρ * w_sub * dot(k̂, diffusive.moisture.∇q_tot)
@@ -115,7 +115,7 @@ function atmos_source!(
     t::Real,
 )
     u_geo = SVector(s.u_geostrophic, s.v_geostrophic, 0)
-    ẑ = vertical_unit_vector(atmos.orientation, aux)
+    ẑ = vertical_unit_vector(atmos, aux)
     fkvector = s.f_coriolis * ẑ
     source.ρu -= fkvector × (state.ρu .- state.ρ * u_geo)
 end
@@ -148,7 +148,7 @@ function atmos_source!(
     aux::Vars,
     t::Real,
 )
-    z = altitude(atmos.orientation, aux)
+    z = altitude(atmos, aux)
     if z >= s.z_sponge
         r = (z - s.z_sponge) / (s.z_max - s.z_sponge)
         β_sponge = s.α_max * sinpi(r / 2)^s.γ

--- a/test/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -249,9 +249,9 @@ function (setup::AcousticWaveSetup)(bl, state, aux, coords, t)
     # callable to set initial conditions
     FT = eltype(state)
 
-    λ = longitude(bl.orientation, aux)
-    φ = latitude(bl.orientation, aux)
-    z = altitude(bl.orientation, aux)
+    λ = longitude(bl, aux)
+    φ = latitude(bl, aux)
+    z = altitude(bl, aux)
 
     β = min(FT(1), setup.α * acos(cos(φ) * cos(λ)))
     f = (1 + cos(FT(π) * β)) / 2

--- a/test/DGmethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/DGmethods/advection_diffusion/advection_diffusion_model.jl
@@ -23,6 +23,10 @@ using CLIMA.DGmethods.NumericalFluxes:
     NumericalFluxNonDiffusive, NumericalFluxDiffusive, NumericalFluxGradient
 import CLIMA.DGmethods.NumericalFluxes: boundary_flux_diffusive!
 
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
 abstract type AdvectionDiffusionProblem end
 struct AdvectionDiffusion{dim, P, fluxBC, no_diffusion} <: BalanceLaw
     problem::P

--- a/test/Driver/gcm_driver_test.jl
+++ b/test/Driver/gcm_driver_test.jl
@@ -28,9 +28,9 @@ function (setup::AcousticWaveSetup)(bl, state, aux, coords, t)
     # callable to set initial conditions
     FT = eltype(state)
 
-    λ = longitude(bl.orientation, aux)
-    φ = latitude(bl.orientation, aux)
-    z = altitude(bl.orientation, aux)
+    λ = longitude(bl, aux)
+    φ = latitude(bl, aux)
+    z = altitude(bl, aux)
 
     β = min(FT(1), setup.α * acos(cos(φ) * cos(λ)))
     f = (1 + cos(FT(π) * β)) / 2

--- a/test/Mesh/interpolation.jl
+++ b/test/Mesh/interpolation.jl
@@ -75,7 +75,7 @@ function (setup::TestSphereSetup)(bl, state, aux, coords, t)
     _grav::FT = grav(param_set)
     _R_d::FT = R_d(param_set)
 
-    z = altitude(bl.orientation, aux)
+    z = altitude(bl, aux)
 
     scale_height = _R_d * setup.T_initial / _grav
     p = setup.p_ground * exp(-z / scale_height)


### PR DESCRIPTION
# Description

This PR adds `param_set` to function arguments in `orientations.jl`, to prepare switching from PlanetParameters to CLIMAParameters. This is needed because `grav` in `altitude` needs to change to `grav(param_set)`. Convenience wrappers were added that accept the balance law and aux.


<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
