### PR TITLE
Add `simtime` to output diagnostics

### DIFF
--- a/src/Diagnostics/atmos_default.jl
+++ b/src/Diagnostics/atmos_default.jl
@@ -426,6 +426,7 @@ Diagnostics $(dgngrp.name) collection
             dfilename,
             OrderedDict("z" => CollectedDiagnostics.zvals),
             varvals,
+            currtime,
         )
     end
 

--- a/src/Diagnostics/dump_state_and_aux.jl
+++ b/src/Diagnostics/dump_state_and_aux.jl
@@ -5,16 +5,30 @@ end
 function get_dims(dgngrp)
     if dgngrp.interpol !== nothing
         if dgngrp.interpol isa InterpolationBrick
-            dims = OrderedDict(
-                "x" => dgngrp.interpol.x1g,
-                "y" => dgngrp.interpol.x2g,
-                "z" => dgngrp.interpol.x3g,
-            )
+            if Array ∈ typeof(dgngrp.interpol.x1g).parameters
+                h_x1g = dgngrp.interpol.x1g
+                h_x2g = dgngrp.interpol.x2g
+                h_x3g = dgngrp.interpol.x3g
+            else
+                h_x1g = Array(dgngrp.interpol.x1g)
+                h_x2g = Array(dgngrp.interpol.x2g)
+                h_x3g = Array(dgngrp.interpol.x3g)
+            end
+            dims = OrderedDict("x" => h_x1g, "y" => h_x2g, "z" => h_x3g)
         elseif dgngrp.interpol isa InterpolationCubedSphere
+            if Array ∈ typeof(dgngrp.interpol.rad_grd).parameters
+                h_rad_grd = dgngrp.interpol.rad_grd
+                h_lat_grd = dgngrp.interpol.lat_grd
+                h_long_grd = dgngrp.interpol.long_grd
+            else
+                h_rad_grd = Array(dgngrp.interpol.rad_grd)
+                h_lat_grd = Array(dgngrp.interpol.lat_grd)
+                h_long_grd = Array(dgngrp.interpol.long_grd)
+            end
             dims = OrderedDict(
-                "rad" => dgngrp.interpol.rad_grd,
-                "lat" => dgngrp.interpol.lat_grd,
-                "long" => dgngrp.interpol.long_grd,
+                "rad" => h_rad_grd,
+                "lat" => h_lat_grd,
+                "long" => h_long_grd,
             )
         else
             error("Unsupported interpolation topology $(dgngrp.interpol)")
@@ -84,13 +98,13 @@ function dump_state_and_aux_collect(dgngrp, currtime)
     for i in 1:num_state(bl, FT)
         statevarvals[statenames[i]] = all_state_data[:, :, :, i]
     end
-    write_data(dgngrp.writer, statefilename, dims, statevarvals)
+    write_data(dgngrp.writer, statefilename, dims, statevarvals, currtime)
 
     auxvarvals = OrderedDict()
     for i in 1:num_aux(bl, FT)
         auxvarvals[auxnames[i]] = all_aux_data[:, :, :, i]
     end
-    write_data(dgngrp.writer, auxfilename, dims, auxvarvals)
+    write_data(dgngrp.writer, auxfilename, dims, auxvarvals, currtime)
 
     return nothing
 end

--- a/src/InputOutput/Writers/Writers.jl
+++ b/src/InputOutput/Writers/Writers.jl
@@ -10,6 +10,7 @@ abstract type AbstractWriter end
         filename,
         dims,
         varvals,
+        simtime,
     )
 
 Writes the specified dimension names, dimensions, axes, variable names
@@ -20,6 +21,7 @@ and variable values to a file. Specialized by every `Writer` subtype.
 # - `filename`: into which to write data (without extension).
 # - `dims`: Dict of dimension name to axis.
 # - `varvals`: Dict of variable name to array of values.
