### PR TITLE
Pass direction into source!

### DIFF
--- a/examples/Microphysics/ex_1_saturation_adjustment.jl
+++ b/examples/Microphysics/ex_1_saturation_adjustment.jl
@@ -151,14 +151,7 @@ end
     # ... and don't advect momentum (kinematic setup)
 end
 
-function source!(
-    m::KinematicModel,
-    source::Vars,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-) end
+source!(::KinematicModel, _...) = nothing
 
 function main()
     CLIMA.init()

--- a/examples/Microphysics/ex_2_Kessler.jl
+++ b/examples/Microphysics/ex_2_Kessler.jl
@@ -215,6 +215,7 @@ function source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     # TODO - ensure positive definite
     FT = eltype(state)

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -98,7 +98,15 @@ function config_heldsuarez(FT, poly_order, resolution)
     return config
 end
 
-function held_suarez_forcing!(bl, source, state, diffusive, aux, t::Real)
+function held_suarez_forcing!(
+    bl,
+    source,
+    state,
+    diffusive,
+    aux,
+    t::Real,
+    direction,
+)
     FT = eltype(state)
 
     # Parameters

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -96,6 +96,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
 
     f_coriolis = s.f_coriolis
@@ -140,6 +141,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
 
     z_max = s.z_max
@@ -192,6 +194,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     FT = eltype(state)
     ρ = state.ρ

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -11,7 +11,8 @@ using ..MoistThermodynamics
 using ..PlanetParameters
 import ..MoistThermodynamics: internal_energy
 using ..MPIStateArrays: MPIStateArray
-using ..Mesh.Grids: VerticalDirection, HorizontalDirection, min_node_distance
+using ..Mesh.Grids:
+    VerticalDirection, HorizontalDirection, min_node_distance, EveryDirection
 
 import CLIMA.DGmethods:
     BalanceLaw,
