### PR TITLE
Change order of user callbacks 

### DIFF
--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -187,7 +187,8 @@ function init(; disable_gpu = false)
 
     # set up the array type appropriately depending on whether we're using GPUs
     if !Settings.disable_gpu &&
-       get(ENV, "CLIMA_GPU", "") != "false" && CUDAapi.has_cuda_gpu()
+       get(ENV, "CLIMA_GPU", "") != "false" &&
+       CUDAapi.has_cuda_gpu()
         atyp = CuArrays.CuArray
     else
         atyp = Array
@@ -437,7 +438,7 @@ function invoke!(
         callbacks = (callbacks..., cbcfl)
     end
 
-    callbacks = (callbacks..., user_callbacks...)
+    callbacks = (user_callbacks..., callbacks...)
 
     # initial condition norm
     eng0 = norm(Q)


### PR DESCRIPTION
# Description

Callbacks are done sequentially so any user-defined callbacks must appear before diagnostic callbacks. Currently this affects filter application.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
