### PR TITLE
Patch courant callback - fixes issue #950

### DIFF
--- a/src/Atmos/Model/courant.jl
+++ b/src/Atmos/Model/courant.jl
@@ -59,7 +59,8 @@ function diffusive_courant(
     t,
     direction,
 )
-    ν, τ = turbulence_tensors(m, state, diffusive, aux, t)
+    ν, _, _ = turbulence_tensors(m, state, diffusive, aux, t)
+    ν = ν isa Real ? ν : diag(ν)
     k̂ = vertical_unit_vector(m, aux)
     normν = norm_ν(ν, k̂, direction)
     return Δt * normν / (Δx * Δx)

--- a/src/Atmos/Model/turbulence.jl
+++ b/src/Atmos/Model/turbulence.jl
@@ -62,9 +62,9 @@ function diffusive!(
 ) end
 
 """
-    ν, τ = turbulence_tensors(::TurbulenceClosure, orientation::Orientation, param_set::AbstractParameterSet, state::Vars, diffusive::Vars, aux::Vars, t::Real)
+    ν, D_t, τ = turbulence_tensors(::TurbulenceClosure, orientation::Orientation, param_set::AbstractParameterSet, state::Vars, diffusive::Vars, aux::Vars, t::Real)
 
-Compute the kinematic viscosity tensor (`ν`) and SGS momentum flux tensor (`τ`).
+    Compute the kinematic viscosity (`ν`), the diffusivity (`D_t`) and SGS momentum flux tensor (`τ`).
 """
 function turbulence_tensors end
 
@@ -214,8 +214,8 @@ function turbulence_tensors(
     _inv_Pr_turb::FT = inv_Pr_turb(param_set)
     S = diffusive.turbulence.S
     ν = m.ρν / state.ρ
+    D_t = ν * _inv_Pr_turb
     τ = (-2 * ν) * S + (2 * ν / 3) * tr(S) * I
-    D_t = (ν isa Real ? ν : diag(ν)) * _inv_Pr_turb
     return ν, D_t, τ
 end
 
@@ -233,7 +233,7 @@ end
 # ```
 # with the stratification correction term
 # ```math
-# \mathrm{f}_{b} = \sqrt{1 - \frac{\mathrm{Ri}}{\mathrm{Pr}_{t}}}
+# \mathrm{f}_{b}^{2} = \sqrt{1 - \frac{\mathrm{Ri}}{\mathrm{Pr}_{t}}}
 # ```\
 # $\mathrm{Ri}$ and $\mathrm{Pr}_{t}$ are the Richardson and
 # turbulent Prandtl numbers respectively.  $\Delta$ is the mixing length in the
@@ -348,11 +348,11 @@ function turbulence_tensors(
     f_b² = sqrt(clamp(FT(1) - Richardson * _inv_Pr_turb, FT(0), FT(1)))
     ν₀ = normS * (m.C_smag * aux.turbulence.Δ)^2 + FT(1e-5)
     ν = SVector{3, FT}(ν₀, ν₀, ν₀)
-    ν_v = k̂ .* dot(ν, f_b² * k̂)
+    ν_v = k̂ .* dot(ν, k̂)
     ν_h = ν₀ .- ν_v
-    ν = SDiagonal(ν_h + ν_v)
+    ν = SDiagonal(ν_h + ν_v .* f_b²)
+    D_t = diag(ν) * _inv_Pr_turb
     τ = -2 * ν * S
-    D_t = (ν isa Real ? ν : diag(ν)) * _inv_Pr_turb
     return ν, D_t, τ
 end
 
@@ -457,12 +457,12 @@ function turbulence_tensors(
 
     ν₀ = m.C_smag^2 * FT(2.5) * sqrt(abs(Bβ / (norm2(α) + eps(FT))))
 
-    ν₀ = SVector{3, FT}(ν₀, ν₀, ν₀)
-    ν_h = cross(k̂, cross(ν₀, k̂))
-    ν_v = k̂ .* dot(ν₀, f_b² * k̂)
-    ν = SDiagonal(ν_h + ν_v)
+    ν = SVector{3, FT}(ν₀, ν₀, ν₀)
+    ν_v = k̂ .* dot(ν, k̂)
+    ν_h = ν₀ .- ν_v
+    ν = SDiagonal(ν_h + ν_v .* f_b²)
+    D_t = diag(ν) * _inv_Pr_turb
     τ = -2 * ν * S
-    D_t = (ν isa Real ? ν : diag(ν)) * _inv_Pr_turb
     return ν, D_t, τ
 end
 
@@ -567,10 +567,11 @@ function turbulence_tensors(
             FT(1e-5),
             -dot(transpose(∇û) * (∇û), Ŝ) / (dot(∇û, ∇û) .+ eps(normS)),
         )
-    ν_h = cross(k̂, cross(ν₀, k̂))
-    ν_v = k̂ .* dot(ν₀, f_b² * k̂)
-    ν = SDiagonal(ν_h + ν_v)
+
+    ν_v = k̂ .* dot(ν₀, k̂)
+    ν_h = ν₀ .- ν_v
+    ν = SDiagonal(ν_h + ν_v .* f_b²)
+    D_t = diag(ν) * _inv_Pr_turb
     τ = -2 * ν * S
-    D_t = (ν isa Real ? ν : diag(ν)) * _inv_Pr_turb
     return ν, D_t, τ
 end


### PR DESCRIPTION
# Description

Patches courant callback functionality, fix for issue #950. Sample output (from `risingbubble.jl`) included below. Removes cross products in `turbulence.jl` and simplifies functions for users. 

```
[ Info: Initializing DryRisingBubble
┌ Info: Starting DryRisingBubble
│     dt              = 2.07039e+00
│     timeend         =  1000.00
│     number of steps = 483
└     norm(Q)         = 3.0116018495687184e+09
┌ Info: Courant numbers at simtime:     0.00, Δt =     2.07 s
│     Acoustic (vertical) Courant number    = 20
│     Acoustic (horizontal) Courant number  = 20
│     Advection (vertical) Courant number   = 0
│     Advection (horizontal) Courant number = 0
│     Diffusion (vertical) Courant number   = 1.6e-08
│     Diffusion (horizontal) Courant number = 2.3e-08
```

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