+# - `simtime`: Current simulation time.
 """
 function write_data end
 

--- a/src/InputOutput/Writers/jld2_writer.jl
+++ b/src/InputOutput/Writers/jld2_writer.jl
@@ -3,7 +3,7 @@ using JLD2
 
 struct JLD2Writer <: AbstractWriter end
 
-function write_data(jld::JLD2Writer, filename, dims, varvals)
+function write_data(jld::JLD2Writer, filename, dims, varvals, simtime)
     jldopen(full_name(jld, filename), "a+") do ds
         dimnames = collect(keys(dims))
         for di in 1:length(dimnames)
@@ -12,9 +12,11 @@ function write_data(jld::JLD2Writer, filename, dims, varvals)
         for (dn, dv) in dims
             ds[dn] = dv
         end
+        ds["time"] = [1]
         for (vn, vv) in varvals
             ds[vn] = vv
         end
+        ds["simtime"] = [simtime]
     end
     return nothing
 end

--- a/src/InputOutput/Writers/netcdf_writer.jl
+++ b/src/InputOutput/Writers/netcdf_writer.jl
@@ -2,17 +2,20 @@ using NCDatasets
 
 struct NetCDFWriter <: AbstractWriter end
 
-function write_data(nc::NetCDFWriter, filename, dims, varvals)
+function write_data(nc::NetCDFWriter, filename, dims, varvals, simtime)
     Dataset(full_name(nc, filename), "c") do ds
         for (dn, dv) in dims
             ds.dim[dn] = length(dv)
         end
+        ds.dim["time"] = 1
         for (dn, dv) in dims
             defVar(ds, dn, dv, (dn,))
         end
+        defVar(ds, "time", 1, ("time",))
         for (vn, vv) in varvals
             defVar(ds, vn, vv, collect(keys(dims)))
         end
+        defVar(ds, "simtime", [simtime], ("time",))
     end
     return nothing
 end

--- a/test/InputOutput/Writers/runtests.jl
+++ b/test/InputOutput/Writers/runtests.jl
@@ -13,10 +13,10 @@ using CLIMA.Writers
     ovars = OrderedDict("v1" => rand(5, 5, 5), "v2" => rand(5, 5, 5))
     jfn, _ = mktemp()
     jfull = full_name(JLD2Writer(), jfn)
-    write_data(JLD2Writer(), jfn, odims, ovars)
+    write_data(JLD2Writer(), jfn, odims, ovars, 0.5)
     nfn, _ = mktemp()
     nfull = full_name(NetCDFWriter(), nfn)
-    write_data(NetCDFWriter(), nfn, odims, ovars)
+    write_data(NetCDFWriter(), nfn, odims, ovars, 0.5)
 
     jldopen(jfull, "r") do jds
         @test get(jds, "dim_1", "foo") == "x"
@@ -26,8 +26,10 @@ using CLIMA.Writers
         @test jds["x"] == odims["x"]
         @test jds["y"] == odims["y"]
         @test jds["z"] == odims["z"]
+        @test jds["time"] == [1]
         @test get(jds, "v1", []) == ovars["v1"]
         @test get(jds, "v2", []) == ovars["v2"]
+        @test get(jds, "simtime", [1.0]) == [0.5]
     end
 
     NCDataset(nfull, "r") do nds
@@ -40,7 +42,9 @@ using CLIMA.Writers
         catch e
             true
         end
+        @test nds["time"] == [1]
         @test nds["v1"] == ovars["v1"]
         @test nds["v2"] == ovars["v2"]
+        @test nds["simtime"] == [0.5]
     end
 end


### PR DESCRIPTION
# Description

Adds a `time` dimension of length 1 as well as a `simtime` variable that uses the `time` dimension and records the simulation time at which the diagnostics were run.

Also fixes a minor bug that was preventing "DumpStateAndAux" from writing diagnostics output.

Closes #940. Cc: @szy21 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
