### PR TITLE
Add back `EveryXSimulationTime` callback mechanism

### DIFF
--- a/src/ODESolvers/GenericCallbacks.jl
+++ b/src/ODESolvers/GenericCallbacks.jl
@@ -1,8 +1,10 @@
 """
-A set of callback functions to be used with an `AbstractAtmosODESolver`
+A set of callback functions to be used with an `AbstractODESolver`
 """
 module GenericCallbacks
 using MPI
+
+using ..ODESolvers
 
 """
     EveryXWallTimeSeconds(f, time, mpicomm)
@@ -11,45 +13,44 @@ This callback will run the function 'f()' every `time` wallclock time seconds.
 The `mpicomm` is used to syncronize runtime across MPI ranks.
 """
 struct EveryXWallTimeSeconds
-  "time of the last callback"
-  lastcbtime_ns::Array{UInt64}
-  "time between callbacks"
-  Δtime::Real
-  "MPI communicator"
-  mpicomm
-  "function to execute for callback"
-  func::Function
-  function EveryXWallTimeSeconds(func, Δtime, mpicomm)
-    lastcbtime_ns = [time_ns()]
-    new(lastcbtime_ns, Δtime, mpicomm, func)
-  end
-end
-function (cb::EveryXWallTimeSeconds)(initialize::Bool=false)
-  # Is this an initialization call? If so, start the timers
-  if initialize
-    cb.lastcbtime_ns[1] = time_ns()
-    # If this is initialization init the callback too
-    try
-      cb.func(true)
-    catch
+    "time of the last callback"
+    lastcbtime_ns::Array{UInt64}
+    "time between callbacks"
+    Δtime::Real
+    "MPI communicator"
+    mpicomm
+    "function to execute for callback"
+    func::Function
+    function EveryXWallTimeSeconds(func, Δtime, mpicomm)
+        lastcbtime_ns = [time_ns()]
+        new(lastcbtime_ns, Δtime, mpicomm, func)
     end
-    return 0
-  end
+end
+function (cb::EveryXWallTimeSeconds)(initialize::Bool = false)
+    # Is this an initialization call? If so, start the timers
+    if initialize
+        cb.lastcbtime_ns[1] = time_ns()
+        # If this is initialization init the callback too
+        try
+            cb.func(true)
+        catch
+        end
+        return 0
+    end
 
-  # Check whether we should do a callback
-  currtime_ns = time_ns()
-  runtime = (currtime_ns - cb.lastcbtime_ns[1]) * 1e-9
-  runtime = MPI.Allreduce(runtime, MPI.MAX, cb.mpicomm)
-  if runtime < cb.Δtime
-    return 0
-  else
-    # Compute the next time to do a callback
-    cb.lastcbtime_ns[1] = currtime_ns
-    retval = cb.func()
-  end
+    # Check whether we should do a callback
+    currtime_ns = time_ns()
+    runtime = (currtime_ns - cb.lastcbtime_ns[1]) * 1e-9
+    runtime = MPI.Allreduce(runtime, MPI.MAX, cb.mpicomm)
+    if runtime < cb.Δtime
+        return 0
+    else
+        # Compute the next time to do a callback
+        cb.lastcbtime_ns[1] = currtime_ns
+        return cb.func()
+    end
 end
 
-#=
 """
    EveryXSimulationTime(f, time, state)
 
@@ -57,42 +58,41 @@ This callback will run the function 'f()' every `time` wallclock time seconds.
 The `state` is used to query for the simulation time.
 """
 struct EveryXSimulationTime
-  "time of the last callback"
-  lastcbtime::Array{Real}
-  "time between callbacks"
-  Δtime::Real
-  "function to execute for callback"
-  func::Function
-  "pointer to the space state to query for time"
-  runner::AD.Runner
-  function EveryXSimulationTime(func, Δtime, runner)
-    lastcbtime = [AD.gettime(runner)]
-    new(lastcbtime, Δtime, func, runner)
-  end
-end
-function (cb::EveryXSimulationTime)(initialize::Bool=false)
-  # Is this an initialization call? If so, start the timers
-  if initialize
-    cb.lastcbtime[1] = AD.gettime(cb.runner)
-    # If this is initialization init the callback too
-    try
-      cb.func(true)
-    catch
+    "time of the last callback"
+    lastcbtime::Array{Real}
+    "time between callbacks"
+    Δtime::Real
+    "function to execute for callback"
+    func::Function
+    "timestepper, used to query for time"
+    solver
+    function EveryXSimulationTime(func, Δtime, solver)
+        lastcbtime = [ODESolvers.gettime(solver)]
+        new(lastcbtime, Δtime, func, solver)
     end
-    return 0
-  end
-
-  # Check whether we should do a callback
-  currtime = AD.gettime(cb.runner)
-  if (currtime - cb.lastcbtime[1]) < cb.Δtime
-    return 0
-  else
-    # Compute the next time to do a callback
-    cb.lastcbtime[1] = currtime
-    retval = cb.func()
-  end
 end
