### PR TITLE
Adding MultiRate, Infinitesimal GARK methods

### DIFF
--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -5,6 +5,7 @@
 cpu = [
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_heat_eqn.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/advection_diffusion/periodic_3D_hyperdiffusion.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/Mesh/mpi_connect_1d.jl", slurmargs = ["--ntasks=5"], args = [] },
@@ -44,6 +45,7 @@ cpu_gpu = [
 gpu = [
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl", slurmargs = ["--ntasks=3"], args = ["--integration-testing"] },
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_heat_eqn.jl", slurmargs = ["--ntasks=3"], args = ["--integration-testing"] },
   { file = "test/Numerics/DGmethods/advection_diffusion/periodic_3D_hyperdiffusion.jl", slurmargs = ["--ntasks=3"], args = ["--integration-testing"] },
   { file = "tutorials/Atmos/dry_rayleigh_benard.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = [] },

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -23,6 +23,7 @@ cpu_gpu = [
   { file = "test/Numerics/DGmethods/Euler/isentropicvortex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/Euler/isentropicvortex_imex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/Euler/isentropicvortex_multirate.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/Numerics/DGmethods/Euler/isentropicvortex_mrigark.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -24,6 +24,7 @@ cpu_gpu = [
   { file = "test/Numerics/DGmethods/Euler/isentropicvortex_imex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/Euler/isentropicvortex_multirate.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/Euler/isentropicvortex_mrigark.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "test/Numerics/DGmethods/Euler/isentropicvortex_mrigark_implicit.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "test/Numerics/DGmethods/compressible_Navier_Stokes/mms_bc_dgmodel.jl", slurmargs = ["--ntasks=3"], args = [] },

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -209,7 +209,10 @@ function SolverConfiguration(
         solver = ode_solver_type.solver_method(
             dg,
             vdg,
-            ode_solver_type.linear_solver(),
+            LinearBackwardEulerSolver(
+                ode_solver_type.linear_solver();
+                isadjustable = false,
+            ),
             Q;
             dt = ode_dt,
             t0 = t0,

--- a/src/Numerics/ODESolvers/AdditiveRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/AdditiveRungeKuttaMethod.jl
@@ -20,36 +20,11 @@ additional_storage(::LowStorageVariant, Q, Nstages) = (Qtt = similar(Q),)
 abstract type AbstractAdditiveRungeKutta <: AbstractODESolver end
 
 """
-    op! = EulerOperator(f!, ϵ)
-
-Construct a linear operator which performs an explicit Euler step ``Q + α
-f(Q)``, where `f!` and `op!` both operate inplace, with extra arguments passed
-through, i.e.
-```
-op!(LQ, Q, args...)
-```
-is equivalent to
-```
-f!(dQ, Q, args...)
-LQ .= Q .+ ϵ .* dQ
-```
-"""
-mutable struct EulerOperator{F, FT}
-    f!::F
-    ϵ::FT
-end
-
-function (op::EulerOperator)(LQ, Q, args...)
-    op.f!(LQ, Q, args...; increment = false)
-    @. LQ = Q + op.ϵ * LQ
-end
-
-"""
-    AdditiveRungeKutta(f, l, linearsolver, RKAe, RKAi, RKB, RKC, Q;
-                       split_nonlinear_linear, variant, dt, t0 = 0)
+    AdditiveRungeKutta(f, l, backward_euler_solver, RKAe, RKAi, RKB, RKC, Q;
+                       split_explicit_implicit, variant, dt, t0 = 0)
 
 This is a time stepping object for implicit-explicit time stepping of a
-decomposed differential equation. When `split_nonlinear_linear == false`
+decomposed differential equation. When `split_explicit_implicit == false`
 the equation is assumed to be decomposed as
 
 ```math
@@ -57,19 +32,19 @@ the equation is assumed to be decomposed as
 ```
 
 where `Q` is the state, `f` is the full tendency and
-`l` is the chosen linear operator. When `split_nonlinear_linear == true`
+`l` is the chosen implicit operator. When `split_explicit_implicit == true`
 the assumed decomposition is
 
 ```math
   \\dot{Q} = [l(Q, t)] + [f(Q, t)]
 ```
 
-where `f` is now only the nonlinear tendency. For both decompositions the linear
+where `f` is now only the nonlinear tendency. For both decompositions the implicit
 operator `l` is integrated implicitly whereas the remaining part is integrated
 explicitly. Other arguments are the required time step size `dt` and the
-optional initial time `t0`. The resulting linear systems are solved using the
-provided `linearsolver` solver. This time stepping object is intended to be
-passed to the `solve!` command.
+optional initial time `t0`. The resulting backward Euler type systems are solved
+using the provided `backward_euler_solver`. This time stepping object is
+intended to be passed to the `solve!` command.
 
 The constructor builds an additive Runge--Kutta scheme based on the provided
 `RKAe`, `RKAi`, `RKB` and `RKC` coefficient arrays.  Additionally `variant`
@@ -82,7 +57,7 @@ The available concrete implementations are:
   - [`ARK548L2SA2KennedyCarpenter`](@ref)
   - [`ARK437L2SA1KennedyCarpenter`](@ref)
 """
-mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <:
+mutable struct AdditiveRungeKutta{T, RT, AT, BE, V, VS, Nstages, Nstages_sq} <:
                AbstractAdditiveRungeKutta
     "time step"
     dt::RT
@@ -91,11 +66,9 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <:
     "rhs function"
     rhs!
     "rhs linear operator"
-    rhs_linear!
-    "implicit operator, pre-factorized"
-    implicitoperator!
-    "linear solver"
-    linearsolver::LT
+    rhs_implicit!
+    "backwark Euler solver"
+    besolver!::BE
     "Storage for solution during the AdditiveRungeKutta update"
     Qstages::NTuple{Nstages, AT}
     "Storage for RHS during the AdditiveRungeKutta update"
@@ -110,7 +83,7 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <:
     RKB::SArray{Tuple{Nstages}, RT, 1, Nstages}
     "RK coefficient vector C (time scaling)"
     RKC::SArray{Tuple{Nstages}, RT, 1, Nstages}
-    split_nonlinear_linear::Bool
+    split_explicit_implicit::Bool
     "Variant of the ARK scheme"
     variant::V
     "Storage dependent on the variant of the ARK scheme"
@@ -118,13 +91,13 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <:
 
     function AdditiveRungeKutta(
         rhs!,
-        rhs_linear!,
-        linearsolver::AbstractLinearSolver,
+        rhs_implicit!,
+        backward_euler_solver,
         RKA_explicit,
         RKA_implicit,
         RKB,
         RKC,
-        split_nonlinear_linear,
+        split_explicit_implicit,
         variant,
         Q::AT;
         dt = nothing,
@@ -134,7 +107,6 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <:
         @assert dt != nothing
 
         T = eltype(Q)
-        LT = typeof(linearsolver)
         RT = real(T)
 
         Nstages = length(RKB)
@@ -154,24 +126,22 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <:
         end
 
         α = dt * RKA_implicit[2, 2]
-        # Here we are passing NaN for the time since prefactorization assumes
-        # the operator is time independent.  If that is not the case the NaN
-        # will surface.
-        implicitoperator! = prefactorize(
-            EulerOperator(rhs_linear!, -α),
-            linearsolver,
+        besolver! = setup_backward_Euler_solver(
+            backward_euler_solver,
             Q,
-            nothing,
-            T(NaN),
+            α,
+            rhs_implicit!,
         )
+        @assert besolver! isa AbstractBackwardEulerSolver
+        @assert besolver! isa LinBESolver || variant isa NaiveVariant
+        BE = typeof(besolver!)
 
-        new{T, RT, AT, LT, V, VS, Nstages, Nstages^2}(
+        new{T, RT, AT, BE, V, VS, Nstages, Nstages^2}(
             RT(dt),
             RT(t0),
             rhs!,
-            rhs_linear!,
-            implicitoperator!,
-            linearsolver,
+            rhs_implicit!,
+            besolver!,
             Qstages,
             Rstages,
             Qhat,
@@ -179,7 +149,7 @@ mutable struct AdditiveRungeKutta{T, RT, AT, LT, V, VS, Nstages, Nstages_sq} <:
             RKA_implicit,
             RKB,
             RKC,
-            split_nonlinear_linear,
+            split_explicit_implicit,
             variant,
             variant_storage,
         )
@@ -189,12 +159,12 @@ end
 function AdditiveRungeKutta(
     spacedisc::AbstractSpaceMethod,
     spacedisc_linear::AbstractSpaceMethod,
-    linearsolver::AbstractLinearSolver,
+    backward_euler_solver,
     RKA_explicit,
     RKA_implicit,
     RKB,
     RKC,
-    split_nonlinear_linear,
+    split_explicit_implicit,
     variant,
     Q::AT;
     dt = nothing,
@@ -203,18 +173,18 @@ function AdditiveRungeKutta(
     rhs! =
         (x...; increment) ->
             SpaceMethods.odefun!(spacedisc, x..., increment = increment)
-    rhs_linear! =
+    rhs_implicit! =
         (x...; increment) ->
             SpaceMethods.odefun!(spacedisc_linear, x..., increment = increment)
     AdditiveRungeKutta(
         rhs!,
-        rhs_linear!,
-        linearsolver,
+        rhs_implicit!,
+        backward_euler_solver,
         RKA_explicit,
         RKA_implicit,
         RKB,
         RKC,
-        split_nonlinear_linear,
+        split_explicit_implicit,
         variant,
         Q;
         dt = dt,
@@ -224,19 +194,11 @@ end
 
 # this will only work for iterative solves
 # direct solvers use prefactorization
-isadjustable(ark::AdditiveRungeKutta) = ark.implicitoperator! isa EulerOperator
 function updatedt!(ark::AdditiveRungeKutta, dt)
-    @assert isadjustable(ark)
+    @assert Δt_is_adjustable(ark.besolver!)
     ark.dt = dt
     α = dt * ark.RKA_implicit[2, 2]
-    FT = eltype(ark.Qstages[1])
-    ark.implicitoperator! = prefactorize(
-        EulerOperator(ark.rhs_linear!, -α),
-        ark.linearsolver,
-        ark.Qstages[1],
-        nothing,
-        FT(NaN),
-    )
+    update_backward_Euler_solver!(ark.besolver!, ark.Qstages[1], α)
 end
 
 function dostep!(
@@ -263,13 +225,13 @@ function dostep!(
 )
     dt = ark.dt
 
-    implicitoperator!, linearsolver = ark.implicitoperator!, ark.linearsolver
+    besolver! = ark.besolver!
     RKA_explicit, RKA_implicit = ark.RKA_explicit, ark.RKA_implicit
     RKB, RKC = ark.RKB, ark.RKC
-    rhs!, rhs_linear! = ark.rhs!, ark.rhs_linear!
+    rhs!, rhs_implicit! = ark.rhs!, ark.rhs_implicit!
     Qstages, Rstages = ark.Qstages, ark.Rstages
     Qhat = ark.Qhat
-    split_nonlinear_linear = ark.split_nonlinear_linear
+    split_explicit_implicit = ark.split_explicit_implicit
     Lstages = ark.variant_storage.Lstages
 
     rv_Q = realview(Q)
@@ -285,7 +247,7 @@ function dostep!(
     # calculate the rhs at first stage to initialize the stage loop
     rhs!(Rstages[1], Qstages[1], p, time + RKC[1] * dt, increment = false)
 
-    rhs_linear!(
+    rhs_implicit!(
         Lstages[1],
         Qstages[1],
         p,
@@ -311,7 +273,7 @@ function dostep!(
             RKA_implicit,
             dt,
             Val(istage),
-            Val(split_nonlinear_linear),
+            Val(split_explicit_implicit),
             slow_δ,
             slow_rv_dQ;
             ndrange = length(rv_Q),
@@ -320,18 +282,12 @@ function dostep!(
         wait(device(Q), event)
 
         # solves
-        # Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_linear!(Q_tt)
-        linearsolve!(
-            implicitoperator!,
-            linearsolver,
-            Qstages[istage],
-            Qhat,
-            p,
-            stagetime,
-        )
+        # Qs = Qhat + dt * RKA_implicit[istage, istage] * rhs_implicit!(Qs)
+        α = dt * RKA_implicit[istage, istage]
+        besolver!(Qstages[istage], Qhat, α, p, stagetime)
 
         rhs!(Rstages[istage], Qstages[istage], p, stagetime, increment = false)
-        rhs_linear!(
+        rhs_implicit!(
             Lstages[istage],
             Qstages[istage],
             p,
@@ -350,7 +306,7 @@ function dostep!(
         RKB,
         dt,
         Val(Nstages),
-        Val(split_nonlinear_linear),
+        Val(split_explicit_implicit),
         slow_δ,
         slow_rv_dQ,
         slow_scaling;
@@ -372,13 +328,13 @@ function dostep!(
 )
     dt = ark.dt
 
-    implicitoperator!, linearsolver = ark.implicitoperator!, ark.linearsolver
+    besolver! = ark.besolver!
     RKA_explicit, RKA_implicit = ark.RKA_explicit, ark.RKA_implicit
     RKB, RKC = ark.RKB, ark.RKC
-    rhs!, rhs_linear! = ark.rhs!, ark.rhs_linear!
+    rhs!, rhs_implicit! = ark.rhs!, ark.rhs_implicit!
     Qstages, Rstages = ark.Qstages, ark.Rstages
     Qhat = ark.Qhat
-    split_nonlinear_linear = ark.split_nonlinear_linear
+    split_explicit_implicit = ark.split_explicit_implicit
     Qtt = ark.variant_storage.Qtt
 
     rv_Q = realview(Q)
@@ -412,7 +368,7 @@ function dostep!(
             RKA_implicit,
             dt,
             Val(istage),
-            Val(split_nonlinear_linear),
+            Val(split_explicit_implicit),
             slow_δ,
             slow_rv_dQ;
             ndrange = length(rv_Q),
@@ -421,8 +377,9 @@ function dostep!(
         wait(device(Q), event)
 
         # solves
-        # Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_linear!(Q_tt)
-        linearsolve!(implicitoperator!, linearsolver, Qtt, Qhat, p, stagetime)
+        # Q_tt = Qhat + dt * RKA_implicit[istage, istage] * rhs_implicit!(Q_tt)
+        α = dt * RKA_implicit[istage, istage]
+        besolver!(Qtt, Qhat, α, p, stagetime)
 
         # update Qstages
         Qstages[istage] .+= Qtt
@@ -430,10 +387,10 @@ function dostep!(
         rhs!(Rstages[istage], Qstages[istage], p, stagetime, increment = false)
     end
 
-    if split_nonlinear_linear
+    if split_explicit_implicit
         for istage in 1:Nstages
             stagetime = time + RKC[istage] * dt
-            rhs_linear!(
+            rhs_implicit!(
                 Rstages[istage],
                 Qstages[istage],
                 p,
@@ -472,10 +429,10 @@ end
     RKA_implicit,
     dt,
     ::Val{is},
-    ::Val{split_nonlinear_linear},
+    ::Val{split_explicit_implicit},
     slow_δ,
     slow_dQ,
-) where {is, split_nonlinear_linear}
+) where {is, split_explicit_implicit}
     i = @index(Global, Linear)
     @inbounds begin
         Qhat_i = Q[i]
@@ -491,7 +448,7 @@ end
             L_implicit = dt * RKA_implicit[is, js] * Lstages[js][i]
             Qhat_i += (R_explicit + L_implicit)
             Qstages_is_i += R_explicit
-            if split_nonlinear_linear
+            if split_explicit_implicit
                 Qstages_is_i += L_explicit
             else
                 Qhat_i -= L_explicit
@@ -513,10 +470,10 @@ end
     RKA_implicit,
     dt,
     ::Val{is},
-    ::Val{split_nonlinear_linear},
+    ::Val{split_explicit_implicit},
     slow_δ,
     slow_dQ,
-) where {is, split_nonlinear_linear}
+) where {is, split_explicit_implicit}
     i = @index(Global, Linear)
     @inbounds begin
         Qhat_i = Q[i]
@@ -527,7 +484,7 @@ end
         end
 
         @unroll for js in 1:(is - 1)
-            if split_nonlinear_linear
+            if split_explicit_implicit
                 rkcoeff = RKA_implicit[is, js] / RKA_implicit[is, is]
             else
                 rkcoeff =
@@ -552,11 +509,11 @@ end
     RKB,
     dt,
     ::Val{Nstages},
-    ::Val{split_nonlinear_linear},
+    ::Val{split_explicit_implicit},
     slow_δ,
     slow_dQ,
     slow_scaling,
-) where {Nstages, split_nonlinear_linear}
+) where {Nstages, split_explicit_implicit}
     i = @index(Global, Linear)
     @inbounds begin
         if slow_δ !== nothing
@@ -568,7 +525,7 @@ end
 
         @unroll for is in 1:Nstages
             Q[i] += RKB[is] * dt * Rstages[is][i]
-            if split_nonlinear_linear
+            if split_explicit_implicit
                 Q[i] += RKB[is] * dt * Lstages[is][i]
             end
         end
@@ -602,8 +559,8 @@ end
 end
 
 """
-    ARK2GiraldoKellyConstantinescu(f, l, linearsolver, Q; dt, t0,
-                                   split_nonlinear_linear, variant, paperversion)
+    ARK2GiraldoKellyConstantinescu(f, l, backward_euler_solver, Q; dt, t0,
+                                   split_explicit_implicit, variant, paperversion)
 
 This function returns an [`AdditiveRungeKutta`](@ref) time stepping object,
 see the documentation of [`AdditiveRungeKutta`](@ref) for arguments definitions.
@@ -631,11 +588,11 @@ Giraldo, Kelly and Constantinescu (2013).
 function ARK2GiraldoKellyConstantinescu(
     F,
     L,
-    linearsolver::AbstractLinearSolver,
+    backward_euler_solver,
     Q::AT;
     dt = nothing,
     t0 = 0,
-    split_nonlinear_linear = false,
+    split_explicit_implicit = false,
     variant = LowStorageVariant(),
     paperversion = false,
 ) where {AT <: AbstractArray}
@@ -666,12 +623,12 @@ function ARK2GiraldoKellyConstantinescu(
     AdditiveRungeKutta(
         F,
         L,
-        linearsolver,
+        backward_euler_solver,
         RKA_explicit,
         RKA_implicit,
         RKB,
         RKC,
-        split_nonlinear_linear,
+        split_explicit_implicit,
         variant,
         Q;
         dt = dt,
@@ -680,8 +637,8 @@ function ARK2GiraldoKellyConstantinescu(
 end
 
 """
-    ARK548L2SA2KennedyCarpenter(f, l, linearsolver, Q; dt, t0,
-                                split_nonlinear_linear, variant)
+    ARK548L2SA2KennedyCarpenter(f, l, backward_euler_solver, Q; dt, t0,
+                                split_explicit_implicit, variant)
 
 This function returns an [`AdditiveRungeKutta`](@ref) time stepping object,
 see the documentation of [`AdditiveRungeKutta`](@ref) for arguments definitions.
@@ -706,11 +663,11 @@ Kennedy and Carpenter (2013).
 function ARK548L2SA2KennedyCarpenter(
     F,
     L,
-    linearsolver::AbstractLinearSolver,
+    backward_euler_solver,
     Q::AT;
     dt = nothing,
     t0 = 0,
-    split_nonlinear_linear = false,
+    split_explicit_implicit = false,
     variant = LowStorageVariant(),
 ) where {AT <: AbstractArray}
 
@@ -818,12 +775,12 @@ function ARK548L2SA2KennedyCarpenter(
     ark = AdditiveRungeKutta(
         F,
         L,
-        linearsolver,
+        backward_euler_solver,
         RKA_explicit,
         RKA_implicit,
         RKB,
         RKC,
-        split_nonlinear_linear,
+        split_explicit_implicit,
         variant,
         Q;
         dt = dt,
@@ -832,8 +789,8 @@ function ARK548L2SA2KennedyCarpenter(
 end
 
 """
-    ARK437L2SA1KennedyCarpenter(f, l, linearsolver, Q; dt, t0,
-                                split_nonlinear_linear, variant)
+    ARK437L2SA1KennedyCarpenter(f, l, backward_euler_solver, Q; dt, t0,
+                                split_explicit_implicit, variant)
 
 This function returns an [`AdditiveRungeKutta`](@ref) time stepping object,
 see the documentation of [`AdditiveRungeKutta`](@ref) for arguments definitions.
@@ -857,11 +814,11 @@ Kennedy and Carpenter (2013).
 function ARK437L2SA1KennedyCarpenter(
     F,
     L,
-    linearsolver::AbstractLinearSolver,
+    backward_euler_solver,
     Q::AT;
     dt = nothing,
     t0 = 0,
-    split_nonlinear_linear = false,
+    split_explicit_implicit = false,
     variant = LowStorageVariant(),
 ) where {AT <: AbstractArray}
 
@@ -959,12 +916,12 @@ function ARK437L2SA1KennedyCarpenter(
     ark = AdditiveRungeKutta(
         F,
         L,
-        linearsolver,
+        backward_euler_solver,
         RKA_explicit,
         RKA_implicit,
         RKB,
         RKC,
-        split_nonlinear_linear,
+        split_explicit_implicit,
         variant,
         Q;
         dt = dt,

--- a/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
+++ b/src/Numerics/ODESolvers/BackwardEulerSolvers.jl
@@ -1,0 +1,131 @@
+export LinearBackwardEulerSolver, AbstractBackwardEulerSolver
+
+"""
+    op! = EulerOperator(f!, ϵ)
+
+Construct a linear operator which performs an explicit Euler step ``Q + α
+f(Q)``, where `f!` and `op!` both operate inplace, with extra arguments passed
+through, i.e.
+```
+op!(LQ, Q, args...)
+```
+is equivalent to
+```
+f!(dQ, Q, args...)
+LQ .= Q .+ ϵ .* dQ
+```
+"""
+mutable struct EulerOperator{F, FT}
+    f!::F
+    ϵ::FT
+end
+
+function (op::EulerOperator)(LQ, Q, args...)
+    op.f!(LQ, Q, args..., increment = false)
+    @. LQ = Q + op.ϵ * LQ
+end
+
+abstract type AbstractBackwardEulerSolver end
+
+"""
+    (be::AbstractBackwardEulerSolver)(Q, Qhat, α, param, time)
+
+Each concrete implementations of `AbstractBackwardEulerSolver` should provide a
+callable version which solves the following system for `Q`
+```
+    Q = Qhat + α f(Q, param, time)
+```
+where `f` is the ODE tendency function, `param` are the ODE parameters, and
+`time` is the current ODE time. The arguments `Q` should be modified in place
+and should not be assumed to be initialized to any value.
+"""
+(be::AbstractBackwardEulerSolver)(Q, Qhat, α, p, t) =
+    throw(MethodError(be, (Q, Qhat, α, p, t)))
+
+"""
+    Δt_is_adjustable(::AbstractBackwardEulerSolver)
+
+Return `Bool` for whether this backward Euler solver can be updated. default is
+`false`.
+"""
+Δt_is_adjustable(::AbstractBackwardEulerSolver) = false
+
+"""
+    update_backward_Euler_solver!(::AbstractBackwardEulerSolver, α)
+
+Update the given backward Euler solver for the parameter `α`; see
+['AbstractBackwardEulerSolver'](@ref). Default behavior is no change to the
+solver.
+"""
+update_backward_Euler_solver!(::AbstractBackwardEulerSolver, Q, α) = nothing
+
+"""
+    setup_backward_Euler_solver(solver, Q, α, tendency!)
+
+Returns a concrete implementation of an `AbstractBackwardEulerSolver` that will
+solve for `Q` in systems of the form of
+```
+    Q = Qhat + α f(Q, param, time)
+```
+where `tendency!` is the in-place tendency function. Not the array `Q` is just
+passed in for type information, e.g., `Q` the same `Q` will not be used for all
+calls to the solver.
+"""
+setup_backward_Euler_solver(solver::AbstractBackwardEulerSolver, _...) = solver
+
+"""
+    LinearBackwardEulerSolver(::AbstractLinearSolver; isadjustable = false)
+
+Helper type for specifying building a backward Euler solver with a linear
+solver.  If `isadjustable == true` then the solver can be updated with a new
+time step size.
+"""
+struct LinearBackwardEulerSolver{LS}
+    solver::LS
+    isadjustable::Bool
+    LinearBackwardEulerSolver(solver; isadjustable = false) =
+        new{typeof(solver)}(solver, isadjustable)
+end
+
+"""
+    LinBESolver
+
+Concrete implementation of an `AbstractBackwardEulerSolver` to use linear
+solvers of type `AbstractLinearSolver`. See helper type
+[`LinearBackwardEulerSolver`](@ref)
+"""
+mutable struct LinBESolver{FT, FAC, LS, F} <: AbstractBackwardEulerSolver
+    α::FT
+    factors::FAC
+    solver::LS
+    isadjustable::Bool
+    rhs!::F
+end
+Δt_is_adjustable(lin::LinBESolver) = lin.isadjustable
+
+function setup_backward_Euler_solver(lin::LinearBackwardEulerSolver, Q, α, rhs!)
+    FT = eltype(α)
+    factors =
+        prefactorize(EulerOperator(rhs!, -α), lin.solver, Q, nothing, FT(NaN))
+    LinBESolver(α, factors, lin.solver, lin.isadjustable, rhs!)
+end
+
+function update_backward_Euler_solver!(lin::LinBESolver, Q, α)
+    lin.α = α
+    FT = eltype(Q)
+    lin.factors = prefactorize(
+        EulerOperator(lin.rhs!, -α),
+        lin.solver,
+        Q,
+        nothing,
+        FT(NaN),
+    )
+end
+
+function (lin::LinBESolver)(Q, Qhat, α, p, t)
+    if lin.α != α
+        @assert lin.isadjustable
+        update_backward_Euler_solver!(lin, Q, α)
+    end
+    linearsolve!(lin.factors, lin.solver, Q, Qhat, p, t)
+end

--- a/src/Numerics/ODESolvers/LowStorageRungeKuttaMethod.jl
+++ b/src/Numerics/ODESolvers/LowStorageRungeKuttaMethod.jl
@@ -145,6 +145,74 @@ end
 end
 
 """
+    dostep!(Q, lsrk::LowStorageRungeKutta2N, p::MRIParam, time::Real,
+            dt::Real)
+
+Use the 2N low storage Runge--Kutta method `lsrk` to step `Q` forward in time
+from the current time `time` to final time `time + dt`.
+
+If the optional parameter `slow_δ !== nothing` then `slow_rv_dQ * slow_δ` is
+added as an additionall ODE right-hand side source. If the optional parameter
+`slow_scaling !== nothing` then after the final stage update the scaling
+`slow_rv_dQ *= slow_scaling` is performed.
+"""
+function dostep!(Q, lsrk::LowStorageRungeKutta2N, mrip::MRIParam, time::Real)
+    dt = lsrk.dt
+
+    RKA, RKB, RKC = lsrk.RKA, lsrk.RKB, lsrk.RKC
+    rhs!, dQ = lsrk.rhs!, lsrk.dQ
+
+    rv_Q = realview(Q)
+    rv_dQ = realview(dQ)
+
+    groupsize = 256
+
+    for s in 1:length(RKA)
+        stage_time = time + RKC[s] * dt
+        rhs!(dQ, Q, mrip.p, stage_time, increment = true)
+
+        # update solution and scale RHS
+        τ = (stage_time - mrip.ts) / mrip.Δts
+        event = Event(device(Q))
+        event = lsrk_mri_update!(device(Q), groupsize)(
+            rv_dQ,
+            rv_Q,
+            RKA[s % length(RKA) + 1],
+            RKB[s],
+            τ,
+            dt,
+            mrip.γs,
+            mrip.Rs;
+            ndrange = length(rv_Q),
+            dependencies = (event,),
+        )
+        wait(device(Q), event)
+    end
+end
+
+@kernel function lsrk_mri_update!(dQ, Q, rka, rkb, τ, dt, γs, Rs)
+    i = @index(Global, Linear)
+    @inbounds begin
+        NΓ = length(γs)
+        Ns = length(γs[1])
+        dqi = dQ[i]
+
+        for s in 1:Ns
+            ri = Rs[s][i]
+            sc = γs[NΓ][s]
+            for k in (NΓ - 1):-1:1
+                sc = sc * τ + γs[k][s]
+            end
+            dqi += sc * ri
+        end
+
+        Q[i] += rkb * dt * dqi
+        dQ[i] = rka * dqi
+    end
+end
+
+
+"""
     LSRKEulerMethod(f, Q; dt, t0 = 0)
 
 This function returns a [`LowStorageRungeKutta2N`](@ref) time stepping object

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKDecoupledImplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKDecoupledImplicit.jl
@@ -1,0 +1,373 @@
+export MRIGARKDecoupledImplicit
+export MRIGARKIRK21aSandu, MRIGARKESDIRK34aSandu, MRIGARKESDIRK46aSandu
+
+"""
+    MRIGARKDecoupledImplicit(f!, backward_euler_solver, fastsolver, Γs, γ̂s, Q,
+                             Δt, t0)
+
+Construct a decoupled implicit MultiRate Infinitesimal General-structure
+Additive Runge--Kutta (MRI-GARK) scheme to solve
+
+```math
+    \\dot{y} = f(y, t) + g(y, t)
+```
+
+where `f` is the slow tendency function and `g` is the fast tendency function;
+see Sandu (2019).
+
+The fast tendency is integrated using the `fastsolver` and the slow tendency
+using the MRI-GARK scheme. Since this is a decoupled, implicit MRI-GARK there is no implicit coupling between the fast and slow tendencies.
+
+The `backward_euler_solver` should be of type `AbstractBackwardEulerSolver` or
+`LinearBackwardEulerSolver`, and is used to perform the backward Euler solves 
+for `y` given the slow tendency function, namely
+
+```math
+   y = z + α f(y, t; p)
+```
+
+Currently only ['LowStorageRungeKutta2N`](@ref) schemes are supported for
+`fastsolver`
+
+The coefficients defined by `γ̂s` can be used for an embedded scheme (only the
+last stage is different).
+
+The available concrete implementations are:
+
+  - [`MRIGARKIRK21aSandu`](@ref)
+  - [`MRIGARKESDIRK34aSandu`](@ref)
+  - [`MRIGARKESDIRK46aSandu`](@ref)
+
+### References
+
+    @article{Sandu2019,
+        title={A class of multirate infinitesimal gark methods},
+        author={Sandu, Adrian},
+        journal={SIAM Journal on Numerical Analysis},
+        volume={57},
+        number={5},
+        pages={2300--2327},
+        year={2019},
+        publisher={SIAM},
+        doi={10.1137/18M1205492}
+    }
+"""
+mutable struct MRIGARKDecoupledImplicit{
+    T,
+    RT,
+    AT,
+    Nstages,
+    NΓ,
+    FS,
+    Nx,
+    Ny,
+    Nx_Ny,
+    BE,
+} <: AbstractODESolver
+    "time step"
+    dt::RT
+    "time"
+    t::RT
+    "rhs function"
+    slowrhs!
+    "backwark Euler solver"
+    besolver!::BE
+    "Storage for RHS during the `MRIGARKDecoupledImplicit` update"
+    Rstages::NTuple{Nstages, AT}
+    "Storage for the implicit solver data vector"
+    Qhat::AT
+    "RK coefficient matrices for coupling coefficients"
+    Γs::NTuple{NΓ, SArray{Tuple{Nx, Ny}, RT, 2, Nx_Ny}}
+    "RK coefficient matrices for embedded scheme"
+    γ̂s::NTuple{NΓ, SArray{NTuple{1, Ny}, RT, 1, Ny}}
+    "RK coefficient vector C (time scaling)"
+    Δc::SArray{NTuple{1, Nstages}, RT, 1, Nstages}
+    "fast solver"
+    fastsolver::FS
+
+    function MRIGARKDecoupledImplicit(
+        slowrhs!,
+        backward_euler_solver,
+        fastsolver,
+        Γs,
+        γ̂s,
+        Q::AT,
+        dt,
+        t0,
+    ) where {AT <: AbstractArray}
+        NΓ = length(Γs)
+
+        T = eltype(Q)
+        RT = real(T)
+
+        # Compute the Δc coefficients (only explicit values kept)
+        Δc = sum(Γs[1], dims = 2)
+
+        # Couple of sanity checks on the assumptions of coefficients being of
+        # the decoupled implicit structure of Sandu (2019)
+        @assert Δc[end] == 0
+        @assert all(isapprox.(Δc[2:2:end], 0; atol = 2 * eps(RT)))
+
+        Δc = Δc[1:2:(end - 1)]
+
+        # number of slow RHS values we need to keep
+        Nstages = length(Δc)
+
+        # Couple more sanity checks on the decoupled implicit structure
+        @assert Nstages == size(Γs[1], 2) - 1
+        @assert Nstages == div(size(Γs[1], 1), 2)
+
+        # Scale in the Δc to the Γ and γ̂, and convert to real type
+        Γs = ntuple(k -> RT.(Γs[k]), NΓ)
+        γ̂s = ntuple(k -> RT.(γ̂s[k]), NΓ)
+
+        # Convert to real type
+        Δc = RT.(Δc)
+
+        # create storage for the stage values
+        Rstages = ntuple(i -> similar(Q), Nstages)
+        Qhat = similar(Q)
+
+        FS = typeof(fastsolver)
+        Nx, Ny = size(Γs[1])
+
+        # Set up the backward Euler solver with the initial value of α
+        α = dt * Γs[1][2, 2]
+        besolver! =
+            setup_backward_Euler_solver(backward_euler_solver, Q, α, slowrhs!)
+        @assert besolver! isa AbstractBackwardEulerSolver
+        BE = typeof(besolver!)
+
+        new{T, RT, AT, Nstages, NΓ, FS, Nx, Ny, Nx * Ny, BE}(
+            RT(dt),
+            RT(t0),
+            slowrhs!,
+            besolver!,
+            Rstages,
+            Qhat,
+            Γs,
+            γ̂s,
+            Δc,
+            fastsolver,
+        )
+    end
+end
+
+function updatedt!(mrigark::MRIGARKDecoupledImplicit, dt)
+    @assert Δt_is_adjustable(mrigark.besolver!)
+    α = dt * mrigark.Γs[1][2, 2]
+    update_backward_Euler_solver!(mrigark.besolver!, mrigark.Qhat, α)
+    mrigark.dt = dt
+end
+
+function dostep!(Q, mrigark::MRIGARKDecoupledImplicit, param, time::Real)
+    dt = mrigark.dt
+    fast = mrigark.fastsolver
+
+    Rs = mrigark.Rstages
+    Δc = mrigark.Δc
+
+    Nstages = length(Δc)
+    groupsize = 256
+
+    slowrhs! = mrigark.slowrhs!
+    Γs = mrigark.Γs
+    NΓ = length(Γs)
+
+    ts = time
+    groupsize = 256
+
+    besolver! = mrigark.besolver!
+    Qhat = mrigark.Qhat
+    # Since decoupled implicit methods are being used, there is an purely
+    # explicit stage followed by an implicit correction stage, hence the divide
+    # by two
+    for s in 1:Nstages
+        # Stage dt
+        dts = Δc[s] * dt
+        stage_end_time = ts + dts
+
+        # initialize the slow tendency stage value
+        slowrhs!(Rs[s], Q, param, ts, increment = false)
+
+        # # advance fast solution to time stage_end_time
+        γs = ntuple(k -> ntuple(j -> Γs[k][2s - 1, j] / Δc[s], s), NΓ)
+        mriparam = MRIParam(param, γs, realview.(Rs[1:s]), ts, dts)
+        updatetime!(mrigark.fastsolver, ts)
+        solve!(Q, mrigark.fastsolver, mriparam; timeend = stage_end_time)
+
+        # correct with implicit slow solve
+        # Qhat = Q + ∑_j Σ_k Γ_{sjk} dt Rs[j] / k
+        # (Divide by k arises from the integration γ_{ij}(τ) in Sandu (2019);
+        # see Equation (2.2b) and Definition 2.2
+        γs = ntuple(k -> ntuple(j -> dt * Γs[k][2s, j] / k, s), NΓ)
+        event = Event(device(Q))
+        event = mri_create_Qhat!(device(Q), groupsize)(
+            realview(Qhat),
+            realview(Q),
+            γs,
+            mriparam.Rs;
+            ndrange = length(realview(Q)),
+            dependencies = (event,),
+        )
+        wait(device(Q), event)
+
+        # Solve: Q = Qhat + α fslow(Q, stage_end_time)
+        α = dt * Γs[1][2s, s + 1]
+        besolver!(Q, Qhat, α, param, stage_end_time)
+
+        # update time
+        ts += dts
+    end
+end
+
+# Compute: Qhat = Q + ∑_j Σ_k Γ_{sjk} dt Rs[j] / k
+@kernel function mri_create_Qhat!(Qhat, Q, γs, Rs)
+    i = @index(Global, Linear)
+    @inbounds begin
+        NΓ = length(γs)
+        Ns = length(γs[1])
+        qhat = Q[i]
+
+        for s in 1:Ns
+            ri = Rs[s][i]
+            sc = γs[1][s]
+            for k in 2:NΓ
+                sc += γs[k][s]
+            end
+            qhat += sc * ri
+        end
+        Qhat[i] = qhat
+    end
+end
+
+"""
+    MRIGARKIRK21aSandu(f!, fastsolver, Q; dt, t0 = 0)
+
+The 2rd order, 2 stage implicit scheme from Sandu (2019).
+"""
+function MRIGARKIRK21aSandu(
+    slowrhs!,
+    backward_euler_solver,
+    fastsolver,
+    Q;
+    dt,
+    t0 = 0,
+)
+    #! format: off
+    Γ0 = [ 1 // 1 0 // 1
+          -1 // 2 1 // 2 ]
+    γ̂0 = [-1 // 2 1 // 2 ]
+    #! format: on
+    MRIGARKDecoupledImplicit(
+        slowrhs!,
+        backward_euler_solver,
+        fastsolver,
+        (Γ0,),
+        (γ̂0,),
+        Q,
+        dt,
+        t0,
+    )
+end
+
+"""
+    MRIGARKESDIRK34aSandu(f!, fastsolver, Q; dt, t0=0)
+
+The 3rd order, 4 stage decoupled implicit scheme from Sandu (2019).
+"""
+function MRIGARKESDIRK34aSandu(
+    slowrhs!,
+    backward_euler_solver,
+    fastsolver,
+    Q;
+    dt,
+    t0 = 0,
+)
+    T = real(eltype(Q))
+    μ = acot(2 * sqrt(T(2))) / 3
+    λ = 1 - cos(μ) / sqrt(T(2)) + sqrt(T(3 // 2)) * sin(μ)
+    @assert isapprox(-1 + 9λ - 18 * λ^2 + 6 * λ^3, 0, atol = 2 * eps(T))
+
+    #! format: off
+    Γ0 = [
+          T(1 // 3)               0                        0           0
+          -λ                      λ                        0           0
+          (3-10λ) / (24λ-6)       (5-18λ) / (6-24λ)        0           0
+          (-24λ^2+6λ+1) / (6-24λ) (-48λ^2+12λ+1) / (24λ-6) λ           0
+          (3-16λ) / (12-48λ)      (48λ^2-21λ+2) / (12λ-3)  (3-16λ) / 4 0
+          -λ                      0                        0           λ
+         ]
+    γ̂0 = [ 0                      0                        0           0]
+    #! format: on
+    MRIGARKDecoupledImplicit(
+        slowrhs!,
+        backward_euler_solver,
+        fastsolver,
+        (Γ0,),
+        (γ̂0,),
+        Q,
+        dt,
+        t0,
+    )
+end
+
+"""
+    MRIGARKESDIRK46aSandu(f!, fastsolver, Q; dt, t0=0)
+
+The 4th order, 6 stage decoupled implicit scheme from Sandu (2019).
+"""
+function MRIGARKESDIRK46aSandu(
+    slowrhs!,
+    implicitsolve!,
+    fastsolver,
+    Q;
+    dt,
+    t0 = 0,
+)
+    T = real(eltype(Q))
+    μ = acot(2 * sqrt(T(2))) / 3
+    λ = 1 - cos(μ) / sqrt(T(2)) + sqrt(T(3 // 2)) * sin(μ)
+    @assert isapprox(-1 + 9λ - 18 * λ^2 + 6 * λ^3, 0, atol = 2 * eps(T))
+
+    #! format: off
+    Γ0 = [
+                         1 // 5                             0 // 1                             0 // 1                              0 // 1                          0 // 1           0 // 1
+                        -1 // 4                             1 // 4                             0 // 1                              0 // 1                          0 // 1           0 // 1
+             1771023115159 // 1929363690800    -1385150376999 // 1929363690800                 0 // 1                              0 // 1                          0 // 1           0 // 1
+                    914009 // 345800                 -1000459 // 345800                        1 // 4                              0 // 1                          0 // 1           0 // 1
+            18386293581909 // 36657910125200       5506531089 // 80566835440       -178423463189 // 482340922700                   0 // 1                          0 // 1           0 // 1 
+                  36036097 // 8299200                    4621 // 118560                -38434367 // 8299200                        1 // 4                          0 // 1           0 // 1
+          -247809665162987 // 146631640500800  10604946373579 // 14663164050080   10838126175385 // 5865265620032    -24966656214317 // 36657910125200             0 // 1           0 // 1
+                  38519701 // 11618880               10517363 // 9682400               -23284701 // 19364800               -10018609 // 2904720                    1 // 4           0 // 1
+           -52907807977903 // 33838070884800   74846944529257 // 73315820250400  365022522318171 // 146631640500800  -20513210406809 // 109973730375600  -2918009798 // 1870301537  0 // 1
+                        19 // 100                         -73 // 300                         127 // 300                          127 // 300                     -313 // 300         1 // 4
+         ]
+
+    Γ1 = [
+                         0 // 1                             0 // 1                               0 // 1                              0 // 1                          0 // 1           0 // 1
+                         0 // 1                             0 // 1                               0 // 1                              0 // 1                          0 // 1           0 // 1
+            -1674554930619 // 964681845400      1674554930619 // 964681845400                    0 // 1                              0 // 1                          0 // 1           0 // 1
+                  -1007739 // 172900                  1007739 // 172900                          0 // 1                              0 // 1                          0 // 1           0 // 1
+            -8450070574289 // 18328955062600     -39429409169 // 40283417720          173621393067 // 120585230675                   0 // 1                          0 // 1           0 // 1
+                -122894383 // 16598400                  14501 // 237120                  121879313 // 16598400                       0 // 1                          0 // 1           0 // 1
+            32410002731287 // 15434909526400  -46499276605921 // 29326328100160    -34914135774643 // 11730531240064    45128506783177 // 18328955062600             0 // 1           0 // 1
+                -128357303 // 23237760              -35433927 // 19364800                 71038479 // 38729600                 8015933 // 1452360                    0 // 1           0 // 1
+           136721604296777 // 67676141769600 -349632444539303 // 146631640500800 -1292744859249609 // 293263281001600    8356250416309 // 54986865187800   17282943803 // 3740603074  0 // 1
+                         3 // 25                          -29 // 300                            71 // 300                           71 // 300                     -149 // 300         0 // 1
+         ]
+
+    γ̂0 = [-1 // 4 5595 // 8804 -2445 // 8804 -4225 // 8804 2205 // 4402 -567 // 4402]
+    γ̂1 = [ 0 // 1    0 // 1        0 // 1        0 // 1       0 // 1       0 // 1   ]
+    #! format: on
+    MRIGARKDecoupledImplicit(
+        slowrhs!,
+        implicitsolve!,
+        fastsolver,
+        (Γ0, Γ1),
+        (γ̂0, γ̂1),
+        Q,
+        dt,
+        t0,
+    )
+end

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
@@ -27,6 +27,16 @@ struct MRIParam{P, T, AT, N, M}
     end
 end
 
+# We overload get property to access the original param
+function Base.getproperty(mriparam::MRIParam, s::Symbol)
+    if s === :p
+        p = getfield(mriparam, :p)
+        return p isa MRIParam ? p.p : p
+    else
+        getfield(mriparam, s)
+    end
+end
+
 """
     MRIGARKExplicit(f!, fastsolver, Γs, γ̂s, Q, Δt, t0)
 
@@ -159,11 +169,27 @@ function dostep!(Q, mrigark::MRIGARKExplicit, param, time::Real)
     NΓ = length(Γs)
 
     ts = time
+    groupsize = 256
     for s in 1:Nstages
         # Stage dt
         dts = Δc[s] * dt
 
-        slowrhs!(Rs[s], Q, param, ts, increment = false)
+        p = param isa MRIParam ? param.p : param
+        slowrhs!(Rs[s], Q, p, ts, increment = false)
+        if param isa MRIParam
+            # fraction of the step slower stage increment we are on
+            τ = (ts - param.ts) / param.Δts
+            event = Event(device(Q))
+            event = mri_update_rate!(device(Q), groupsize)(
+                realview(Rs[s]),
+                τ,
+                param.γs,
+                param.Rs;
+                ndrange = length(realview(Rs[s])),
+                dependencies = (event,),
+            )
+            wait(device(Q), event)
+        end
 
         γs = ntuple(k -> ntuple(j -> Γs[k][s, j], s), NΓ)
         mriparam = MRIParam(param, γs, realview.(Rs[1:s]), ts, dts)
@@ -172,6 +198,26 @@ function dostep!(Q, mrigark::MRIGARKExplicit, param, time::Real)
 
         # update time
         ts += dts
+    end
+end
+
+@kernel function mri_update_rate!(dQ, τ, γs, Rs)
+    i = @index(Global, Linear)
+    @inbounds begin
+        NΓ = length(γs)
+        Ns = length(γs[1])
+        dqi = dQ[i]
+
+        for s in 1:Ns
+            ri = Rs[s][i]
+            sc = γs[NΓ][s]
+            for k in (NΓ - 1):-1:1
+                sc = sc * τ + γs[k][s]
+            end
+            dqi += sc * ri
+        end
+
+        dQ[i] = dqi
     end
 end
 

--- a/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
+++ b/src/Numerics/ODESolvers/MultirateInfinitesimalGARKExplicit.jl
@@ -1,0 +1,232 @@
+export MRIGARKExplicit
+export MRIGARKERK33aSandu, MRIGARKERK45aSandu
+
+"""
+    MRIParam(p, γs, Rs, ts, Δts)
+
+Construct a type for passing the data around for the `MRIGARKExplicit` explicit
+time stepper to follow on methods. `p` is the original user defined ODE
+parameters, `γs` and `Rs` are the MRI parameters and stage values, respectively.
+`ts` and `Δts` are the stage time and stage time step.
+"""
+struct MRIParam{P, T, AT, N, M}
+    p::P
+    γs::NTuple{M, SArray{NTuple{1, N}, T, 1, N}}
+    Rs::NTuple{N, AT}
+    ts::T
+    Δts::T
+    function MRIParam(
+        p::P,
+        γs::NTuple{M},
+        Rs::NTuple{N, AT},
+        ts,
+        Δts,
+    ) where {P, M, N, AT}
+        T = eltype(γs[1])
+        new{P, T, AT, N, M}(p, γs, Rs, ts, Δts)
+    end
+end
+
+"""
+    MRIGARKExplicit(f!, fastsolver, Γs, γ̂s, Q, Δt, t0)
+
+Construct an explicit MultiRate Infinitesimal General-structure Additive
+Runge--Kutta (MRI-GARK) scheme to solve
+
+```math
+    \\dot{y} = f(y, t) + g(y, t)
+```
+
+where `f` is the slow tendency function and `g` is the fast tendency function;
+see Sandu (2019).
+
+The fast tendency is integrated using the `fastsolver` and the slow tendency
+using the MRI-GARK scheme. Namely, at each stage the scheme solves
+
+```math
+               v(T_i) &= Y_i \\\\
+             \\dot{v} &= f(v, t) + \\sum_{j=1}^{i} \\bar{γ}_{ij}(t) R_j \\\\
+    \\bar{γ}_{ijk}(t) &= \\sum_{k=0}^{NΓ-1} γ_{ijk} τ(t)^k / Δc_s \\\\
+                 τ(t) &= (t - t_s) / Δt \\\\
+              Y_{i+1} &= v(T_i + c_s * Δt)
+```
+
+where ``Y_1 = y_n`` and ``y_{n+1} = Y_{Nstages+1}``.
+
+Here ``R_j = g(Y_j, t_0 + c_j * Δt)`` is the tendency for stage ``j``,
+``γ_{ijk}`` are the GARK coupling coefficients,
+``NΓ`` is the number of sets of GARK coupling coefficients there are
+``Δc_s = \\sum_{j=1}^{Nstages} γ_{sj1} = c_{s+1} - c_s`` is the scaling
+increment between stage times. The ODE for ``v(t)`` is solved using the
+`fastsolver`.  Note that this form of the scheme is based on Definition 2.2 of
+Sandu (2019), but ODE for ``v(t)`` is written to go from ``t_s`` to
+``T_i + c_s * Δt`` as opposed to ``0`` to ``1``.
+
+Currently only ['LowStorageRungeKutta2N`](@ref) schemes are supported for
+`fastsolver`
+
+The coefficients defined by `γ̂s` can be used for an embedded scheme (only the
+last stage is different).
+
+The available concrete implementations are:
+
+  - [`MRIGARKERK33aSandu`](@ref)
+  - [`MRIGARKERK45aSandu`](@ref)
+
+### References
+
+    @article{Sandu2019,
+        title={A class of multirate infinitesimal gark methods},
+        author={Sandu, Adrian},
+        journal={SIAM Journal on Numerical Analysis},
+        volume={57},
+        number={5},
+        pages={2300--2327},
+        year={2019},
+        publisher={SIAM},
+        doi={10.1137/18M1205492}
+    }
+"""
+mutable struct MRIGARKExplicit{T, RT, AT, Nstages, NΓ, FS, Nstages_sq} <:
+               AbstractODESolver
+    "time step"
+    dt::RT
+    "time"
+    t::RT
+    "rhs function"
+    slowrhs!
+    "Storage for RHS during the `MRIGARKExplicit` update"
+    Rstages::NTuple{Nstages, AT}
+    "RK coefficient matrices for coupling coefficients"
+    Γs::NTuple{NΓ, SArray{NTuple{2, Nstages}, RT, 2, Nstages_sq}}
+    "RK coefficient matrices for embedded scheme"
+    γ̂s::NTuple{NΓ, SArray{NTuple{1, Nstages}, RT, 1, Nstages}}
+    "RK coefficient vector C (time scaling)"
+    Δc::SArray{NTuple{1, Nstages}, RT, 1, Nstages}
+    "fast solver"
+    fastsolver::FS
+
+    function MRIGARKExplicit(
+        slowrhs!,
+        fastsolver,
+        Γs,
+        γ̂s,
+        Q::AT,
+        dt,
+        t0,
+    ) where {AT <: AbstractArray}
+        NΓ = length(Γs)
+        Nstages = size(Γs[1], 1)
+        T = eltype(Q)
+        RT = real(T)
+
+        # Compute the Δc coefficients
+        Δc = sum(Γs[1], dims = 2)[:]
+
+        # Scale in the Δc to the Γ and γ̂, and convert to real type
+        Γs = ntuple(k -> RT.(Γs[k] ./ Δc), NΓ)
+        γ̂s = ntuple(k -> RT.(γ̂s[k] / Δc[Nstages]), NΓ)
+
+        # Convert to real type
+        Δc = RT.(Δc)
+
+        # create storage for the stage values
+        Rstages = ntuple(i -> similar(Q), Nstages)
+
+        FS = typeof(fastsolver)
+        new{T, RT, AT, Nstages, NΓ, FS, Nstages^2}(
+            RT(dt),
+            RT(t0),
+            slowrhs!,
+            Rstages,
+            Γs,
+            γ̂s,
+            Δc,
+            fastsolver,
+        )
+    end
+end
+
+function dostep!(Q, mrigark::MRIGARKExplicit, param, time::Real)
+    dt = mrigark.dt
+    fast = mrigark.fastsolver
+
+    Rs = mrigark.Rstages
+    Δc = mrigark.Δc
+    Nstages = length(Δc)
+    slowrhs! = mrigark.slowrhs!
+    Γs = mrigark.Γs
+    NΓ = length(Γs)
+
+    ts = time
+    for s in 1:Nstages
+        # Stage dt
+        dts = Δc[s] * dt
+
+        slowrhs!(Rs[s], Q, param, ts, increment = false)
+
+        γs = ntuple(k -> ntuple(j -> Γs[k][s, j], s), NΓ)
+        mriparam = MRIParam(param, γs, realview.(Rs[1:s]), ts, dts)
+        updatetime!(mrigark.fastsolver, ts)
+        solve!(Q, mrigark.fastsolver, mriparam; timeend = ts + dts)
+
+        # update time
+        ts += dts
+    end
+end
+
+"""
+    MRIGARKERK33aSandu(f!, fastsolver, Q; dt, t0 = 0, δ = -1 // 2)
+
+The 3rd order, 3 stage scheme from Sandu (2019). The parameter `δ` defaults to
+the value suggested by Sandu, but can be varied.
+"""
+function MRIGARKERK33aSandu(slowrhs!, fastsolver, Q; dt, t0 = 0, δ = -1 // 2)
+    T = eltype(Q)
+    RT = real(T)
+    #! format: off
+    Γ0 = [
+                1 // 3           0 // 1          0 // 1
+        (-6δ - 7) // 12  (6δ + 11) // 12         0 // 1
+                0 // 1    (6δ - 5) // 12  (3 - 2δ) // 4
+    ]
+    γ̂0 = [     1 // 12          -1 // 3          7 // 12]
+
+    Γ1 = [
+               0 // 1          0 // 1   0 // 1
+        (2δ + 1) // 2  -(2δ + 1) // 2   0 // 1
+               1 // 2  -(2δ + 1) // 2   δ // 1
+    ]
+    γ̂1 = [     0 // 1          0 // 1   0 // 1]
+    #! format: on
+    MRIGARKExplicit(slowrhs!, fastsolver, (Γ0, Γ1), (γ̂0, γ̂1), Q, dt, t0)
+end
+
+"""
+    MRIGARKERK45aSandu(f!, fastsolver, Q; dt, t0 = 0)
+
+The 4th order, 5 stage scheme from Sandu (2019).
+"""
+function MRIGARKERK45aSandu(slowrhs!, fastsolver, Q; dt, t0 = 0)
+    T = eltype(Q)
+    RT = real(T)
+    #! format: off
+    Γ0 = [
+                  1 // 5                 0 // 1                 0 // 1               0 // 1             0 // 1
+                -53 // 16              281 // 80                0 // 1               0 // 1             0 // 1
+         -36562993 // 71394880    34903117 // 17848720  -88770499 // 71394880        0 // 1             0 // 1
+          -7631593 // 71394880  -166232021 // 35697440    6068517 // 1519040   8644289 // 8924360       0 // 1
+            277061 // 303808       -209323 // 1139280    -1360217 // 1139280   -148789 // 56964    147889 // 45120
+    ]
+    γ̂0 = [-1482837 // 759520        175781 // 71205       -790577 // 1139280     -6379 // 56964        47 // 96]
+    Γ1 = [
+               0 // 1                0 // 1               0 // 1               0 // 1             0 // 1
+             503 // 80            -503 // 80              0 // 1               0 // 1             0 // 1
+        -1365537 // 35697440   4963773 // 7139488  -1465833 // 2231090         0 // 1             0 // 1
+        66974357 // 35697440  21445367 // 7139488        -3 // 1        -8388609 // 4462180       0 // 1
+          -18227 // 7520             2 // 1               1 // 1               5 // 1        -41933 // 7520
+    ]
+    γ̂1 = [  6213 // 1880         -6213 // 1880            0 // 1               0 // 1             0 // 1]
+    #! format: on
+    MRIGARKExplicit(slowrhs!, fastsolver, (Γ0, Γ1), (γ̂0, γ̂1), Q, dt, t0)
+end

--- a/src/Numerics/ODESolvers/ODESolvers.jl
+++ b/src/Numerics/ODESolvers/ODESolvers.jl
@@ -158,6 +158,7 @@ function solve!(
 end
 # }}}
 
+include("BackwardEulerSolvers.jl")
 include("MultirateInfinitesimalGARKExplicit.jl")
 include("LowStorageRungeKuttaMethod.jl")
 include("StrongStabilityPreservingRungeKuttaMethod.jl")

--- a/src/Numerics/ODESolvers/ODESolvers.jl
+++ b/src/Numerics/ODESolvers/ODESolvers.jl
@@ -160,6 +160,7 @@ end
 
 include("BackwardEulerSolvers.jl")
 include("MultirateInfinitesimalGARKExplicit.jl")
+include("MultirateInfinitesimalGARKDecoupledImplicit.jl")
 include("LowStorageRungeKuttaMethod.jl")
 include("StrongStabilityPreservingRungeKuttaMethod.jl")
 include("AdditiveRungeKuttaMethod.jl")

--- a/src/Numerics/ODESolvers/ODESolvers.jl
+++ b/src/Numerics/ODESolvers/ODESolvers.jl
@@ -47,6 +47,7 @@ function general_dostep!(
     time, dt = solver.t, solver.dt
     final_step = false
     if adjustfinalstep && time + dt > timeend
+        orig_dt = dt
         dt = timeend - time
         updatedt!(solver, dt)
         final_step = true
@@ -58,6 +59,7 @@ function general_dostep!(
     if !final_step
         solver.t += dt
     else
+        updatedt!(solver, orig_dt)
         solver.t = timeend
     end
 end
@@ -156,6 +158,7 @@ function solve!(
 end
 # }}}
 
+include("MultirateInfinitesimalGARKExplicit.jl")
 include("LowStorageRungeKuttaMethod.jl")
 include("StrongStabilityPreservingRungeKuttaMethod.jl")
 include("AdditiveRungeKuttaMethod.jl")

--- a/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -153,11 +153,11 @@ function run(
     odesolver = ARK2GiraldoKellyConstantinescu(
         dg,
         lineardg,
-        linearsolver,
+        LinearBackwardEulerSolver(linearsolver; isadjustable = false),
         Q;
         dt = dt,
         t0 = 0,
-        split_nonlinear_linear = false,
+        split_explicit_implicit = false,
     )
 
     filterorder = 18

--- a/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark.jl
@@ -1,0 +1,383 @@
+using CLIMA
+using CLIMA.ConfigTypes
+using CLIMA.Mesh.Topologies: BrickTopology
+using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
+using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
+using CLIMA.DGmethods.NumericalFluxes:
+    Rusanov, CentralNumericalFluxGradient, CentralNumericalFluxDiffusive
+using CLIMA.ODESolvers
+using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
+using CLIMA.VTK: writevtk, writepvtu
+using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
+using CLIMA.MPIStateArrays: euclidean_distance
+using CLIMA.MoistThermodynamics:
+    air_density, total_energy, internal_energy, soundspeed_air
+using CLIMA.Atmos:
+    AtmosModel,
+    AtmosAcousticLinearModel,
+    RemainderModel,
+    NoOrientation,
+    NoReferenceState,
+    ReferenceState,
+    DryModel,
+    NoPrecipitation,
+    NoRadiation,
+    ConstantViscosityWithDivergence,
+    vars_state
+using CLIMA.VariableTemplates: @vars, Vars, flattenednames
+import CLIMA.Atmos: atmos_init_aux!, vars_aux
+
+using CLIMAParameters
+using CLIMAParameters.Planet: kappa_d
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+const output_vtk = false
+
+function main()
+    CLIMA.init()
+    ArrayType = CLIMA.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    numlevels = integration_testing ? 4 : 1
+
+    expected_error = Dict()
+    expected_error[Float64, MRIGARKERK33aSandu, 1] = 2.3357934866477940e+01
+    expected_error[Float64, MRIGARKERK33aSandu, 2] = 5.3328129440361121e+00
+    expected_error[Float64, MRIGARKERK33aSandu, 3] = 1.2991232057877919e-01
+    expected_error[Float64, MRIGARKERK33aSandu, 4] = 6.1056067013518876e-03
+    expected_error[Float64, MRIGARKERK45aSandu, 1] = 2.3207510164213900e+01
+    expected_error[Float64, MRIGARKERK45aSandu, 2] = 5.2787446598866872e+00
+    expected_error[Float64, MRIGARKERK45aSandu, 3] = 1.2151170640665301e-01
+    expected_error[Float64, MRIGARKERK45aSandu, 4] = 2.1001271191583956e-03
+
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64,), dims in 2
+            for mrigark_method in (MRIGARKERK33aSandu, MRIGARKERK45aSandu)
+                @info @sprintf """Configuration
+                                  ArrayType  = %s
+                                  mrigark_method = %s
+                                  FT     = %s
+                                  dims       = %d
+                                  """ ArrayType "$mrigark_method" "$FT" dims
+
+                setup = IsentropicVortexSetup{FT}()
+                errors = Vector{FT}(undef, numlevels)
+
+                for level in 1:numlevels
+                    numelems =
+                        ntuple(dim -> dim == 3 ? 1 : 2^(level - 1) * 5, dims)
+                    errors[level] = run(
+                        mpicomm,
+                        ArrayType,
+                        polynomialorder,
+                        numelems,
+                        setup,
+                        FT,
+                        mrigark_method,
+                        dims,
+                        level,
+                    )
+
+                    @test errors[level] ≈
+                          expected_error[FT, mrigark_method, level]
+                end
+
+                rates = @. log2(
+                    first(errors[1:(numlevels - 1)]) /
+                    first(errors[2:numlevels]),
+                )
+                numlevels > 1 && @info "Convergence rates\n" * join(
+                    [
+                        "rate for levels $l → $(l + 1) = $(rates[l])"
+                        for l in 1:(numlevels - 1)
+                    ],
+                    "\n",
+                )
+            end
+        end
+    end
+end
+
+function run(
+    mpicomm,
+    ArrayType,
+    polynomialorder,
+    numelems,
+    setup,
+    FT,
+    mrigark_method,
+    dims,
+    level,
+)
+    brickrange = ntuple(dims) do dim
+        range(
+            -setup.domain_halflength;
+            length = numelems[dim] + 1,
+            stop = setup.domain_halflength,
+        )
+    end
+
+    topology = BrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = ntuple(_ -> true, dims),
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorder,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        orientation = NoOrientation(),
+        ref_state = IsentropicVortexReferenceState{FT}(setup),
+        turbulence = ConstantViscosityWithDivergence(FT(0)),
+        moisture = DryModel(),
+        source = nothing,
+        boundarycondition = (),
+        init_state = isentropicvortex_initialcondition!,
+    )
+    # The linear model has the fast time scales
+    fast_model = AtmosAcousticLinearModel(model)
+    # The nonlinear model has the slow time scales
+    slow_model = RemainderModel(model, (fast_model,))
+
+    dg = DGModel(
+        model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient(),
+    )
+    fast_dg = DGModel(
+        fast_model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient();
+        auxstate = dg.auxstate,
+    )
+    slow_dg = DGModel(
+        slow_model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient();
+        auxstate = dg.auxstate,
+    )
+
+    timeend = FT(2 * setup.domain_halflength / setup.translation_speed)
+    # determine the slow time step
+    elementsize = minimum(step.(brickrange))
+    slow_dt =
+        2 * elementsize / soundspeed_air(model.param_set, setup.T∞) /
+        polynomialorder^2
+    nsteps = ceil(Int, timeend / slow_dt)
+    slow_dt = timeend / nsteps
+
+    # arbitrary and not needed for stability, just for testing
+    fast_dt = slow_dt / 3
+
+    Q = init_ode_state(dg, FT(0), setup)
+
+    fastsolver = LSRK144NiegemannDiehlBusch(fast_dg, Q; dt = fast_dt)
+
+    ode_solver = mrigark_method(slow_dg, fastsolver, Q, dt = slow_dt)
+
+    eng0 = norm(Q)
+    dims == 2 && (numelems = (numelems..., 0))
+    @info @sprintf """Starting refinement level %d
+                      numelems  = (%d, %d, %d)
+                      slow_dt   = %.16e
+                      fast_dt   = %.16e
+                      norm(Q₀)  = %.16e
+                      """ level numelems... slow_dt fast_dt eng0
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            runtime = Dates.format(
+                convert(DateTime, now() - starttime[]),
+                dateformat"HH:MM:SS",
+            )
+            @info @sprintf """Update
+                              simtime = %.16e
+                              runtime = %s
+                              norm(Q) = %.16e
+                              """ gettime(ode_solver) runtime energy
+        end
+    end
+    callbacks = (cbinfo,)
+
+    if output_vtk
+        # create vtk dir
+        vtkdir =
+            "vtk_isentropicvortex_mrigark" *
+            "_poly$(polynomialorder)_dims$(dims)_$(ArrayType)_$(FT)" *
+            "_$(FastMethod)_level$(level)"
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # output initial step
+        do_output(mpicomm, vtkdir, vtkstep, dg, Q, Q, model)
+
+        # setup the output callback
+        outputtime = timeend
+        cbvtk = EveryXSimulationSteps(floor(outputtime / slow_dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dg, gettime(ode_solver))
+            do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model)
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(Q, ode_solver; timeend = timeend, callbacks = callbacks)
+
+    # final statistics
+    Qe = init_ode_state(dg, timeend)
+    engf = norm(Q)
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished refinement level %d
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ level engf engf / eng0 engf - eng0 errf errf / engfe
+    errf
+end
+
+Base.@kwdef struct IsentropicVortexSetup{FT}
+    p∞::FT = 10^5
+    T∞::FT = 300
+    ρ∞::FT = air_density(param_set, FT(T∞), FT(p∞))
+    translation_speed::FT = 150
+    translation_angle::FT = pi / 4
+    vortex_speed::FT = 50
+    vortex_radius::FT = 1 // 200
+    domain_halflength::FT = 1 // 20
+end
+
+struct IsentropicVortexReferenceState{FT} <: ReferenceState
+    setup::IsentropicVortexSetup{FT}
+end
+vars_aux(::IsentropicVortexReferenceState, FT) =
+    @vars(ρ::FT, ρe::FT, p::FT, T::FT)
+function atmos_init_aux!(
+    m::IsentropicVortexReferenceState,
+    atmos::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    setup = m.setup
+    ρ∞ = setup.ρ∞
+    p∞ = setup.p∞
+    T∞ = setup.T∞
+
+    aux.ref_state.ρ = ρ∞
+    aux.ref_state.p = p∞
+    aux.ref_state.T = T∞
+    aux.ref_state.ρe = ρ∞ * internal_energy(atmos.param_set, T∞)
+end
+
+function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
+    setup = bl.ref_state.setup
+    FT = eltype(state)
+    x = MVector(coords)
+
+    ρ∞ = setup.ρ∞
+    p∞ = setup.p∞
+    T∞ = setup.T∞
+    translation_speed = setup.translation_speed
+    α = setup.translation_angle
+    vortex_speed = setup.vortex_speed
+    R = setup.vortex_radius
+    L = setup.domain_halflength
+
+    u∞ = SVector(translation_speed * cos(α), translation_speed * sin(α), 0)
+
+    x .-= u∞ * t
+    # make the function periodic
+    x .-= floor.((x .+ L) / 2L) * 2L
+
+    @inbounds begin
+        r = sqrt(x[1]^2 + x[2]^2)
+        δu_x = -vortex_speed * x[2] / R * exp(-(r / R)^2 / 2)
+        δu_y = vortex_speed * x[1] / R * exp(-(r / R)^2 / 2)
+    end
+    u = u∞ .+ SVector(δu_x, δu_y, 0)
+
+    _kappa_d::FT = kappa_d(param_set)
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    # adiabatic/isentropic relation
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
+    ρ = air_density(bl.param_set, T, p)
+
+    state.ρ = ρ
+    state.ρu = ρ * u
+    e_kin = u' * u / 2
+    state.ρe = ρ * total_energy(bl.param_set, e_kin, FT(0), T)
+end
+
+function do_output(
+    mpicomm,
+    vtkdir,
+    vtkstep,
+    dg,
+    Q,
+    Qe,
+    model,
+    testname = "isentropicvortex_mrigark",
+)
+    ## name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dg, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+main()

--- a/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -1,0 +1,393 @@
+using CLIMA
+using CLIMA.ConfigTypes
+using CLIMA.Mesh.Topologies: BrickTopology
+using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
+using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
+using CLIMA.DGmethods.NumericalFluxes:
+    Rusanov, CentralNumericalFluxGradient, CentralNumericalFluxDiffusive
+using CLIMA.ODESolvers
+using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
+using CLIMA.VTK: writevtk, writepvtu
+using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
+using CLIMA.MPIStateArrays: euclidean_distance
+using CLIMA.MoistThermodynamics:
+    air_density, total_energy, internal_energy, soundspeed_air
+using CLIMA.Atmos:
+    AtmosModel,
+    AtmosAcousticLinearModel,
+    RemainderModel,
+    NoOrientation,
+    NoReferenceState,
+    ReferenceState,
+    DryModel,
+    NoPrecipitation,
+    NoRadiation,
+    ConstantViscosityWithDivergence,
+    vars_state
+using CLIMA.VariableTemplates: @vars, Vars, flattenednames
+import CLIMA.Atmos: atmos_init_aux!, vars_aux
+
+using CLIMAParameters
+using CLIMAParameters.Planet: kappa_d
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using MPI, Logging, StaticArrays, LinearAlgebra, Printf, Dates, Test
+
+if !@isdefined integration_testing
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
+end
+
+const output_vtk = false
+
+function main()
+    CLIMA.init()
+    ArrayType = CLIMA.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    numlevels = integration_testing ? 4 : 1
+
+    expected_error = Dict()
+    expected_error[Float64, MRIGARKIRK21aSandu, 1] = 2.3236071337679274e+01
+    expected_error[Float64, MRIGARKIRK21aSandu, 2] = 5.2652585224989430e+00
+    expected_error[Float64, MRIGARKIRK21aSandu, 3] = 1.2100430848052603e-01
+    expected_error[Float64, MRIGARKIRK21aSandu, 4] = 2.1974838909870273e-03
+
+    expected_error[Float64, MRIGARKESDIRK34aSandu, 1] = 2.3235626679098608e+01
+    expected_error[Float64, MRIGARKESDIRK34aSandu, 2] = 5.2672845223341218e+00
+    expected_error[Float64, MRIGARKESDIRK34aSandu, 3] = 1.2097276468825705e-01
+    expected_error[Float64, MRIGARKESDIRK34aSandu, 4] = 2.0920468129065205e-03
+
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64,), dims in 2
+            for mrigark_method in (MRIGARKIRK21aSandu, MRIGARKESDIRK34aSandu)
+                @info @sprintf """Configuration
+                                  ArrayType      = %s
+                                  mrigark_method = %s
+                                  FT             = %s
+                                  dims           = %d
+                                  """ ArrayType "$mrigark_method" "$FT" dims
+
+                setup = IsentropicVortexSetup{FT}()
+                errors = Vector{FT}(undef, numlevels)
+
+                for level in 1:numlevels
+                    numelems =
+                        ntuple(dim -> dim == 3 ? 1 : 2^(level - 1) * 5, dims)
+                    errors[level] = run(
+                        mpicomm,
+                        ArrayType,
+                        polynomialorder,
+                        numelems,
+                        setup,
+                        mrigark_method,
+                        FT,
+                        dims,
+                        level,
+                    )
+
+                    @test errors[level] ≈
+                          expected_error[FT, mrigark_method, level]
+                end
+
+                rates = @. log2(
+                    first(errors[1:(numlevels - 1)]) /
+                    first(errors[2:numlevels]),
+                )
+                numlevels > 1 && @info "Convergence rates\n" * join(
+                    [
+                        "rate for levels $l → $(l + 1) = $(rates[l])"
+                        for l in 1:(numlevels - 1)
+                    ],
+                    "\n",
+                )
+            end
+        end
+    end
+end
+
+function run(
+    mpicomm,
+    ArrayType,
+    polynomialorder,
+    numelems,
+    setup,
+    mrigark_method,
+    FT,
+    dims,
+    level,
+)
+    brickrange = ntuple(dims) do dim
+        range(
+            -setup.domain_halflength;
+            length = numelems[dim] + 1,
+            stop = setup.domain_halflength,
+        )
+    end
+
+    topology = BrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = ntuple(_ -> true, dims),
+    )
+
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorder,
+    )
+
+    model = AtmosModel{FT}(
+        AtmosLESConfigType,
+        param_set;
+        orientation = NoOrientation(),
+        ref_state = IsentropicVortexReferenceState{FT}(setup),
+        turbulence = ConstantViscosityWithDivergence(FT(0)),
+        moisture = DryModel(),
+        source = nothing,
+        boundarycondition = (),
+        init_state = isentropicvortex_initialcondition!,
+    )
+    # This is a bad idea; this test is just testing how
+    # implicit GARK composes with explicit methods
+    # The linear model has the fast time scales but will be
+    # treated implicitly (outer solver)
+    slow_model = AtmosAcousticLinearModel(model)
+    # The remainder will be treated explicitly in the inner loop
+    fast_model = RemainderModel(model, (slow_model,))
+
+    dg = DGModel(
+        model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient(),
+    )
+    fast_dg = DGModel(
+        fast_model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient();
+        auxstate = dg.auxstate,
+    )
+    slow_dg = DGModel(
+        slow_model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient();
+        auxstate = dg.auxstate,
+    )
+
+    timeend = FT(2 * setup.domain_halflength / setup.translation_speed)
+
+    # determine the time step
+    elementsize = minimum(step.(brickrange))
+    dt =
+        elementsize / soundspeed_air(model.param_set, setup.T∞) /
+        polynomialorder^2 / 5
+    nsteps = ceil(Int, timeend / dt)
+    dt = timeend / nsteps
+
+    Q = init_ode_state(dg, FT(0))
+
+    fastsolver = LSRK54CarpenterKennedy(fast_dg, Q; dt = dt)
+
+    linearsolver = GeneralizedMinimalResidual(Q; M = 50, rtol = 1e-10)
+
+    ode_solver = mrigark_method(
+        slow_dg,
+        LinearBackwardEulerSolver(linearsolver; isadjustable = true),
+        fastsolver,
+        Q;
+        dt = dt,
+        t0 = 0,
+    )
+
+    eng0 = norm(Q)
+    dims == 2 && (numelems = (numelems..., 0))
+    @info @sprintf """Starting refinement level %d
+                      numelems  = (%d, %d, %d)
+                      dt        = %.16e
+                      norm(Q₀)  = %.16e
+                      """ level numelems... dt eng0
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            runtime = Dates.format(
+                convert(DateTime, now() - starttime[]),
+                dateformat"HH:MM:SS",
+            )
+            @info @sprintf """Update
+                              simtime = %.16e
+                              runtime = %s
+                              norm(Q) = %.16e
+                              """ gettime(ode_solver) runtime energy
+        end
+    end
+    callbacks = (cbinfo,)
+
+    if output_vtk
+        # create vtk dir
+        vtkdir =
+            "vtk_isentropicvortex_mrigark" *
+            "_poly$(polynomialorder)_dims$(dims)_$(ArrayType)_$(FT)" *
+            "_$(FastMethod)_level$(level)"
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # output initial step
+        do_output(mpicomm, vtkdir, vtkstep, dg, Q, Q, model)
+
+        # setup the output callback
+        outputtime = timeend
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dg, gettime(ode_solver))
+            do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model)
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    solve!(Q, ode_solver; timeend = timeend, callbacks = callbacks)
+
+    # final statistics
+    Qe = init_ode_state(dg, timeend)
+    engf = norm(Q)
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished refinement level %d
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ level engf engf / eng0 engf - eng0 errf errf / engfe
+    errf
+end
+
+Base.@kwdef struct IsentropicVortexSetup{FT}
+    p∞::FT = 10^5
+    T∞::FT = 300
+    ρ∞::FT = air_density(param_set, FT(T∞), FT(p∞))
+    translation_speed::FT = 150
+    translation_angle::FT = pi / 4
+    vortex_speed::FT = 50
+    vortex_radius::FT = 1 // 200
+    domain_halflength::FT = 1 // 20
+end
+
+struct IsentropicVortexReferenceState{FT} <: ReferenceState
+    setup::IsentropicVortexSetup{FT}
+end
+vars_aux(::IsentropicVortexReferenceState, FT) =
+    @vars(ρ::FT, ρe::FT, p::FT, T::FT)
+function atmos_init_aux!(
+    m::IsentropicVortexReferenceState,
+    atmos::AtmosModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    setup = m.setup
+    ρ∞ = setup.ρ∞
+    p∞ = setup.p∞
+    T∞ = setup.T∞
+
+    aux.ref_state.ρ = ρ∞
+    aux.ref_state.p = p∞
+    aux.ref_state.T = T∞
+    aux.ref_state.ρe = ρ∞ * internal_energy(atmos.param_set, T∞)
+end
+
+function isentropicvortex_initialcondition!(bl, state, aux, coords, t, args...)
+    setup = bl.ref_state.setup
+    FT = eltype(state)
+    x = MVector(coords)
+
+    ρ∞ = setup.ρ∞
+    p∞ = setup.p∞
+    T∞ = setup.T∞
+    translation_speed = setup.translation_speed
+    α = setup.translation_angle
+    vortex_speed = setup.vortex_speed
+    R = setup.vortex_radius
+    L = setup.domain_halflength
+
+    u∞ = SVector(translation_speed * cos(α), translation_speed * sin(α), 0)
+
+    x .-= u∞ * t
+    # make the function periodic
+    x .-= floor.((x .+ L) / 2L) * 2L
+
+    @inbounds begin
+        r = sqrt(x[1]^2 + x[2]^2)
+        δu_x = -vortex_speed * x[2] / R * exp(-(r / R)^2 / 2)
+        δu_y = vortex_speed * x[1] / R * exp(-(r / R)^2 / 2)
+    end
+    u = u∞ .+ SVector(δu_x, δu_y, 0)
+
+    _kappa_d::FT = kappa_d(param_set)
+    T = T∞ * (1 - _kappa_d * vortex_speed^2 / 2 * ρ∞ / p∞ * exp(-(r / R)^2))
+    # adiabatic/isentropic relation
+    p = p∞ * (T / T∞)^(FT(1) / _kappa_d)
+    ρ = air_density(bl.param_set, T, p)
+
+    state.ρ = ρ
+    state.ρu = ρ * u
+    e_kin = u' * u / 2
+    state.ρe = ρ * total_energy(bl.param_set, e_kin, FT(0), T)
+end
+
+function do_output(
+    mpicomm,
+    vtkdir,
+    vtkstep,
+    dg,
+    Q,
+    Qe,
+    model,
+    testname = "isentropicvortex_mrigark",
+)
+    ## name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dg, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+main()

--- a/test/Numerics/DGmethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGmethods/Euler/isentropicvortex_multirate.jl
@@ -211,7 +211,7 @@ function run(
         fast_ode_solver = FastMethod(
             fast_dg,
             fast_dg,
-            linearsolver,
+            LinearBackwardEulerSolver(linearsolver; isadjustable = true),
             Q;
             dt = fast_dt,
             paperversion = true,

--- a/test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
+++ b/test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_1dimex.jl
@@ -158,11 +158,11 @@ function run(
     ode_solver = ARK548L2SA2KennedyCarpenter(
         dg,
         vdg,
-        linearsolvertype(),
+        LinearBackwardEulerSolver(linearsolvertype(); isadjustable = false),
         Q;
         dt = dt,
         t0 = 0,
-        split_nonlinear_linear = false,
+        split_explicit_implicit = false,
     )
 
     eng0 = norm(Q)

--- a/test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
+++ b/test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion_mrigark_implicit.jl
@@ -1,0 +1,399 @@
+using MPI
+using CLIMA
+using Logging
+using Test
+using CLIMA.Mesh.Topologies
+using CLIMA.Mesh.Grids
+using CLIMA.DGmethods
+using CLIMA.DGmethods.NumericalFluxes
+using CLIMA.MPIStateArrays
+using CLIMA.LinearSolvers
+using CLIMA.GeneralizedMinimalResidualSolver
+using CLIMA.ColumnwiseLUSolver:
+    SingleColumnLU, ManyColumnLU, banded_matrix, banded_matrix_vector_product!
+using CLIMA.ODESolvers
+using LinearAlgebra
+using Printf
+using Dates
+using CLIMA.GenericCallbacks: EveryXWallTimeSeconds, EveryXSimulationSteps
+using CLIMA.VTK: writevtk, writepvtu
+
+if !@isdefined integration_testing
+    if length(ARGS) > 0
+        const integration_testing = parse(Bool, ARGS[1])
+    else
+        const integration_testing = parse(
+            Bool,
+            lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+        )
+    end
+end
+
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
+
+include("advection_diffusion_model.jl")
+
+struct Pseudo1D{n, α, β, μ, δ} <: AdvectionDiffusionProblem end
+
+function init_velocity_diffusion!(
+    ::Pseudo1D{n, α, β},
+    aux::Vars,
+    geom::LocalGeometry,
+) where {n, α, β}
+    # Direction of flow is n with magnitude α
+    aux.u = α * n
+
+    # diffusion of strength β in the n direction
+    aux.D = β * n * n'
+end
+
+function initial_condition!(
+    ::Pseudo1D{n, α, β, μ, δ},
+    state,
+    aux,
+    x,
+    t,
+) where {n, α, β, μ, δ}
+    ξn = dot(n, x)
+    # ξT = SVector(x) - ξn * n
+    state.ρ = exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+end
+Dirichlet_data!(P::Pseudo1D, x...) = initial_condition!(P, x...)
+function Neumann_data!(
+    ::Pseudo1D{n, α, β, μ, δ},
+    ∇state,
+    aux,
+    x,
+    t,
+) where {n, α, β, μ, δ}
+    ξn = dot(n, x)
+    ∇state.ρ =
+        -(
+            2n * (ξn - μ - α * t) / (4 * β * (δ + t)) *
+            exp(-(ξn - μ - α * t)^2 / (4 * β * (δ + t))) / sqrt(1 + t / δ)
+        )
+end
+
+function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
+    ## name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
+
+    statenames = flattenednames(vars_state(model, eltype(Q)))
+    exactnames = statenames .* "_exact"
+
+    writevtk(filename, Q, dg, statenames, Qe, exactnames)
+
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+
+        ## name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+
+        @info "Done writing VTK: $pvtuprefix"
+    end
+end
+
+
+function run(
+    mpicomm,
+    ArrayType,
+    dim,
+    topl,
+    N,
+    timeend,
+    FT,
+    dt,
+    n,
+    α,
+    β,
+    μ,
+    δ,
+    vtkdir,
+    outputtime,
+    linearsolvertype,
+    fluxBC,
+)
+
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+    )
+    model = AdvectionDiffusion{dim, fluxBC}(Pseudo1D{n, α, β, μ, δ}())
+    dg = DGModel(
+        model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient(),
+    )
+
+    vdg = DGModel(
+        model,
+        grid,
+        Rusanov(),
+        CentralNumericalFluxDiffusive(),
+        CentralNumericalFluxGradient(),
+        auxstate = dg.auxstate,
+        direction = VerticalDirection(),
+    )
+
+    Q = init_ode_state(dg, FT(0))
+
+    # With diffussion the Vertical + Horizontal ≠ Full because of 2nd
+    # derivative mixing. So we define a custom RHS
+    dQ2 = similar(Q)
+    function rhs!(dQ, Q, p, time; increment)
+        dg(dQ, Q, p, time; increment = increment)
+        vdg(dQ2, Q, p, time; increment = false)
+        dQ .= dQ .- dQ2
+    end
+
+    fastsolver = LSRK144NiegemannDiehlBusch(rhs!, Q; dt = dt)
+
+    # We're dominated by spatial error, so we can get away with a low order time
+    # integrator
+    ode_solver = MRIGARKESDIRK46aSandu(
+        vdg,
+        LinearBackwardEulerSolver(linearsolvertype(); isadjustable = false),
+        fastsolver,
+        Q;
+        dt = dt,
+        t0 = 0,
+    )
+
+    eng0 = norm(Q)
+    @info @sprintf """Starting
+    norm(Q₀) = %.16e""" eng0
+
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %.16e
+                runtime = %s
+                norm(Q) = %.16e""",
+                gettime(ode_solver),
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+        end
+    end
+    callbacks = (cbinfo,)
+    if ~isnothing(vtkdir)
+        # create vtk dir
+        mkpath(vtkdir)
+
+        vtkstep = 0
+        # output initial step
+        do_output(
+            mpicomm,
+            vtkdir,
+            vtkstep,
+            dg,
+            Q,
+            Q,
+            model,
+            "advection_diffusion",
+        )
+
+        # setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dg, gettime(ode_solver))
+            do_output(
+                mpicomm,
+                vtkdir,
+                vtkstep,
+                dg,
+                Q,
+                Qe,
+                model,
+                "advection_diffusion",
+            )
+        end
+        callbacks = (callbacks..., cbvtk)
+    end
+
+    numberofsteps = convert(Int64, cld(timeend, dt))
+    dt = timeend / numberofsteps
+
+    @info "time step" dt numberofsteps dt * numberofsteps timeend
+
+    solve!(
+        Q,
+        ode_solver;
+        numberofsteps = numberofsteps,
+        callbacks = callbacks,
+        adjustfinalstep = false,
+    )
+
+    # Print some end of the simulation information
+    engf = norm(Q)
+    Qe = init_ode_state(dg, FT(timeend))
+
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ engf engf / eng0 engf - eng0 errf errf / engfe
+    errf
+end
+
+let
+    CLIMA.init()
+    ArrayType = CLIMA.array_type()
+
+    mpicomm = MPI.COMM_WORLD
+
+    polynomialorder = 4
+    base_num_elem = 4
+
+    expected_result = Dict()
+    expected_result[2, 1, Float64] = 7.3188989633310442e-02
+    expected_result[2, 2, Float64] = 6.8155958327716232e-03
+    expected_result[2, 3, Float64] = 1.4832570828897563e-04
+    expected_result[2, 4, Float64] = 3.3905353801669396e-06
+    expected_result[3, 1, Float64] = 1.0501469629884301e-01
+    expected_result[3, 2, Float64] = 1.0341917570778314e-02
+    expected_result[3, 3, Float64] = 2.1032014288411172e-04
+    expected_result[3, 4, Float64] = 4.5797013335024617e-06
+    expected_result[2, 1, Float32] = 7.3186099529266357e-02
+    expected_result[2, 2, Float32] = 6.8112355656921864e-03
+    expected_result[2, 3, Float32] = 1.4748815738130361e-04
+    # This is near roundoff so we will not check it
+    # expected_result[2, 4, Float32] = 2.9435863325488754e-05
+    expected_result[3, 1, Float32] = 1.0500905662775040e-01
+    expected_result[3, 2, Float32] = 1.0342594236135483e-02
+    expected_result[3, 3, Float32] = 4.2716524330899119e-04
+    # This is near roundoff so we will not check it
+    # expected_result[3, 4, Float32] = 1.9564463291317225e-03
+
+    numlevels = integration_testing ? 4 : 1
+
+    @testset "$(@__FILE__)" begin
+        for FT in (Float64, Float32)
+            result = zeros(FT, numlevels)
+            for dim in 2:3
+                for fluxBC in (true, false)
+                    for linearsolvertype in (SingleColumnLU,)# ManyColumnLU)
+                        d = dim == 2 ? FT[1, 10, 0] : FT[1, 1, 10]
+                        n = SVector{3, FT}(d ./ norm(d))
+
+                        α = FT(1)
+                        β = FT(1 // 100)
+                        μ = FT(-1 // 2)
+                        δ = FT(1 // 10)
+                        for l in 1:numlevels
+                            Ne = 2^(l - 1) * base_num_elem
+                            brickrange = (
+                                ntuple(
+                                    j -> range(
+                                        FT(-1);
+                                        length = Ne + 1,
+                                        stop = 1,
+                                    ),
+                                    dim - 1,
+                                )...,
+                                range(FT(-5); length = 5Ne + 1, stop = 5),
+                            )
+
+                            periodicity = ntuple(j -> false, dim)
+                            topl = StackedBrickTopology(
+                                mpicomm,
+                                brickrange;
+                                periodicity = periodicity,
+                                boundary = (
+                                    ntuple(j -> (1, 2), dim - 1)...,
+                                    (3, 4),
+                                ),
+                            )
+                            dt = 32 * (α / 4) / (Ne * polynomialorder^2)
+
+                            outputtime = 0.01
+                            timeend = 0.5
+
+                            @info (
+                                ArrayType,
+                                FT,
+                                dim,
+                                linearsolvertype,
+                                l,
+                                fluxBC,
+                            )
+                            vtkdir = output ?
+                                "vtk_advection" *
+                            "_poly$(polynomialorder)" *
+                            "_dim$(dim)_$(ArrayType)_$(FT)" *
+                            "_$(linearsolvertype)_level$(l)" :
+                                nothing
+                            result[l] = run(
+                                mpicomm,
+                                ArrayType,
+                                dim,
+                                topl,
+                                polynomialorder,
+                                timeend,
+                                FT,
+                                dt,
+                                n,
+                                α,
+                                β,
+                                μ,
+                                δ,
+                                vtkdir,
+                                outputtime,
+                                linearsolvertype,
+                                fluxBC,
+                            )
+                            # test the errors significantly larger than floating point epsilon
+                            if !(l == 4 && FT == Float32)
+                                @test result[l] ≈
+                                      FT(expected_result[dim, l, FT])
+                            end
+                        end
+                        @info begin
+                            msg = ""
+                            for l in 1:(numlevels - 1)
+                                rate = log2(result[l]) - log2(result[l + 1])
+                                msg *= @sprintf(
+                                    "\n  rate for level %d = %e\n",
+                                    l,
+                                    rate
+                                )
+                            end
+                            msg
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+nothing

--- a/test/Numerics/ODESolvers/ode_tests_common.jl
+++ b/test/Numerics/ODESolvers/ode_tests_common.jl
@@ -29,6 +29,12 @@ const mis_methods =
 
 const mrigark_erk_methods = ((MRIGARKERK33aSandu, 3), (MRIGARKERK45aSandu, 4))
 
+const mrigark_irk_methods = (
+    (MRIGARKIRK21aSandu, 2),
+    (MRIGARKESDIRK34aSandu, 3),
+    (MRIGARKESDIRK46aSandu, 4),
+)
+
 const fast_mrigark_methods =
     ((LSRK54CarpenterKennedy, 4), (LSRK144NiegemannDiehlBusch, 4))
 

--- a/test/Numerics/ODESolvers/ode_tests_common.jl
+++ b/test/Numerics/ODESolvers/ode_tests_common.jl
@@ -30,6 +30,7 @@ const mis_methods =
 const mrigark_erk_methods = ((MRIGARKERK33aSandu, 3), (MRIGARKERK45aSandu, 4))
 
 const mrigark_irk_methods = (
+    (MRIGARKESDIRK23LSA, 2),
     (MRIGARKIRK21aSandu, 2),
     (MRIGARKESDIRK34aSandu, 3),
     (MRIGARKESDIRK46aSandu, 4),

--- a/test/Numerics/ODESolvers/ode_tests_common.jl
+++ b/test/Numerics/ODESolvers/ode_tests_common.jl
@@ -26,6 +26,12 @@ const imex_methods = (
 const mis_methods =
     ((MIS2, 2), (MIS3C, 2), (MIS4, 3), (MIS4a, 3), (TVDMISA, 2), (TVDMISB, 2))
 
+
+const mrigark_erk_methods = ((MRIGARKERK33aSandu, 3), (MRIGARKERK45aSandu, 4))
+
+const fast_mrigark_methods =
+    ((LSRK54CarpenterKennedy, 4), (LSRK144NiegemannDiehlBusch, 4))
+
 struct DivideLinearSolver <: AbstractLinearSolver end
 function LinearSolvers.prefactorize(
     linearoperator!,

--- a/test/Numerics/ODESolvers/ode_tests_common.jl
+++ b/test/Numerics/ODESolvers/ode_tests_common.jl
@@ -30,6 +30,7 @@ const mis_methods =
 const mrigark_erk_methods = ((MRIGARKERK33aSandu, 3), (MRIGARKERK45aSandu, 4))
 
 const mrigark_irk_methods = (
+    (MRIGARKESDIRK24LSA, 2),
     (MRIGARKESDIRK23LSA, 2),
     (MRIGARKIRK21aSandu, 2),
     (MRIGARKESDIRK34aSandu, 3),


### PR DESCRIPTION
Adds support for the MRI-GARK methods of Sandu (2019).

Also refactors the linear solver interface for the ODE solvers, by allowing for non-linear solvers (as opposed to just linear solvers).

```
    @article{Sandu2019,
        title={A class of multirate infinitesimal gark methods},
        author={Sandu, Adrian},
        journal={SIAM Journal on Numerical Analysis},
        volume={57},
        number={5},
        pages={2300--2327},
        year={2019},
        publisher={SIAM},
        doi={10.1137/18M1205492}
    }
```

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
