### PR TITLE
Patch callback functionality (courant monitor) 

### DIFF
--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -59,7 +59,8 @@ function diffusive_courant(
     t,
     direction,
 )
-    ν, τ = turbulence_tensors(m.turbulence, state, diffusive, aux, t)
+    ν, _, _ = turbulence_tensors(m.turbulence, state, diffusive, aux, t)
+    ν = ν isa Real ? ν : diag(ν)
     k̂ = vertical_unit_vector(m, aux)
     normν = norm_ν(ν, k̂, direction)
     return Δt * normν / (Δx * Δx)

--- a/src/Atmos/Model/turbulence.jl
+++ b/src/Atmos/Model/turbulence.jl
@@ -63,7 +63,7 @@ function diffusive!(
 ) end
 
 """
-    ν, τ = turbulence_tensors(::TurbulenceClosure, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+    ν, D_t, τ = turbulence_tensors(::TurbulenceClosure, state::Vars, diffusive::Vars, aux::Vars, t::Real)
 
 Compute the kinematic viscosity tensor (`ν`) and SGS momentum flux tensor (`τ`).
 """


### PR DESCRIPTION
Fixes method mismatch for courant callbacks based on updates to turbulence file. 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