-=#
+function (cb::EveryXSimulationTime)(initialize::Bool = false)
+    # Is this an initialization call? If so, start the timers
+    if initialize
+        cb.lastcbtime[1] = ODESolvers.gettime(cb.solver)
+        # If this is initialization init the callback too
+        try
+            cb.func(true)
+        catch
+        end
+        return 0
+    end
+
+    # Check whether we should do a callback
+    currtime = ODESolvers.gettime(cb.solver)
+    if (currtime - cb.lastcbtime[1]) < cb.Δtime
+        return 0
+    else
+        # Compute the next time to do a callback
+        cb.lastcbtime[1] = currtime
+        return cb.func()
+    end
+end
 
 """
    EveryXSimulationSteps(f, steps)
@@ -100,37 +100,37 @@ end
 This callback will run the function 'f()' every `steps` of the time stepper
 """
 struct EveryXSimulationSteps
-  "number of steps since last callback"
-  steps::Array{Int}
-  "number of steps between callbacks"
-  Δsteps::Integer
-  "function to execute for callback"
-  func::Function
-  function EveryXSimulationSteps(func, Δsteps)
-   steps = [Int(0)]
-   new(steps, Δsteps, func)
-  end
-end
-function (cb::EveryXSimulationSteps)(initialize::Bool=false)
-  # Is this an initialization call? If so, start the timers
-  if initialize
-    cb.steps[1] = 0
-    # If this is initialization init the callback too
-    try
-      cb.func(true)
-    catch
+    "number of steps since last callback"
+    steps::Array{Int}
+    "number of steps between callbacks"
+    Δsteps::Integer
+    "function to execute for callback"
+    func::Function
+    function EveryXSimulationSteps(func, Δsteps)
+        steps = [Int(0)]
+        new(steps, Δsteps, func)
     end
-    return 0
-  end
+end
+function (cb::EveryXSimulationSteps)(initialize::Bool = false)
+    # Is this an initialization call? If so, start the timers
+    if initialize
+        cb.steps[1] = 0
+        # If this is initialization init the callback too
+        try
+            cb.func(true)
+        catch
+        end
+        return 0
+    end
 
-  # Check whether we should do a callback
-  cb.steps[1] += 1
-  if cb.steps[1] < cb.Δsteps
-    return 0
-  else
-    cb.steps[1] = 0
-    retval = cb.func()
-  end
+    # Check whether we should do a callback
+    cb.steps[1] += 1
+    if cb.steps[1] < cb.Δsteps
+        return 0
+    else
+        cb.steps[1] = 0
+        return cb.func()
+    end
 end
 
 end

--- a/test/ODESolvers/genericcb_tests.jl
+++ b/test/ODESolvers/genericcb_tests.jl
@@ -1,0 +1,83 @@
+using MPI
+using Test
+using CLIMA.GenericCallbacks
+using CLIMA.ODESolvers: AbstractODESolver
+
+mutable struct PseudoSolver <: AbstractODESolver
+    t::UInt64
+    step::Int
+    PseudoSolver() = new(time_ns(), 0)
+end
+gettime(ps::PseudoSolver) = ps.t
+
+function call_cbs(cbs, init = false)
+    foreach(cbs) do cb
+        cb(init)
+    end
+end
+
+function main()
+    MPI.Init()
+    mpicomm = MPI.COMM_WORLD
+    ps = PseudoSolver()
+
+    wtcb_initialized = false
+    wtcb_calls = 0
+    wtcb = GenericCallbacks.EveryXWallTimeSeconds(1, mpicomm) do (init = false)
+        if init
+            wtcb_initialized = true
+        else
+            wtcb_calls = wtcb_calls + 1
+        end
+    end
+    stcb_initialized = false
+    stcb_calls = 0
+    stcb = GenericCallbacks.EveryXSimulationTime(0.5, ps) do (init = false)
+        if init
+            stcb_initialized = true
+        else
+            stcb_calls = stcb_calls + 1
+        end
+    end
+    sscb_initialized = false
+    sscb_calls = 0
+    sscb = GenericCallbacks.EveryXSimulationSteps(10) do (init = false)
+        if init
+            sscb_initialized = true
+        else
+            sscb_calls = sscb_calls + 1
+        end
+    end
+    callbacks = (wtcb, stcb, sscb)
+
+    @testset "Generic Callbacks" begin
+        call_cbs(callbacks, true)
+        @test wtcb_initialized
+        @test stcb_initialized
+        @test sscb_initialized
+        call_cbs(callbacks)
+        @test wtcb_calls == 0
+        @test stcb_calls == 0
+        @test sscb_calls == 0
+        sleep(0.5)
+        ps.t = time_ns()
+        call_cbs(callbacks)
+        @test wtcb_calls == 0
+        @test stcb_calls == 1
+        @test sscb_calls == 0
+        sleep(0.5)
+        ps.t = time_ns()
+        call_cbs(callbacks)
+        @test wtcb_calls == 1
+        @test stcb_calls == 2
+        @test sscb_calls == 0
+        for i in 1:7
+            call_cbs(callbacks)
+        end
+        @test wtcb_calls == 1
+        @test stcb_calls == 2
+        @test sscb_calls == 1
+    end
+end
+
+main()

--- a/test/ODESolvers/runtests.jl
+++ b/test/ODESolvers/runtests.jl
@@ -2,6 +2,6 @@ using Test, MPI
 include("../testhelpers.jl")
 
 @testset "ODE Solvers" begin
-    tests = [(1, "ode_tests_basic.jl")]
+    tests = [(1, "ode_tests_basic.jl"), (1, "genericcb_tests.jl")]
     runmpi(tests, @__FILE__)
 end


### PR DESCRIPTION
# Description

Was not enabled. Closes #878. Also adds tests for `GenericCallbacks`.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