@@ -443,7 +444,8 @@ function init_aux!(m::AtmosModel, aux::Vars, geom::LocalGeometry)
 end
 
 """
-    source!(m::AtmosModel, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+    source!(m::AtmosModel, source::Vars, state::Vars, diffusive::Vars,
+            aux::Vars, t::Real, direction::Direction)
 Computes flux `S(Y)` in:
 ```
 ∂Y
@@ -458,8 +460,9 @@ function source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
-    atmos_source!(m.source, m, source, state, diffusive, aux, t)
+    atmos_source!(m.source, m, source, state, diffusive, aux, t, direction)
 end
 
 function init_state!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -146,16 +146,7 @@ function flux_nondiffusive!(
     flux.ρe = ((ref.ρe + ref.p) / ref.ρ - e_pot) * state.ρu
     nothing
 end
-function source!(
-    lm::AtmosAcousticLinearModel,
-    source::Vars,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-)
-    nothing
-end
+source!(::AtmosAcousticLinearModel, _...) = nothing
 
 struct AtmosAcousticGravityLinearModel{M} <: AtmosLinearModel
     atmos::M
@@ -191,8 +182,11 @@ function source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
-    ∇Φ = ∇gravitational_potential(lm.atmos.orientation, aux)
-    source.ρu -= state.ρ * ∇Φ
+    if direction isa VerticalDirection || direction isa EveryDirection
+        ∇Φ = ∇gravitational_potential(lm.atmos.orientation, aux)
+        source.ρu -= state.ρ * ∇Φ
+    end
     nothing
 end

--- a/src/Atmos/Model/remainder.jl
+++ b/src/Atmos/Model/remainder.jl
@@ -156,16 +156,17 @@ function source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     m = getfield(source, :array)
-    source!(rem.main, source, state, diffusive, aux, t)
+    source!(rem.main, source, state, diffusive, aux, t, direction)
 
     source_s = similar(source)
     m_s = getfield(source_s, :array)
 
     for sub in rem.subs
         fill!(m_s, 0)
-        source!(sub, source_s, state, diffusive, aux, t)
+        source!(sub, source_s, state, diffusive, aux, t, direction)
         m .-= m_s
     end
     nothing

--- a/src/Atmos/Model/source.jl
+++ b/src/Atmos/Model/source.jl
@@ -11,8 +11,9 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
-    f(atmos, source, state, diffusive, aux, t)
+    f(atmos, source, state, diffusive, aux, t, direction)
 end
 function atmos_source!(
     ::Nothing,
@@ -22,6 +23,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 ) end
 # sources are applied additively
 @generated function atmos_source!(
@@ -32,11 +34,20 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     N = fieldcount(stuple)
     return quote
-        Base.Cartesian.@nexprs $N i ->
-            atmos_source!(stuple[i], atmos, source, state, diffusive, aux, t)
+        Base.Cartesian.@nexprs $N i -> atmos_source!(
+            stuple[i],
+            atmos,
+            source,
+            state,
+            diffusive,
+            aux,
+            t,
+            direction,
+        )
         return nothing
     end
 end
@@ -52,6 +63,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     if atmos.ref_state isa HydrostaticState
         source.ρu -= (state.ρ - aux.ref_state.ρ) * aux.orientation.∇Φ
@@ -69,6 +81,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     # note: this assumes a SphericalOrientation
     source.ρu -= SVector(0, 0, 2 * Omega) × state.ρu
@@ -86,6 +99,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     ρ = state.ρ
     z = altitude(atmos, aux)
@@ -113,6 +127,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     u_geo = SVector(s.u_geostrophic, s.v_geostrophic, 0)
     ẑ = vertical_unit_vector(atmos, aux)
@@ -147,6 +162,7 @@ function atmos_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     z = altitude(atmos, aux)
     if z >= s.z_sponge

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -46,7 +46,7 @@ See [`odefun!`](@ref) for usage.
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     rhs,
     Q,
     Qvisc,
@@ -58,7 +58,7 @@ See [`odefun!`](@ref) for usage.
     D,
     elems,
     increment,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
         FT = eltype(Q)
@@ -98,12 +98,12 @@ See [`odefun!`](@ref) for usage.
         ξ1x1 = vgeo[ijk, _ξ1x1, e]
         ξ1x2 = vgeo[ijk, _ξ1x2, e]
         ξ1x3 = vgeo[ijk, _ξ1x3, e]
-        if dim == 3 || (dim == 2 && direction == EveryDirection)
+        if dim == 3 || (dim == 2 && direction isa EveryDirection)
             ξ2x1 = vgeo[ijk, _ξ2x1, e]
             ξ2x2 = vgeo[ijk, _ξ2x2, e]
             ξ2x3 = vgeo[ijk, _ξ2x3, e]
         end
-        if dim == 3 && direction == EveryDirection
+        if dim == 3 && direction isa EveryDirection
             ξ3x1 = vgeo[ijk, _ξ3x1, e]
             ξ3x2 = vgeo[ijk, _ξ3x2, e]
             ξ3x3 = vgeo[ijk, _ξ3x3, e]
@@ -167,10 +167,10 @@ See [`odefun!`](@ref) for usage.
                 s_F[1, i, j, k, s], s_F[2, i, j, k, s], s_F[3, i, j, k, s]
 
             s_F[1, i, j, k, s] = M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
-            if dim == 3 || (dim == 2 && direction == EveryDirection)
+            if dim == 3 || (dim == 2 && direction isa EveryDirection)
                 s_F[2, i, j, k, s] = M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
             end
-            if dim == 3 && direction == EveryDirection
+            if dim == 3 && direction isa EveryDirection
                 s_F[3, i, j, k, s] = M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
             end
         end
@@ -198,12 +198,12 @@ See [`odefun!`](@ref) for usage.
                 l_rhs[s] += MI * s_D[n, i] * s_F[1, n, j, k, s]
 
                 # ξ2-grid lines
-                if dim == 3 || (dim == 2 && direction == EveryDirection)
+                if dim == 3 || (dim == 2 && direction isa EveryDirection)
                     l_rhs[s] += MI * s_D[n, j] * s_F[2, i, n, k, s]
                 end
 
                 # ξ3-grid lines
-                if dim == 3 && direction == EveryDirection
+                if dim == 3 && direction isa EveryDirection
                     l_rhs[s] += MI * s_D[n, k] * s_F[3, i, j, n, s]
                 end
             end
@@ -389,7 +389,7 @@ See [`odefun!`](@ref) for usage.
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     numfluxnondiff::NumericalFluxNonDiffusive,
     numfluxdiff::NumericalFluxDiffusive,
     rhs,
@@ -404,7 +404,7 @@ See [`odefun!`](@ref) for usage.
     vmap⁺,
     elemtobndy,
     elems,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
         FT = eltype(Q)
@@ -429,9 +429,9 @@ See [`odefun!`](@ref) for usage.
         end
 
         faces = 1:nface
-        if direction == VerticalDirection
+        if direction isa VerticalDirection
             faces = (nface - 1):nface
-        elseif direction == HorizontalDirection
+        elseif direction isa HorizontalDirection
             faces = 1:(nface - 2)
         end
 
@@ -605,7 +605,7 @@ end
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     Q,
     Qvisc,
     Qhypervisc_grad,
@@ -615,7 +615,7 @@ end
     D,
     hypervisc_indexmap,
     elems,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
 
@@ -674,11 +674,11 @@ end
         # Compute gradient of each state
         ξ1x1, ξ1x2, ξ1x3 =
             vgeo[ijk, _ξ1x1, e], vgeo[ijk, _ξ1x2, e], vgeo[ijk, _ξ1x3, e]
-        if dim == 3 || (dim == 2 && direction == EveryDirection)
+        if dim == 3 || (dim == 2 && direction isa EveryDirection)
             ξ2x1, ξ2x2, ξ2x3 =
                 vgeo[ijk, _ξ2x1, e], vgeo[ijk, _ξ2x2, e], vgeo[ijk, _ξ2x3, e]
         end
-        if dim == 3 && direction == EveryDirection
+        if dim == 3 && direction isa EveryDirection
             ξ3x1, ξ3x2, ξ3x3 =
                 vgeo[ijk, _ξ3x1, e], vgeo[ijk, _ξ3x2, e], vgeo[ijk, _ξ3x3, e]
         end
@@ -687,10 +687,10 @@ end
             Gξ1 = Gξ2 = Gξ3 = zero(FT)
             @unroll for n in 1:Nq
                 Gξ1 += s_D[i, n] * s_G[n, j, k, s]
-                if dim == 3 || (dim == 2 && direction == EveryDirection)
+                if dim == 3 || (dim == 2 && direction isa EveryDirection)
                     Gξ2 += s_D[j, n] * s_G[i, n, k, s]
                 end
-                if dim == 3 && direction == EveryDirection
+                if dim == 3 && direction isa EveryDirection
                     Gξ3 += s_D[k, n] * s_G[i, j, n, s]
                 end
             end
@@ -698,13 +698,13 @@ end
             l_gradG[2, s] = ξ1x2 * Gξ1
             l_gradG[3, s] = ξ1x3 * Gξ1
 
-            if dim == 3 || (dim == 2 && direction == EveryDirection)
+            if dim == 3 || (dim == 2 && direction isa EveryDirection)
                 l_gradG[1, s] += ξ2x1 * Gξ2
                 l_gradG[2, s] += ξ2x2 * Gξ2
                 l_gradG[3, s] += ξ2x3 * Gξ2
             end
 
-            if dim == 3 && direction == EveryDirection
+            if dim == 3 && direction isa EveryDirection
                 l_gradG[1, s] += ξ3x1 * Gξ3
                 l_gradG[2, s] += ξ3x2 * Gξ3
                 l_gradG[3, s] += ξ3x3 * Gξ3
@@ -862,7 +862,7 @@ end
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     gradnumflux::NumericalFluxGradient,
     Q,
     Qvisc,
@@ -876,7 +876,7 @@ end
     elemtobndy,
     hypervisc_indexmap,
     elems,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
         FT = eltype(Q)
@@ -901,9 +901,9 @@ end
         end
 
         faces = 1:nface
-        if direction == VerticalDirection
+        if direction isa VerticalDirection
             faces = (nface - 1):nface
-        elseif direction == HorizontalDirection
+        elseif direction isa HorizontalDirection
             faces = 1:(nface - 2)
         end
 
@@ -1517,13 +1517,13 @@ end
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     Qhypervisc_grad,
     Qhypervisc_div,
     vgeo,
     D,
     elems,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
@@ -1555,11 +1555,11 @@ end
 
         ξ1x1, ξ1x2, ξ1x3 =
             vgeo[ijk, _ξ1x1, e], vgeo[ijk, _ξ1x2, e], vgeo[ijk, _ξ1x3, e]
-        if dim == 3 || (dim == 2 && direction == EveryDirection)
+        if dim == 3 || (dim == 2 && direction isa EveryDirection)
             ξ2x1, ξ2x2, ξ2x3 =
                 vgeo[ijk, _ξ2x1, e], vgeo[ijk, _ξ2x2, e], vgeo[ijk, _ξ2x3, e]
         end
-        if dim == 3 && direction == EveryDirection
+        if dim == 3 && direction isa EveryDirection
             ξ3x1, ξ3x2, ξ3x3 =
                 vgeo[ijk, _ξ3x1, e], vgeo[ijk, _ξ3x2, e], vgeo[ijk, _ξ3x3, e]
         end
@@ -1573,13 +1573,13 @@ end
                 g1ξ1 += Din * s_grad[n, j, k, s, 1]
                 g2ξ1 += Din * s_grad[n, j, k, s, 2]
                 g3ξ1 += Din * s_grad[n, j, k, s, 3]
-                if dim == 3 || (dim == 2 && direction == EveryDirection)
+                if dim == 3 || (dim == 2 && direction isa EveryDirection)
                     Djn = s_D[j, n]
                     g1ξ2 += Djn * s_grad[i, n, k, s, 1]
                     g2ξ2 += Djn * s_grad[i, n, k, s, 2]
                     g3ξ2 += Djn * s_grad[i, n, k, s, 3]
                 end
-                if dim == 3 && direction == EveryDirection
+                if dim == 3 && direction isa EveryDirection
                     Dkn = s_D[k, n]
                     g1ξ3 += Dkn * s_grad[i, j, n, s, 1]
                     g2ξ3 += Dkn * s_grad[i, j, n, s, 2]
@@ -1588,11 +1588,11 @@ end
             end
             l_div[s] = ξ1x1 * g1ξ1 + ξ1x2 * g2ξ1 + ξ1x3 * g3ξ1
 
-            if dim == 3 || (dim == 2 && direction == EveryDirection)
+            if dim == 3 || (dim == 2 && direction isa EveryDirection)
                 l_div[s] += ξ2x1 * g1ξ2 + ξ2x2 * g2ξ2 + ξ2x3 * g3ξ2
             end
 
-            if dim == 3 && direction == EveryDirection
+            if dim == 3 && direction isa EveryDirection
                 l_div[s] += ξ3x1 * g1ξ3 + ξ3x2 * g2ξ3 + ξ3x3 * g3ξ3
             end
         end
@@ -1685,7 +1685,7 @@ end
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     divgradnumpenalty,
     Qhypervisc_grad,
     Qhypervisc_div,
@@ -1695,7 +1695,7 @@ end
     vmap⁺,
     elemtobndy,
     elems,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
@@ -1716,9 +1716,9 @@ end
         end
 
         faces = 1:nface
-        if direction == VerticalDirection
+        if direction isa VerticalDirection
             faces = (nface - 1):nface
-        elseif direction == HorizontalDirection
+        elseif direction isa HorizontalDirection
             faces = 1:(nface - 2)
         end
 
@@ -1796,7 +1796,7 @@ end
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     Qhypervisc_grad,
     Qhypervisc_div,
     Q,
@@ -1806,7 +1806,7 @@ end
     D,
     elems,
     t,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
 
@@ -1853,11 +1853,11 @@ end
 
         ξ1x1, ξ1x2, ξ1x3 =
             vgeo[ijk, _ξ1x1, e], vgeo[ijk, _ξ1x2, e], vgeo[ijk, _ξ1x3, e]
-        if dim == 3 || (dim == 2 && direction == EveryDirection)
+        if dim == 3 || (dim == 2 && direction isa EveryDirection)
             ξ2x1, ξ2x2, ξ2x3 =
                 vgeo[ijk, _ξ2x1, e], vgeo[ijk, _ξ2x2, e], vgeo[ijk, _ξ2x3, e]
         end
-        if dim == 3 && direction == EveryDirection
+        if dim == 3 && direction isa EveryDirection
             ξ3x1, ξ3x2, ξ3x3 =
                 vgeo[ijk, _ξ3x1, e], vgeo[ijk, _ξ3x2, e], vgeo[ijk, _ξ3x3, e]
         end
@@ -1868,13 +1868,13 @@ end
                 Dni = s_D[n, i] * s_ω[n] / s_ω[i]
                 lap_njk = s_lap[n, j, k, s]
                 lap_ξ1 += Dni * lap_njk
-                if dim == 3 || (dim == 2 && direction == EveryDirection)
+                if dim == 3 || (dim == 2 && direction isa EveryDirection)
                     ink = i + Nq * ((n - 1) + Nq * (k - 1))
                     Dnj = s_D[n, j] * s_ω[n] / s_ω[j]
                     lap_ink = s_lap[i, n, k, s]
                     lap_ξ2 += Dnj * lap_ink
                 end
-                if dim == 3 && direction == EveryDirection
+                if dim == 3 && direction isa EveryDirection
                     ijn = i + Nq * ((j - 1) + Nq * (n - 1))
                     Dnk = s_D[n, k] * s_ω[n] / s_ω[k]
                     lap_ijn = s_lap[i, j, n, s]
@@ -1886,13 +1886,13 @@ end
             l_grad_lap[2, s] = -ξ1x2 * lap_ξ1
             l_grad_lap[3, s] = -ξ1x3 * lap_ξ1
 
-            if dim == 3 || (dim == 2 && direction == EveryDirection)
+            if dim == 3 || (dim == 2 && direction isa EveryDirection)
                 l_grad_lap[1, s] -= ξ2x1 * lap_ξ2
                 l_grad_lap[2, s] -= ξ2x2 * lap_ξ2
                 l_grad_lap[3, s] -= ξ2x3 * lap_ξ2
             end
 
-            if dim == 3 && direction == EveryDirection
+            if dim == 3 && direction isa EveryDirection
                 l_grad_lap[1, s] -= ξ3x1 * lap_ξ3
                 l_grad_lap[2, s] -= ξ3x2 * lap_ξ3
                 l_grad_lap[3, s] -= ξ3x3 * lap_ξ3
@@ -2022,7 +2022,7 @@ end
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::direction,
+    direction,
     hyperviscnumflux,
     Qhypervisc_grad,
     Qhypervisc_div,
@@ -2035,7 +2035,7 @@ end
     elemtobndy,
     elems,
     t,
-) where {dim, polyorder, direction}
+) where {dim, polyorder}
     @uniform begin
         N = polyorder
         FT = eltype(Qhypervisc_grad)
@@ -2060,9 +2060,9 @@ end
         end
 
         faces = 1:nface
-        if direction == VerticalDirection
+        if direction isa VerticalDirection
             faces = (nface - 1):nface
-        elseif direction == HorizontalDirection
+        elseif direction isa HorizontalDirection
             faces = 1:(nface - 2)
         end
 

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -73,7 +73,7 @@ See [`odefun!`](@ref) for usage.
 
         Nqk = dim == 2 ? 1 : Nq
 
-        source! !== nothing && (l_S = MArray{Tuple{nstate}, FT}(undef))
+        l_S = MArray{Tuple{nstate}, FT}(undef)
         l_Q = MArray{Tuple{nstate}, FT}(undef)
         l_Qvisc = MArray{Tuple{nviscstate}, FT}(undef)
         l_Qhypervisc = MArray{Tuple{nhyperviscstate}, FT}(undef)
@@ -248,7 +248,7 @@ end
 
         Nqk = dim == 2 ? 1 : Nq
 
-        source! !== nothing && (l_S = MArray{Tuple{nstate}, FT}(undef))
+        l_S = MArray{Tuple{nstate}, FT}(undef)
         l_Q = MArray{Tuple{nstate}, FT}(undef)
         l_Qvisc = MArray{Tuple{nviscstate}, FT}(undef)
         l_Qhypervisc = MArray{Tuple{nhyperviscstate}, FT}(undef)
@@ -337,7 +337,6 @@ end
             s_F[3, i, j, k, s] = M * (ζx1 * F1 + ζx2 * F2 + ζx3 * F3)
         end
 
-        # if source! !== nothing
         fill!(l_S, -zero(eltype(l_S)))
         source!(
             bl,

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -183,6 +183,7 @@ See [`odefun!`](@ref) for usage.
             Vars{vars_diffusive(bl, FT)}(l_Qvisc),
             Vars{vars_aux(bl, FT)}(l_aux),
             t,
+            direction,
         )
 
         @unroll for s in 1:nstate
@@ -220,7 +221,7 @@ end
     bl::BalanceLaw,
     ::Val{dim},
     ::Val{polyorder},
-    ::VerticalDirection,
+    direction::VerticalDirection,
     rhs,
     Q,
     Qvisc,
@@ -345,6 +346,7 @@ end
             Vars{vars_diffusive(bl, FT)}(l_Qvisc),
             Vars{vars_aux(bl, FT)}(l_aux),
             t,
+            direction,
         )
 
         @unroll for s in 1:nstate

--- a/src/DGmethods/balancelaw.jl
+++ b/src/DGmethods/balancelaw.jl
@@ -21,7 +21,7 @@ Subtypes `L` should define the following methods:
 - `gradvariables!(::L, transformstate::State, state::State, auxstate::State, t::Real)`: transformation of state variables to variables of which gradients are computed
 - `diffusive!(::L, diffstate::State, ∇transformstate::Grad, auxstate::State, t::Real)`: transformation of gradients to the diffusive variables
 - `hyperdiffusive!(::L, hyperdiffstate::State, ∇Δtransformstate::Grad, auxstate::State, t::Real)`: transformation of laplacian gradients to the hyperdiffusive variables
-- `source!(::L, source::State, state::State, diffusive::Vars, auxstate::State, t::Real)`
+- `source!(::L, source::State, state::State, diffusive::Vars, auxstate::State, t::Real, direction::Direction)
 - `wavespeed(::L, n⁻, state::State, aux::State, t::Real)`
 - `boundary_state!(::NumericalFluxGradient, ::L, state⁺::State, aux⁺::State, normal⁻, state⁻::State, aux⁻::State, bctype, t)`
 - `boundary_state!(::NumericalFluxNonDiffusive, ::L, state⁺::State, aux⁺::State, normal⁻, state⁻::State, aux⁻::State, bctype, t)`

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -514,6 +514,7 @@ end
     D::Vars,
     A::Vars,
     t::Real,
+    direction,
 ) where {P}
     @inbounds begin
         u, v = Q.u # Horizontal components of velocity

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -7,12 +7,23 @@ using ..VariableTemplates
 using LinearAlgebra: I, dot
 using ..PlanetParameters: grav
 
-import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
-                        vars_diffusive, vars_integrals, flux_nondiffusive!,
-                        flux_diffusive!, source!, wavespeed,
-                        boundary_state!,
-                        gradvariables!, init_aux!, init_state!,
-                        LocalGeometry, diffusive!
+import CLIMA.DGmethods:
+    BalanceLaw,
+    vars_aux,
+    vars_state,
+    vars_gradient,
+    vars_diffusive,
+    vars_integrals,
+    flux_nondiffusive!,
+    flux_diffusive!,
+    source!,
+    wavespeed,
+    boundary_state!,
+    gradvariables!,
+    init_aux!,
+    init_state!,
+    LocalGeometry,
+    diffusive!
 
 using ..DGmethods.NumericalFluxes
 
@@ -24,205 +35,320 @@ abstract type SWProblem end
 
 abstract type TurbulenceClosure end
 struct LinearDrag{L} <: TurbulenceClosure
-  λ::L
+    λ::L
 end
 struct ConstantViscosity{L} <: TurbulenceClosure
-  ν::L
+    ν::L
 end
 
 abstract type AdvectionTerm end
 struct NonLinearAdvection <: AdvectionTerm end
 
 struct SWModel{P, T, A, S} <: BalanceLaw
-  problem::P
-  turbulence::T
-  advection::A
-  c::S
+    problem::P
+    turbulence::T
+    advection::A
+    c::S
 end
 
 function vars_state(m::SWModel, T)
-  @vars begin
-    U::SVector{3, T}
-    η::T
-  end
+    @vars begin
+        U::SVector{3, T}
+        η::T
+    end
 end
 
 function vars_aux(m::SWModel, T)
-  @vars begin
-    f::SVector{3, T}
-    τ::SVector{3, T}  # value includes τₒ, g, and ρ
-  end
+    @vars begin
+        f::SVector{3, T}
+        τ::SVector{3, T}  # value includes τₒ, g, and ρ
+    end
 end
 
 function vars_gradient(m::SWModel, T)
-  @vars begin
-    U::SVector{3, T}
-  end
+    @vars begin
+        U::SVector{3, T}
+    end
 end
 
 function vars_diffusive(m::SWModel, T)
-  @vars begin
-    ν∇U::SMatrix{3, 3, T, 9}
-  end
+    @vars begin
+        ν∇U::SMatrix{3, 3, T, 9}
+    end
 end
 
-@inline function flux_nondiffusive!(m::SWModel, F::Grad, q::Vars,
-                                    α::Vars, t::Real)
-  U = q.U
-  η = q.η
-  H = m.problem.H
+@inline function flux_nondiffusive!(
+    m::SWModel,
+    F::Grad,
+    q::Vars,
+    α::Vars,
+    t::Real,
+)
+    U = q.U
+    η = q.η
+    H = m.problem.H
 
-  F.η += U
-  F.U += grav * H * η * I
+    F.η += U
+    F.U += grav * H * η * I
 
-  advective_flux!(m, m.advection, F, q, α, t)
+    advective_flux!(m, m.advection, F, q, α, t)
 
-  return nothing
+    return nothing
 end
 
 advective_flux!(::SWModel, ::Nothing, _...) = nothing
 
-@inline function advective_flux!(m::SWModel, A::NonLinearAdvection, F::Grad,
-                                 q::Vars, α::Vars, t::Real)
-  U = q.U
-  H = m.problem.H
+@inline function advective_flux!(
+    m::SWModel,
+    A::NonLinearAdvection,
+    F::Grad,
+    q::Vars,
+    α::Vars,
+    t::Real,
+)
+    U = q.U
+    H = m.problem.H
 
-  F.U += 1 / H * U ⊗ U
+    F.U += 1 / H * U ⊗ U
 
-  return nothing
+    return nothing
 end
 
 function gradvariables!(m::SWModel, f::Vars, q::Vars, α::Vars, t::Real)
-  gradvariables!(m.turbulence, f, q, α, t)
+    gradvariables!(m.turbulence, f, q, α, t)
 end
 
 gradvariables!(::LinearDrag, _...) = nothing
 
-@inline function gradvariables!(T::ConstantViscosity, f::Vars, q::Vars,
-                                α::Vars, t::Real)
-  f.U = q.U
+@inline function gradvariables!(
+    T::ConstantViscosity,
+    f::Vars,
+    q::Vars,
+    α::Vars,
+    t::Real,
+)
+    f.U = q.U
 
-  return nothing
+    return nothing
 end
 
 function diffusive!(m::SWModel, σ::Vars, δ::Grad, q::Vars, α::Vars, t::Real)
-  diffusive!(m.turbulence, σ, δ, q, α, t)
+    diffusive!(m.turbulence, σ, δ, q, α, t)
 end
 
 diffusive!(::LinearDrag, _...) = nothing
 
-@inline function diffusive!(T::ConstantViscosity, σ::Vars, δ::Grad, q::Vars,
-                            α::Vars, t::Real)
-  ν  = T.ν
-  ∇U = δ.U
+@inline function diffusive!(
+    T::ConstantViscosity,
+    σ::Vars,
+    δ::Grad,
+    q::Vars,
+    α::Vars,
+    t::Real,
+)
+    ν = T.ν
+    ∇U = δ.U
 
-  σ.ν∇U = ν * ∇U
+    σ.ν∇U = ν * ∇U
 
-  return nothing
+    return nothing
 end
 
-function flux_diffusive!(m::SWModel, G::Grad, q::Vars, σ::Vars, ::Vars,
-                         α::Vars, t::Real)
-  flux_diffusive!(m.turbulence, G, q, σ, α, t)
+function flux_diffusive!(
+    m::SWModel,
+    G::Grad,
+    q::Vars,
+    σ::Vars,
+    ::Vars,
+    α::Vars,
+    t::Real,
+)
+    flux_diffusive!(m.turbulence, G, q, σ, α, t)
 end
 
 flux_diffusive!(::LinearDrag, _...) = nothing
 
-@inline function flux_diffusive!(::ConstantViscosity, G::Grad, q::Vars,
-                                 σ::Vars, α::Vars, t::Real)
-  G.U -= σ.ν∇U
+@inline function flux_diffusive!(
+    ::ConstantViscosity,
+    G::Grad,
+    q::Vars,
+    σ::Vars,
+    α::Vars,
+    t::Real,
+)
+    G.U -= σ.ν∇U
 
-  return nothing
+    return nothing
 end
 
 @inline wavespeed(m::SWModel, n⁻, q::Vars, α::Vars, t::Real) = m.c
 
-@inline function source!(m::SWModel{P}, S::Vars, q::Vars,
-                         diffusive::Vars, α::Vars, t::Real) where P
-  τ = α.τ
-  f = α.f
-  U = q.U
-  S.U += τ - f × U
+@inline function source!(
+    m::SWModel{P},
+    S::Vars,
+    q::Vars,
+    diffusive::Vars,
+    α::Vars,
+    t::Real,
+    direction,
+) where {P}
+    τ = α.τ
+    f = α.f
+    U = q.U
+    S.U += τ - f × U
 
-  linear_drag!(m.turbulence, S, q, α, t)
+    linear_drag!(m.turbulence, S, q, α, t)
 
-  return nothing
+    return nothing
 end
 
 linear_drag!(::ConstantViscosity, _...) = nothing
 
-@inline function linear_drag!(T::LinearDrag, S::Vars, q::Vars,
-                              α::Vars, t::Real)
-  λ = T.λ
-  U = q.U
+@inline function linear_drag!(T::LinearDrag, S::Vars, q::Vars, α::Vars, t::Real)
+    λ = T.λ
+    U = q.U
 
-  S.U -= λ * U
+    S.U -= λ * U
 
-  return nothing
+    return nothing
 end
 
 function shallow_init_aux! end
 function init_aux!(m::SWModel, aux::Vars, geom::LocalGeometry)
-  shallow_init_aux!(m.problem, aux, geom)
+    shallow_init_aux!(m.problem, aux, geom)
 end
 
 function shallow_init_state! end
 function init_state!(m::SWModel, state::Vars, aux::Vars, coords, t)
-  shallow_init_state!(m.problem, m.turbulence, state, aux, coords, t)
+    shallow_init_state!(m.problem, m.turbulence, state, aux, coords, t)
 end
 
-function boundary_state!(nf, m::SWModel, state⁺::Vars, aux⁺::Vars, n⁻,
-                         state⁻::Vars, aux⁻::Vars, bctype, t, _...)
-    shallow_boundary_state!(nf, m, m.turbulence, state⁺, aux⁺, n⁻, state⁻,
-                          aux⁻, t)
+function boundary_state!(
+    nf,
+    m::SWModel,
+    state⁺::Vars,
+    aux⁺::Vars,
+    n⁻,
+    state⁻::Vars,
+    aux⁻::Vars,
+    bctype,
+    t,
+    _...,
+)
+    shallow_boundary_state!(
+        nf,
+        m,
+        m.turbulence,
+        state⁺,
+        aux⁺,
+        n⁻,
+        state⁻,
+        aux⁻,
+        t,
+    )
 end
 
-@inline function shallow_boundary_state!(::Rusanov, m::SWModel, ::LinearDrag, state⁺,
-                               aux⁺, n⁻, state⁻, aux⁻, t)
-  U⁻ = state⁻.U
-  n⁻ = SVector(n⁻)
+@inline function shallow_boundary_state!(
+    ::Rusanov,
+    m::SWModel,
+    ::LinearDrag,
+    state⁺,
+    aux⁺,
+    n⁻,
+    state⁻,
+    aux⁻,
+    t,
+)
+    U⁻ = state⁻.U
+    n⁻ = SVector(n⁻)
 
-  state⁺.η = state⁻.η
-  state⁺.U = U⁻ - 2 * (n⁻⋅U⁻) * n⁻
+    state⁺.η = state⁻.η
+    state⁺.U = U⁻ - 2 * (n⁻ ⋅ U⁻) * n⁻
 
-  return nothing
+    return nothing
 end
 
-shallow_boundary_state!(::CentralNumericalFluxGradient, m::SWModel,
-                        ::LinearDrag, _...) = nothing
+shallow_boundary_state!(
+    ::CentralNumericalFluxGradient,
+    m::SWModel,
+    ::LinearDrag,
+    _...,
+) = nothing
 
-shallow_boundary_state!(::CentralNumericalFluxDiffusive, m::SWModel,
-                        ::LinearDrag, _...) = nothing
+shallow_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    m::SWModel,
+    ::LinearDrag,
+    _...,
+) = nothing
 
-function boundary_state!(nf, m::SWModel, q⁺::Vars, σ⁺::Vars, α⁺::Vars,
-                         n⁻, q⁻::Vars, σ⁻::Vars, α⁻::Vars, bctype, t, _...)
-  shallow_boundary_state!(nf, m, m.turbulence, q⁺, σ⁺, α⁺, n⁻, q⁻, σ⁻, α⁻, t)
+function boundary_state!(
+    nf,
+    m::SWModel,
+    q⁺::Vars,
+    σ⁺::Vars,
+    α⁺::Vars,
+    n⁻,
+    q⁻::Vars,
+    σ⁻::Vars,
+    α⁻::Vars,
+    bctype,
+    t,
+    _...,
+)
+    shallow_boundary_state!(nf, m, m.turbulence, q⁺, σ⁺, α⁺, n⁻, q⁻, σ⁻, α⁻, t)
 end
 
-@inline function shallow_boundary_state!(::Rusanov, m::SWModel,
-                                         ::ConstantViscosity,
-                                         q⁺, α⁺, n⁻, q⁻, α⁻, t)
-  q⁺.η =  q⁻.η
-  q⁺.U = -q⁻.U
+@inline function shallow_boundary_state!(
+    ::Rusanov,
+    m::SWModel,
+    ::ConstantViscosity,
+    q⁺,
+    α⁺,
+    n⁻,
+    q⁻,
+    α⁻,
+    t,
+)
+    q⁺.η = q⁻.η
+    q⁺.U = -q⁻.U
 
-  return nothing
+    return nothing
 end
 
-@inline function shallow_boundary_state!(::CentralNumericalFluxGradient, m::SWModel,
-                                         ::ConstantViscosity, q⁺, α⁺, n⁻, q⁻, α⁻, t)
-  q⁺.U = 0
+@inline function shallow_boundary_state!(
+    ::CentralNumericalFluxGradient,
+    m::SWModel,
+    ::ConstantViscosity,
+    q⁺,
+    α⁺,
+    n⁻,
+    q⁻,
+    α⁻,
+    t,
+)
+    q⁺.U = 0
 
-  return nothing
+    return nothing
 end
 
-@inline function shallow_boundary_state!(::CentralNumericalFluxDiffusive,
-                                         m::SWModel,
-                                         ::ConstantViscosity, q⁺, σ⁺, α⁺,
-                                         n⁻, q⁻, σ⁻, α⁻, t)
-  q⁺.U   = -q⁻.U
-  σ⁺.ν∇U =  σ⁻.ν∇U
+@inline function shallow_boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    m::SWModel,
+    ::ConstantViscosity,
+    q⁺,
+    σ⁺,
+    α⁺,
+    n⁻,
+    q⁻,
+    σ⁻,
+    α⁻,
+    t,
+)
+    q⁺.U = -q⁻.U
+    σ⁺.ν∇U = σ⁻.ν∇U
 
-  return nothing
+    return nothing
 end
 
 end

--- a/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_bc_atmos.jl
@@ -99,6 +99,7 @@ function mms2_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     x1, x2, x3 = aux.coord
     source.ρ = Sρ_g(t, x1, x2, x3, Val(2))
@@ -127,6 +128,7 @@ function mms3_source!(
     diffusive::Vars,
     aux::Vars,
     t::Real,
+    direction,
 )
     x1, x2, x3 = aux.coord
     source.ρ = Sρ_g(t, x1, x2, x3, Val(3))

--- a/test/DGmethods/compressible_Navier_Stokes/mms_model.jl
+++ b/test/DGmethods/compressible_Navier_Stokes/mms_model.jl
@@ -1,127 +1,201 @@
 using CLIMA.VariableTemplates
 
-import CLIMA.DGmethods: BalanceLaw, vars_aux, vars_state, vars_gradient,
-                        vars_diffusive, flux_nondiffusive!, flux_diffusive!,
-                        source!, wavespeed, boundary_state!,
-                        gradvariables!,
-                        diffusive!, init_aux!, init_state!,
-                        init_ode_state, LocalGeometry
+import CLIMA.DGmethods:
+    BalanceLaw,
+    vars_aux,
+    vars_state,
+    vars_gradient,
+    vars_diffusive,
+    flux_nondiffusive!,
+    flux_diffusive!,
+    source!,
+    wavespeed,
+    boundary_state!,
+    gradvariables!,
+    diffusive!,
+    init_aux!,
+    init_state!,
+    init_ode_state,
+    LocalGeometry
 
 
-struct MMSModel{dim} <: BalanceLaw
-end
+struct MMSModel{dim} <: BalanceLaw end
 
-vars_aux(::MMSModel,T) = @vars(x1::T, x2::T, x3::T)
+vars_aux(::MMSModel, T) = @vars(x1::T, x2::T, x3::T)
 vars_state(::MMSModel, T) = @vars(ρ::T, ρu::T, ρv::T, ρw::T, ρe::T)
 vars_gradient(::MMSModel, T) = @vars(u::T, v::T, w::T)
-vars_diffusive(::MMSModel, T) = @vars(τ11::T, τ22::T, τ33::T, τ12::T, τ13::T, τ23::T)
+vars_diffusive(::MMSModel, T) =
+    @vars(τ11::T, τ22::T, τ33::T, τ12::T, τ13::T, τ23::T)
 
-function flux_nondiffusive!(::MMSModel, flux::Grad, state::Vars,
-                            auxstate::Vars, t::Real)
-  # preflux
-  T = eltype(flux)
-  γ = T(γ_exact)
-  ρinv = 1 / state.ρ
-  u, v, w = ρinv * state.ρu, ρinv * state.ρv, ρinv * state.ρw
-  P = (γ-1)*(state.ρe - ρinv * (state.ρu^2 + state.ρv^2 + state.ρw^2) / 2)
+function flux_nondiffusive!(
+    ::MMSModel,
+    flux::Grad,
+    state::Vars,
+    auxstate::Vars,
+    t::Real,
+)
+    # preflux
+    T = eltype(flux)
+    γ = T(γ_exact)
+    ρinv = 1 / state.ρ
+    u, v, w = ρinv * state.ρu, ρinv * state.ρv, ρinv * state.ρw
+    P = (γ - 1) * (state.ρe - ρinv * (state.ρu^2 + state.ρv^2 + state.ρw^2) / 2)
 
-  # invisc terms
-  flux.ρ  = SVector(state.ρu          , state.ρv          , state.ρw)
-  flux.ρu = SVector(u * state.ρu  + P , v * state.ρu      , w * state.ρu)
-  flux.ρv = SVector(u * state.ρv      , v * state.ρv + P  , w * state.ρv)
-  flux.ρw = SVector(u * state.ρw      , v * state.ρw      , w * state.ρw + P)
-  flux.ρe = SVector(u * (state.ρe + P), v * (state.ρe + P), w * (state.ρe + P))
+    # invisc terms
+    flux.ρ = SVector(state.ρu, state.ρv, state.ρw)
+    flux.ρu = SVector(u * state.ρu + P, v * state.ρu, w * state.ρu)
+    flux.ρv = SVector(u * state.ρv, v * state.ρv + P, w * state.ρv)
+    flux.ρw = SVector(u * state.ρw, v * state.ρw, w * state.ρw + P)
+    flux.ρe =
+        SVector(u * (state.ρe + P), v * (state.ρe + P), w * (state.ρe + P))
 end
 
-function flux_diffusive!(::MMSModel, flux::Grad, state::Vars,
-                         diffusive::Vars, hyperdiffusive::Vars, auxstate::Vars, t::Real)
-  ρinv = 1 / state.ρ
-  u, v, w = ρinv * state.ρu, ρinv * state.ρv, ρinv * state.ρw
+function flux_diffusive!(
+    ::MMSModel,
+    flux::Grad,
+    state::Vars,
+    diffusive::Vars,
+    hyperdiffusive::Vars,
+    auxstate::Vars,
+    t::Real,
+)
+    ρinv = 1 / state.ρ
+    u, v, w = ρinv * state.ρu, ρinv * state.ρv, ρinv * state.ρw
 
-  # viscous terms
-  flux.ρu -= SVector(diffusive.τ11, diffusive.τ12, diffusive.τ13)
-  flux.ρv -= SVector(diffusive.τ12, diffusive.τ22, diffusive.τ23)
-  flux.ρw -= SVector(diffusive.τ13, diffusive.τ23, diffusive.τ33)
+    # viscous terms
+    flux.ρu -= SVector(diffusive.τ11, diffusive.τ12, diffusive.τ13)
+    flux.ρv -= SVector(diffusive.τ12, diffusive.τ22, diffusive.τ23)
+    flux.ρw -= SVector(diffusive.τ13, diffusive.τ23, diffusive.τ33)
 
-  flux.ρe -= SVector(u * diffusive.τ11 + v * diffusive.τ12 + w * diffusive.τ13,
-                     u * diffusive.τ12 + v * diffusive.τ22 + w * diffusive.τ23,
-                     u * diffusive.τ13 + v * diffusive.τ23 + w * diffusive.τ33)
+    flux.ρe -= SVector(
+        u * diffusive.τ11 + v * diffusive.τ12 + w * diffusive.τ13,
+        u * diffusive.τ12 + v * diffusive.τ22 + w * diffusive.τ23,
+        u * diffusive.τ13 + v * diffusive.τ23 + w * diffusive.τ33,
+    )
 end
 
-function gradvariables!(::MMSModel, transformstate::Vars, state::Vars, auxstate::Vars, t::Real)
-  ρinv = 1 / state.ρ
-  transformstate.u = ρinv * state.ρu
-  transformstate.v = ρinv * state.ρv
-  transformstate.w = ρinv * state.ρw
+function gradvariables!(
+    ::MMSModel,
+    transformstate::Vars,
+    state::Vars,
+    auxstate::Vars,
+    t::Real,
+)
+    ρinv = 1 / state.ρ
+    transformstate.u = ρinv * state.ρu
+    transformstate.v = ρinv * state.ρv
+    transformstate.w = ρinv * state.ρw
 end
 
-function diffusive!(::MMSModel, diffusive::Vars, ∇transform::Grad, state::Vars, auxstate::Vars, t::Real)
-  T = eltype(diffusive)
-  μ = T(μ_exact)
+function diffusive!(
+    ::MMSModel,
+    diffusive::Vars,
+    ∇transform::Grad,
+    state::Vars,
+    auxstate::Vars,
+    t::Real,
+)
+    T = eltype(diffusive)
+    μ = T(μ_exact)
 
-  dudx, dudy, dudz = ∇transform.u
-  dvdx, dvdy, dvdz = ∇transform.v
-  dwdx, dwdy, dwdz = ∇transform.w
+    dudx, dudy, dudz = ∇transform.u
+    dvdx, dvdy, dvdz = ∇transform.v
+    dwdx, dwdy, dwdz = ∇transform.w
 
-  # strains
-  ϵ11 = dudx
-  ϵ22 = dvdy
-  ϵ33 = dwdz
-  ϵ12 = (dudy + dvdx) / 2
-  ϵ13 = (dudz + dwdx) / 2
-  ϵ23 = (dvdz + dwdy) / 2
+    # strains
+    ϵ11 = dudx
+    ϵ22 = dvdy
+    ϵ33 = dwdz
+    ϵ12 = (dudy + dvdx) / 2
+    ϵ13 = (dudz + dwdx) / 2
+    ϵ23 = (dvdz + dwdy) / 2
 
-  # deviatoric stresses
-  diffusive.τ11 = 2μ * (ϵ11 - (ϵ11 + ϵ22 + ϵ33) / 3)
-  diffusive.τ22 = 2μ * (ϵ22 - (ϵ11 + ϵ22 + ϵ33) / 3)
-  diffusive.τ33 = 2μ * (ϵ33 - (ϵ11 + ϵ22 + ϵ33) / 3)
-  diffusive.τ12 = 2μ * ϵ12
-  diffusive.τ13 = 2μ * ϵ13
-  diffusive.τ23 = 2μ * ϵ23
+    # deviatoric stresses
+    diffusive.τ11 = 2μ * (ϵ11 - (ϵ11 + ϵ22 + ϵ33) / 3)
+    diffusive.τ22 = 2μ * (ϵ22 - (ϵ11 + ϵ22 + ϵ33) / 3)
+    diffusive.τ33 = 2μ * (ϵ33 - (ϵ11 + ϵ22 + ϵ33) / 3)
+    diffusive.τ12 = 2μ * ϵ12
+    diffusive.τ13 = 2μ * ϵ13
+    diffusive.τ23 = 2μ * ϵ23
 end
 
-function source!(::MMSModel{dim}, source::Vars, state::Vars, diffusive::Vars, aux::Vars, t::Real) where {dim}
-  source.ρ  = Sρ_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
-  source.ρu = SU_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
-  source.ρv = SV_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
-  source.ρw = SW_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
-  source.ρe = SE_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
+function source!(
+    ::MMSModel{dim},
+    source::Vars,
+    state::Vars,
+    diffusive::Vars,
+    aux::Vars,
+    t::Real,
+    direction,
+) where {dim}
+    source.ρ = Sρ_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
+    source.ρu = SU_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
+    source.ρv = SV_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
+    source.ρw = SW_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
+    source.ρe = SE_g(t, aux.x1, aux.x2, aux.x3, Val(dim))
 end
 
 function wavespeed(::MMSModel, nM, state::Vars, aux::Vars, t::Real)
-  T = eltype(state)
-  γ = T(γ_exact)
-  ρinv = 1 / state.ρ
-  u, v, w = ρinv * state.ρu, ρinv * state.ρv, ρinv * state.ρw
-  P = (γ-1)*(state.ρe - ρinv * (state.ρu^2 + state.ρv^2 + state.ρw^2) / 2)
-  return abs(nM[1] * u + nM[2] * v + nM[3] * w) + sqrt(ρinv * γ * P)
+    T = eltype(state)
+    γ = T(γ_exact)
+    ρinv = 1 / state.ρ
+    u, v, w = ρinv * state.ρu, ρinv * state.ρv, ρinv * state.ρw
+    P = (γ - 1) * (state.ρe - ρinv * (state.ρu^2 + state.ρv^2 + state.ρw^2) / 2)
+    return abs(nM[1] * u + nM[2] * v + nM[3] * w) + sqrt(ρinv * γ * P)
 end
 
-function boundary_state!(::Rusanov, bl::MMSModel, stateP::Vars, auxP::Vars, nM,
-                         stateM::Vars, auxM::Vars, bctype, t, _...)
-  init_state!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+function boundary_state!(
+    ::Rusanov,
+    bl::MMSModel,
+    stateP::Vars,
+    auxP::Vars,
+    nM,
+    stateM::Vars,
+    auxM::Vars,
+    bctype,
+    t,
+    _...,
+)
+    init_state!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
 end
 
 # FIXME: This is probably not right....
 boundary_state!(::CentralNumericalFluxGradient, bl::MMSModel, _...) = nothing
 
-function boundary_state!(::CentralNumericalFluxDiffusive, bl::MMSModel,
-                         stateP::Vars, diffP::Vars, auxP::Vars, nM,
-                         stateM::Vars, diffM::Vars, auxM::Vars, bctype, t, _...)
-  init_state!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
+function boundary_state!(
+    ::CentralNumericalFluxDiffusive,
+    bl::MMSModel,
+    stateP::Vars,
+    diffP::Vars,
+    auxP::Vars,
+    nM,
+    stateM::Vars,
+    diffM::Vars,
+    auxM::Vars,
+    bctype,
+    t,
+    _...,
+)
+    init_state!(bl, stateP, auxP, (auxM.x1, auxM.x2, auxM.x3), t)
 end
 
 function init_aux!(::MMSModel, aux::Vars, g::LocalGeometry)
-  x1,x2,x3 = g.coord
-  aux.x1 = x1
-  aux.x2 = x2
-  aux.x3 = x3
+    x1, x2, x3 = g.coord
+    aux.x1 = x1
+    aux.x2 = x2
+    aux.x3 = x3
 end
 
-function init_state!(bl::MMSModel{dim}, state::Vars, aux::Vars, (x1,x2,x3), t) where {dim}
-  state.ρ = ρ_g(t, x1, x2, x3, Val(dim))
-  state.ρu = U_g(t, x1, x2, x3, Val(dim))
-  state.ρv = V_g(t, x1, x2, x3, Val(dim))
-  state.ρw = W_g(t, x1, x2, x3, Val(dim))
-  state.ρe = E_g(t, x1, x2, x3, Val(dim))
+function init_state!(
+    bl::MMSModel{dim},
+    state::Vars,
+    aux::Vars,
+    (x1, x2, x3),
+    t,
+) where {dim}
+    state.ρ = ρ_g(t, x1, x2, x3, Val(dim))
+    state.ρu = U_g(t, x1, x2, x3, Val(dim))
+    state.ρv = V_g(t, x1, x2, x3, Val(dim))
+    state.ρw = W_g(t, x1, x2, x3, Val(dim))
+    state.ρe = E_g(t, x1, x2, x3, Val(dim))
 end

--- a/test/DGmethods/vars_test.jl
+++ b/test/DGmethods/vars_test.jl
@@ -19,7 +19,6 @@ import CLIMA.DGmethods:
     vars_gradient,
     vars_diffusive,
     vars_integrals,
-    integrate_aux!,
     flux_nondiffusive!,
     flux_diffusive!,
     source!,

--- a/test/LinearSolvers/poisson.jl
+++ b/test/LinearSolvers/poisson.jl
@@ -135,14 +135,7 @@ function diffusive!(
     diffusive.∇ϕ = ∇transform.ϕ
 end
 
-source!(
-    ::PoissonModel,
-    source::Vars,
-    state::Vars,
-    diffusive::Vars,
-    aux::Vars,
-    t::Real,
-) = nothing
+source!(::PoissonModel, _...) = nothing
 
 # note, that the code assumes solutions with zero mean
 sol1d(x) = sin(2pi * x)^4 - 3 / 8


### PR DESCRIPTION
In order to avoid applying the sources twice (once in the vertical and again in the horizontal) for multirate time stepping methods, the `source!` function needs to be direction aware.

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
