### PR TITLE
Move coverage CI  to GitHub Actions

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -1,0 +1,52 @@
+name: Coverage
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run at 2am every day:
+    - cron:  '0 2 * * *'
+
+jobs:
+  coverage:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1.3']
+        os: [ubuntu-latest]
+        project: ['CLIMA']
+
+    steps:
+    - uses: actions/checkout@v1.0.0
+    - name: "Set up Julia"
+      uses: julia-actions/setup-julia@v1
+      with:
+        version: ${{ matrix.julia-version }}
+    - name: Install deps
+      run: |
+        set -o xtrace
+        sudo apt-get update
+        sudo apt-get install mpich libmpich-dev
+    - name: Test with coverage
+      env:
+        JULIA_PROJECT: "@."
+      run: |
+        julia --project=@. -e 'using Pkg;
+                               Pkg.instantiate()'
+        julia --project=@. -e 'using Pkg;
+                               cd(Pkg.dir("CLIMA"));
+                               Pkg.test(coverage=true)'
+    - name: Generate coverage
+      env:
+        JULIA_PROJECT: "@."
+      run: julia --project=@. -e 'using Pkg;
+                                  cd(Pkg.dir("CLIMA"));
+                                  Pkg.add("Coverage");
+                                  using Coverage;
+                                  LCOV.writefile("coverage-lcov.info", Codecov.process_folder())'
+      if: success()
+    - name: Submit coverage
+      uses: codecov/codecov-action@v1.0.2
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+      if: success()
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,22 +35,8 @@ jobs:
       set -o xtrace
       ./julia-$(JULIA_VERSION)/bin/julia -e 'using InteractiveUtils; versioninfo()'
       ./julia-$(JULIA_VERSION)/bin/julia --project=@. -e 'using Pkg; Pkg.instantiate()'
-      ./julia-$(JULIA_VERSION)/bin/julia --project=@. -e 'using Pkg; Pkg.test(coverage=true)'
+      ./julia-$(JULIA_VERSION)/bin/julia --project=@. -e 'using Pkg; Pkg.test()'
     displayName: 'Run the tests'
-  - bash: |
-      ./julia-$(JULIA_VERSION)/bin/julia --project=.coverage -e 'using Pkg; Pkg.instantiate();
-                                                                 Pkg.add("Coverage");
-                                                                 using Coverage;
-                                                                 Codecov.submit_local(Codecov.process_folder();
-                                                                   service = "azure_pipelines",
-                                                                   commit       = ENV["BUILD_SOURCEVERSION"],
-                                                                   pull_request = get(ENV, "SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", "false"),
-                                                                   job          = ENV["BUILD_DEFINITIONNAME"],
-                                                                   slug         = ENV["BUILD_REPOSITORY_NAME"],
-                                                                   build        = ENV["BUILD_BUILDID"])'
-    env:
-      CODECOV_TOKEN: "d5ad49b6-c247-44f7-a529-5f749a8b0c2a"
-    displayName: 'Submit code coverage'
     continueOnError: true
 
 - job: macOS


### PR DESCRIPTION
# Description

This PR:
 - [x] Adds a coverage GitHub Actions CI (GitHub hosted)
 - [x] Removes coverage from the azure pipeline YML

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
