### PR TITLE
Rework command line arguments

### DIFF
--- a/examples/Atmos/dry_rayleigh_benard.jl
+++ b/examples/Atmos/dry_rayleigh_benard.jl
@@ -163,7 +163,7 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    interval = 10000 # in time steps
+    interval = "10000steps"
     dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
     return CLIMA.DiagnosticsConfiguration([dgngrp])
 end

--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -150,7 +150,7 @@ function held_suarez_forcing!(
 end
 
 function config_diagnostics(FT, driver_config)
-    interval = 1000 # in time steps
+    interval = "1000steps"
 
     _planet_radius = FT(planet_radius(param_set))
 

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -459,7 +459,7 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    interval = 10000 # in time steps
+    interval = "10000steps"
     dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
     return CLIMA.DiagnosticsConfiguration([dgngrp])
 end

--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -302,7 +302,7 @@ function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
         param_set;
         ref_state = ref_state,
         turbulence = SmagorinskyLilly{FT}(C_smag),
-        moisture = EquilMoist{FT}(maxiter = 1, tolerance=FT(100)),
+        moisture = EquilMoist{FT}(maxiter = 1, tolerance = FT(100)),
         radiation = radiation,
         source = source,
         boundarycondition = (
@@ -339,7 +339,7 @@ function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    interval = 10000 # in time steps
+    interval = "10000steps"
     dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
     return CLIMA.DiagnosticsConfiguration([dgngrp])
 end

--- a/experiments/AtmosLES/risingbubble.jl
+++ b/experiments/AtmosLES/risingbubble.jl
@@ -123,7 +123,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    interval = 10000 # in time steps
+    interval = "10000steps"
     dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
     return CLIMA.DiagnosticsConfiguration([dgngrp])
 end

--- a/experiments/AtmosLES/surfacebubble.jl
+++ b/experiments/AtmosLES/surfacebubble.jl
@@ -119,7 +119,7 @@ function config_surfacebubble(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    interval = 10000 # in time steps
+    interval = "10000steps"
     dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
     return CLIMA.DiagnosticsConfiguration([dgngrp])
 end

--- a/experiments/OceanBoxGCM/ocean_gyre.jl
+++ b/experiments/OceanBoxGCM/ocean_gyre.jl
@@ -79,12 +79,13 @@ function run_ocean_gyre(; imex::Bool = false, BC = nothing)
     )
 
     mkpath(outpdir)
-    CLIMA.Settings.enable_vtk = false
-    CLIMA.Settings.vtk_interval = ceil(Int64, timeout / solver_config.dt)
+    CLIMA.Settings.vtk = "never"
+    # vtk_interval = ceil(Int64, timeout / solver_config.dt)
+    # CLIMA.Settings.vtk = "$(vtk_interval)steps"
 
-    CLIMA.Settings.enable_diagnostics = false
-    CLIMA.Settings.diagnostics_interval =
-        ceil(Int64, timeout / solver_config.dt)
+    CLIMA.Settings.diagnostics = "never"
+    # diagnostics_interval = ceil(Int64, timeout / solver_config.dt)
+    # CLIMA.Settings.diagnostics = "$(diagnostics_interval)steps"
 
     result = CLIMA.invoke!(solver_config)
 

--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -1,21 +1,23 @@
 module MPIStateArrays
-using ..TicToc
-using LinearAlgebra
+
 using DoubleFloats
-using LazyArrays
-using StaticArrays
 using KernelAbstractions
-using Requires
+using LazyArrays
+using LinearAlgebra
 using MPI
+using StaticArrays
+
+using ..TicToc
 using ..VariableTemplates: @vars, varsindex
 
 using Base.Broadcast: Broadcasted, BroadcastStyle, ArrayStyle
-
 
 # This is so we can do things like
 #   similar(Array{Float64}, Int, 3, 4)
 Base.similar(::Type{A}, ::Type{FT}, dims...) where {A <: Array, FT} =
     similar(Array{FT}, dims...)
+
+using Requires
 @init @require CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
     using .CuArrays
     Base.similar(::Type{A}, ::Type{FT}, dims...) where {A <: CuArray, FT} =

--- a/src/CLIMA.jl
+++ b/src/CLIMA.jl
@@ -37,10 +37,11 @@ include(joinpath("LinearSolvers", "ColumnwiseLUSolver.jl"))
 include(joinpath("LinearSolvers", "ConjugateGradientSolver.jl"))
 include(joinpath("ODESolvers", "ODESolvers.jl"))
 include(joinpath("ODESolvers", "GenericCallbacks.jl"))
-include(joinpath("Utilities", "Callbacks", "Callbacks.jl"))
 include(joinpath("Atmos", "Model", "AtmosModel.jl"))
 include(joinpath("InputOutput", "VTK", "VTK.jl"))
 include(joinpath("Diagnostics", "Diagnostics.jl"))
+include(joinpath("Utilities", "Checkpoint", "Checkpoint.jl"))
+include(joinpath("Utilities", "Callbacks", "Callbacks.jl"))
 include(joinpath("Driver", "Driver.jl"))
 
 end

--- a/src/DGmethods/DGmodel_kernels.jl
+++ b/src/DGmethods/DGmodel_kernels.jl
@@ -1176,7 +1176,7 @@ See [`DGBalanceLaw`](@ref) for usage.
 end
 
 @doc """
-    knl_nodal_update_aux!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, f!, Q, auxstate,
+    knl_nodal_update_aux!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, f!, Q, auxstate, [diffstate,]
                           t, elems, activedofs) where {dim, N}
 
 Update the auxiliary state array
@@ -1236,12 +1236,6 @@ Update the auxiliary state array
     end
 end
 
-@doc """
-    knl_nodal_update_aux!(bl::BalanceLaw, ::Val{dim}, ::Val{N}, f!, Q, auxstate, diffstate,
-                          t, elems, activedofs) where {dim, N}
-
-Update the auxiliary state array
-""" knl_nodal_update_aux!
 @kernel function knl_nodal_update_aux!(
     bl::BalanceLaw,
     ::Val{dim},

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -74,7 +74,7 @@ mutable struct DiagnosticsGroup
     init::Function
     fini::Function
     collect::Function
-    interval::Int
+    interval::String
     out_prefix::String
     writer::AbstractWriter
     interpol::Union{Nothing, InterpolationTopology}
@@ -119,11 +119,12 @@ end
 
 """
     setup_atmos_default_diagnostics(
-            interval::Int,
-            out_prefix::String;
-            writer::AbstractWriter,
-            interpol = nothing,
-            project  = true)
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+        project = true,
+    )
 
 Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
 diagnostics, currently a set of diagnostics developed for DYCOMS. All
@@ -134,7 +135,7 @@ will be written to files prefixed by `out_prefix` using `writer`.
 TODO: this will be refactored soon.
 """
 function setup_atmos_default_diagnostics(
-    interval::Int,
+    interval::String,
     out_prefix::String;
     writer = NetCDFWriter(),
     interpol = nothing,
@@ -155,10 +156,12 @@ end
 
 """
     setup_dump_state_and_aux_diagnostics(
-            interval::Int,
-            out_prefix::String;
-            interpol = nothing,
-            project  = true)
+        interval::String,
+        out_prefix::String;
+        writer = NetCDFWriter(),
+        interpol = nothing,
+        project = true,
+    )
 
 Create and return a `DiagnosticsGroup` containing a diagnostic that
 simply dumps the state and aux variables at the specified `interval`
@@ -167,7 +170,7 @@ after being interpolated, into NetCDF files prefixed by `out_prefix`.
 TODO: this will be refactored soon.
 """
 function setup_dump_state_and_aux_diagnostics(
-    interval::Int,
+    interval::String,
     out_prefix::String;
     writer = NetCDFWriter(),
     interpol = nothing,

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -96,8 +96,10 @@ function SolverConfiguration(
 
     # create DG model, initialize ODE state
     if Settings.restart_from_num > 0
-        s_Q, s_aux, t0 = read_checkpoint(
+        s_Q, s_aux, t0 = Callbacks.read_checkpoint(
+            Settings.checkpoint_dir,
             driver_config.name,
+            driver_config.array_type,
             driver_config.mpicomm,
             Settings.restart_from_num,
         )

--- a/src/Utilities/Callbacks/Callbacks.jl
+++ b/src/Utilities/Callbacks/Callbacks.jl
@@ -1,32 +1,200 @@
 module Callbacks
 
+using CUDAapi
+using Dates
 using KernelAbstractions
+using LinearAlgebra
 using MPI
 using Printf
 using Requires
 using Statistics
 
+using CLIMAParameters
+using CLIMAParameters.Planet: day
+
+using ..Courant
+using ..Checkpoint
+using ..DGmethods: vars_state, vars_aux
+using ..Diagnostics
 using ..GenericCallbacks
+using ..MPIStateArrays
+using ..ODESolvers
+using ..VariableTemplates
+using ..VTK
+
+@init @require CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
+    using .CuArrays, .CuArrays.CUDAdrv, .CuArrays.CUDAnative
+    @eval _sync_device(::Type{CuArray}) = synchronize()
+end
 
 _sync_device(::Type{Array}) = nothing
-@init @require CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
-    using .CuArrays, .CuArrays.CUDAdrv
-    _sync_device(::Type{CuArray}) = synchronize()
+
+"""
+    show_updates(show_updates_opt, solver_config, user_info_callback)
+
+Return a callback function that shows simulation updates at the specified
+interval and also invokes the user-specified info callback.
+"""
+function show_updates(show_updates_opt, solver_config, user_info_callback)
+    timeend = solver_config.timeend
+
+    cb_constr = CB_constructor(show_updates_opt, solver_config)
+    if cb_constr !== nothing
+        # set up the information callback
+        upd_starttime = Ref(now())
+        cb_updates = cb_constr() do (init = false)
+            if init
+                upd_starttime[] = now()
+            else
+                runtime = Dates.format(
+                    convert(Dates.DateTime, Dates.now() - upd_starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                )
+                energy = norm(solver_config.Q)
+                @info @sprintf(
+                    """
+Update
+    simtime = %8.2f / %8.2f
+    runtime = %s
+    norm(Q) = %.16e""",
+                    ODESolvers.gettime(solver_config.solver),
+                    solver_config.timeend,
+                    runtime,
+                    energy,
+                )
+                isnan(energy) && error("norm(Q) is NaN")
+            end
+            user_info_callback(init)
+        end
+        return cb_updates
+    else
+        return nothing
+    end
 end
 
 """
-    wall_clock_time_per_time_step(interval, array_type, comm)
+    diagnostics(diagnostics_opt, solver_config, dgn_starttime, diagnostics_config)
 
-Returns a callback function that gives wall-clock time per time-step statistics
-across MPI ranks in the communicator `comm`.  The times are averaged over the
-`interval` of time steps requested for output.  The `array_type` is used
-to synchronize the compute device.
+Return callback functions that shows simulation updates at the specified
+interval and also invokes the user-specified info callback.
 """
-function wall_clock_time_per_time_step(interval, array_type, comm)
+function diagnostics(
+    diagnostics_opt,
+    solver_config,
+    dgn_starttime,
+    diagnostics_config,
+)
+    if diagnostics_opt != "never" && diagnostics_config !== nothing
+        # set up a callback for each diagnostics group
+        dgncbs = ()
+        for dgngrp in diagnostics_config.groups
+            cb_constr =
+                CB_constructor(diagnostics_opt, solver_config, dgngrp.interval)
+            cb_constr === nothing && continue
+            fn = cb_constr() do (init = false)
+                currtime = ODESolvers.gettime(solver_config.solver)
+                @info @sprintf(
+                    """
+Diagnostics: %s
+    %s at %s""",
+                    dgngrp.name,
+                    init ? "initializing" : "collecting",
+                    string(currtime),
+                )
+                dgngrp(currtime, init = init)
+                nothing
+            end
+            dgncbs = (dgncbs..., fn)
+        end
+        return dgncbs
+    else
+        return nothing
+    end
+end
+
+"""
+    vtk(vtk_opt, solver_config)
+
+Return a callback that saves state and auxiliary variables to a VTK
+file.
+"""
+function vtk(vtk_opt, solver_config, output_dir)
+    cb_constr = CB_constructor(vtk_opt, solver_config)
+    if cb_constr !== nothing
+        vtknum = Ref(1)
+
+        mpicomm = solver_config.mpicomm
+        dg = solver_config.dg
+        bl = dg.balancelaw
+        Q = solver_config.Q
+        FT = eltype(Q)
+
+        cb_vtk = cb_constr() do (init = false)
+            vprefix = @sprintf(
+                "%s_mpirank%04d_num%04d",
+                solver_config.name,
+                MPI.Comm_rank(mpicomm),
+                vtknum[],
+            )
+            outprefix = joinpath(output_dir, vprefix)
+
+            statenames = flattenednames(vars_state(bl, FT))
+            auxnames = flattenednames(vars_aux(bl, FT))
+
+            writevtk(outprefix, Q, dg, statenames, dg.auxstate, auxnames)
+
+            # Generate the pvtu file for these vtk files
+            if MPI.Comm_rank(mpicomm) == 0
+                # name of the pvtu file
+                pprefix = @sprintf("%s_num%04d", solver_config.name, vtknum[])
+                pvtuprefix = joinpath(output_dir, pprefix)
+
+                # name of each of the ranks vtk files
+                prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+                    @sprintf(
+                        "%s_mpirank%04d_num%04d",
+                        solver_config.name,
+                        i - 1,
+                        vtknum[],
+                    )
+                end
+                writepvtu(pvtuprefix, prefixes, (statenames..., auxnames...))
+            end
+
+            vtknum[] += 1
+            nothing
+        end
+        return cb_vtk
+    else
+        return nothing
+    end
+end
+
+"""
+    monitor_timestep_duration(mtd_opt, array_type, comm)
+
+Returns a callback function that displays wall-clock time per time-step
+statistics across MPI ranks in the communicator `comm`.  The times are
+averaged over the `mtd_opt` time steps requested for output.  The
+`array_type` is used to synchronize the compute device.
+"""
+function monitor_timestep_duration(mtd_opt, array_type, comm)
+    if mtd_opt == "never"
+        return nothing
+    elseif !endswith(mtd_opt, "steps")
+        @warn @sprintf(
+            """
+monitor-timestep-duration must be in 'steps'; %s unrecognized; disabling""",
+            mtd_opt,
+        )
+        return nothing
+    end
+    steps = parse(Int, mtd_opt[1:(end - 5)])
+
     _sync_device(array_type)
     before = time_ns()
 
-    callback = GenericCallbacks.EveryXSimulationSteps(interval) do
+    cb_mtd = GenericCallbacks.EveryXSimulationSteps(steps) do
         _sync_device(array_type)
         after = time_ns()
 
@@ -35,7 +203,7 @@ function wall_clock_time_per_time_step(interval, array_type, comm)
         times = MPI.Gather(time_per_timesteps, 0, comm)
         if MPI.Comm_rank(comm) == 0
             ns_per_s = 1e9
-            times = times ./ ns_per_s ./ interval
+            times = times ./ ns_per_s ./ steps
 
             @info @sprintf(
                 """Wall-clock time per time-step (statistics across MPI ranks)
@@ -57,7 +225,182 @@ function wall_clock_time_per_time_step(interval, array_type, comm)
         nothing
     end
 
-    return callback
+    return cb_mtd
 end
 
+"""
+    monitor_courant_numbers(mcn_opt, solver_config)
+
+Return a callback function that displays Courant numbers for the simulation
+at `mcn_opt` intervals.
+"""
+function monitor_courant_numbers(mcn_opt, solver_config)
+    cb_constr = CB_constructor(mcn_opt, solver_config)
+    if cb_constr !== nothing
+        cb_cfl = cb_constr() do (init = false)
+            Δt = solver_config.dt
+            c_v = DGmethods.courant(
+                nondiffusive_courant,
+                solver_config,
+                direction = VerticalDirection(),
+            )
+            c_h = DGmethods.courant(
+                nondiffusive_courant,
+                solver_config,
+                direction = HorizontalDirection(),
+            )
+            ca_v = DGmethods.courant(
+                advective_courant,
+                solver_config,
+                direction = VerticalDirection(),
+            )
+            ca_h = DGmethods.courant(
+                advective_courant,
+                solver_config,
+                direction = HorizontalDirection(),
+            )
+            cd_v = DGmethods.courant(
+                diffusive_courant,
+                solver_config,
+                direction = VerticalDirection(),
+            )
+            cd_h = DGmethods.courant(
+                diffusive_courant,
+                solver_config,
+                direction = HorizontalDirection(),
+            )
+            simtime = ODESolvers.gettime(solver_config.solver)
+            @info @sprintf(
+                """
+Courant numbers at simtime: %8.2f, Δt = %8.2f s
+    Acoustic (vertical) Courant number    = %.2g
+    Acoustic (horizontal) Courant number  = %.2g
+    Advection (vertical) Courant number   = %.2g
+    Advection (horizontal) Courant number = %.2g
+    Diffusion (vertical) Courant number   = %.2g
+    Diffusion (horizontal) Courant number = %.2g""",
+                simtime,
+                Δt,
+                c_v,
+                c_h,
+                ca_v,
+                ca_h,
+                cd_v,
+                cd_h,
+            )
+            nothing
+        end
+        return cb_cfl
+    else
+        return nothing
+    end
 end
+
+"""
+    checkpoint(
+        checkpoint_opt,
+        checkpoint_keep_one,
+        solver_config,
+        checkpoint_dir,
+    )
+
+Return a callback function that runs at `checkpoint_opt` intervals
+and stores a simulation checkpoint into `checkpoint_dir` identified
+by a running number.
+"""
+function checkpoint(
+    checkpoint_opt,
+    checkpoint_keep_one,
+    solver_config,
+    checkpoint_dir,
+)
+    cb_constr = CB_constructor(checkpoint_opt, solver_config)
+    if cb_constr !== nothing
+        cpnum = Ref(1)
+        cb_checkpoint = cb_constr() do (init = false)
+            write_checkpoint(
+                solver_config,
+                checkpoint_dir,
+                solver_config.name,
+                solver_config.mpicomm,
+                cpnum[],
+            )
+            if checkpoint_keep_one
+                rm_checkpoint(
+                    checkpoint_dir,
+                    solver_config.name,
+                    solver_config.mpicomm,
+                    cpnum[] - 1,
+                )
+            end
+            cpnum[] += 1
+            nothing
+        end
+        return cb_checkpoint
+    else
+        return nothing
+    end
+end
+
+"""
+    CB_constructor(interval, solver_config, default)
+
+Parse the specified `interval` and return the appropriate `GenericCallbacks`
+constructor. If `interval` is "default", then use `default` as the interval.
+"""
+function CB_constructor(interval::String, solver_config, default = nothing)
+    mpicomm = solver_config.mpicomm
+    solver = solver_config.solver
+    dg = solver_config.dg
+    bl = dg.balancelaw
+    secs_per_day = day(bl.param_set)
+
+    if endswith(interval, "hours")
+        secs = 60 * 60 * parse(Int, interval[1:(end - 5)])
+        return (func) ->
+            GenericCallbacks.EveryXWallTimeSeconds(func, secs, mpicomm)
+    elseif endswith(interval, "mins")
+        secs = 60 * parse(Int, interval[1:(end - 4)])
+        return (func) ->
+            GenericCallbacks.EveryXWallTimeSeconds(func, secs, mpicomm)
+    elseif endswith(interval, "secs")
+        secs = parse(Int, interval[1:(end - 4)])
+        return (func) ->
+            GenericCallbacks.EveryXWallTimeSeconds(func, secs, mpicomm)
+    elseif endswith(interval, "smonths")
+        ticks = 30.0 * secs_per_day * parse(Float64, interval[1:(end - 7)])
+        return (func) ->
+            GenericCallbacks.EveryXSimulationTime(func, ticks, solver)
+    elseif endswith(interval, "sdays")
+        ticks = secs_per_day * parse(Float64, interval[1:(end - 5)])
+        return (func) ->
+            GenericCallbacks.EveryXSimulationTime(func, ticks, solver)
+    elseif endswith(interval, "shours")
+        ticks = 60.0 * 60.0 * parse(Float64, interval[1:(end - 6)])
+        return (func) ->
+            GenericCallbacks.EveryXSimulationTime(func, ticks, solver)
+    elseif endswith(interval, "steps")
+        steps = parse(Int, interval[1:(end - 5)])
+        return (func) -> GenericCallbacks.EveryXSimulationSteps(func, steps)
+    elseif interval == "default"
+        if default === nothing
+            @warn "no default available; ignoring"
+            return nothing
+        elseif default === ""
+            return nothing
+        else
+            return CB_constructor(default, solver_config, "")
+        end
+    elseif interval == "never"
+        return nothing
+    else
+        @warn @sprintf(
+            """
+%s: unrecognized interval; ignoring""",
+            interval,
+        )
+        return nothing
+    end
+end
+
+end # module

--- a/src/Utilities/Checkpoint/Checkpoint.jl
+++ b/src/Utilities/Checkpoint/Checkpoint.jl
@@ -1,0 +1,107 @@
+module Checkpoint
+
+export write_checkpoint, rm_checkpoint, read_checkpoint
+
+using JLD2
+using MPI
+using Printf
+
+using ..ODESolvers
+
+"""
+    write_checkpoint(solver_config, checkpoint_dir, name, mpicomm, num)
+
+Read in the state and auxiliary arrays as well as the simulation time
+stored in the checkpoint file for `name` and `num`.
+"""
+function write_checkpoint(
+    solver_config,
+    checkpoint_dir::String,
+    name::String,
+    mpicomm::MPI.Comm,
+    num::Int,
+)
+    nm = replace(name, " " => "_")
+    cname = @sprintf(
+        "%s_checkpoint_mpirank%04d_num%04d.jld2",
+        nm,
+        MPI.Comm_rank(mpicomm),
+        num,
+    )
+    cfull = joinpath(checkpoint_dir, cname)
+    @info @sprintf(
+        """
+Checkpoint
+    saving to %s""",
+        cfull
+    )
+
+    dg = solver_config.dg
+    Q = solver_config.Q
+    if Array ∈ typeof(Q).parameters
+        h_Q = Q.realdata
+        h_aux = dg.auxstate.realdata
+    else
+        h_Q = Array(Q.realdata)
+        h_aux = Array(dg.auxstate.realdata)
+    end
+    t = ODESolvers.gettime(solver_config.solver)
+    @save cfull h_Q h_aux t
+
+    return nothing
+end
+
+"""
+    rm_checkpoint(checkpoint_dir, name, mpicomm, num)
+
+Remove the checkpoint file identified by `solver_config.name` and `num`.
+"""
+function rm_checkpoint(
+    checkpoint_dir::String,
+    name::String,
+    mpicomm::MPI.Comm,
+    num::Int,
+)
+    nm = replace(name, " " => "_")
+    cname = @sprintf(
+        "%s_checkpoint_mpirank%04d_num%04d.jld2",
+        nm,
+        MPI.Comm_rank(mpicomm),
+        num,
+    )
+    rm(joinpath(checkpoint_dir, cname), force = true)
+
+    return nothing
+end
+
+"""
+    read_checkpoint(checkpoint_dir, name, mpicomm, num)
+
+Read in the state and auxiliary arrays as well as the simulation time
+stored in the checkpoint file for `name` and `num`.
+"""
+function read_checkpoint(
+    checkpoint_dir::String,
+    name::String,
+    array_type,
+    mpicomm::MPI.Comm,
+    num::Int,
+)
+    nm = replace(name, " " => "_")
+    cname = @sprintf(
+        "%s_checkpoint_mpirank%04d_num%04d.jld2",
+        nm,
+        MPI.Comm_rank(mpicomm),
+        num,
+    )
+    cfull = joinpath(checkpoint_dir, cname)
+    if !isfile(cfull)
+        error("Cannot restore from checkpoint in %s, file not found")
+    end
+
+    @load cfull h_Q h_aux t
+
+    return (array_type(h_Q), array_type(h_aux), t)
+end
+
+end # module

--- a/test/Diagnostics/diagnostic_fields_test.jl
+++ b/test/Diagnostics/diagnostic_fields_test.jl
@@ -19,7 +19,7 @@ struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
 import CLIMA.Mesh.Grids: _x1, _x2, _x3
-import CLIMA.vars_state
+import CLIMA.DGmethods: vars_state
 import CLIMA.VariableTemplates.varsindex
 
 # ------------------------ Description ------------------------- #
@@ -117,7 +117,7 @@ function config_risingbubble(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    interval = 10000 # in time steps
+    interval = "10000steps"
     dgngrp = setup_atmos_default_diagnostics(interval, driver_config.name)
     return CLIMA.DiagnosticsConfiguration([dgngrp])
 end

--- a/test/Diagnostics/sin_test.jl
+++ b/test/Diagnostics/sin_test.jl
@@ -99,7 +99,7 @@ function config_sin_test(FT, N, resolution, xmax, ymax, zmax)
 end
 
 function config_diagnostics(driver_config)
-    interval = 100
+    interval = "100steps"
     dgngrp = setup_atmos_default_diagnostics(
         interval,
         replace(driver_config.name, " " => "_"),
@@ -112,7 +112,7 @@ function main()
     CLIMA.init()
 
     # Disable driver diagnostics as we're testing it here
-    CLIMA.Settings.enable_diagnostics = false
+    CLIMA.Settings.diagnostics = "never"
 
     FT = Float64
 
@@ -180,4 +180,5 @@ function main()
         @test err1 <= 1e-16
     end
 end
+
 main()

--- a/test/Driver/cr_unit_tests.jl
+++ b/test/Driver/cr_unit_tests.jl
@@ -1,5 +1,6 @@
 using CLIMA
 using CLIMA.Atmos
+using CLIMA.Checkpoint
 using CLIMA.ConfigTypes
 using CLIMA.MoistThermodynamics
 using CLIMA.VariableTemplates
@@ -97,8 +98,19 @@ function main()
     mkpath(CLIMA.Settings.checkpoint_dir)
 
     @testset "Checkpoint/restart unit tests" begin
-        CLIMA.rm_checkpoint(solver_config, 0)
-        CLIMA.write_checkpoint(solver_config, 0)
+        rm_checkpoint(
+            CLIMA.Settings.checkpoint_dir,
+            solver_config.name,
+            solver_config.mpicomm,
+            0,
+        )
+        write_checkpoint(
+            solver_config,
+            CLIMA.Settings.checkpoint_dir,
+            solver_config.name,
+            solver_config.mpicomm,
+            0,
+        )
 
         nm = replace(solver_config.name, " " => "_")
         cname = @sprintf(
@@ -111,7 +123,13 @@ function main()
         @test isfile(cfull)
 
         s_Q, s_aux, s_t = try
-            CLIMA.read_checkpoint(nm, solver_config.mpicomm, 0)
+            read_checkpoint(
+                CLIMA.Settings.checkpoint_dir,
+                nm,
+                driver_config.array_type,
+                solver_config.mpicomm,
+                0,
+            )
         catch
             (nothing, nothing, nothing)
         end
@@ -138,7 +156,12 @@ function main()
         @test h_aux == s_aux
         @test t == s_t
 
-        CLIMA.rm_checkpoint(solver_config, 0)
+        rm_checkpoint(
+            CLIMA.Settings.checkpoint_dir,
+            solver_config.name,
+            solver_config.mpicomm,
+            0,
+        )
         @test !isfile(cfull)
     end
 end


### PR DESCRIPTION
# Description

Closes #877 and #909.

Most of the command line arguments relate to whether or not something should occur, and then specifying the interval at which it occurs. These intervals are (somewhat randomly) either in wall-clock time or simulation steps.

After #951, specifying simulation time is now also possible. So, rather than have, for instance, `--checkpoint-walltime` and `--checkpoint-simtime` and `--checkpoint-simsteps`, this allows intervals to be specified as:
- `2hours` or `10mins` or `30secs` => wall-clock time,
- `9.5smonths` or `3.3sdays` or `1.5shours` => simulation time,
- `1000steps` => simulation steps,
- `never` => disable,
- `default` => use any pre-defined interval (only present for diagnostics groups at the moment).

And now there is just `--checkpoint <interval>`. All command line arguments are reworked to conform to this.

This also adds the ability for experiments to have their own command line arguments. To do this, create an [`ArgParse.ArgParseSettings`](https://carlobaldassi.github.io/ArgParse.jl/stable/settings/) that defines an [argument group](https://carlobaldassi.github.io/ArgParse.jl/stable/arg_table/#Argument-groups-1) with an argument table containing the experiment's argument definitions. Then:
```
parsed_args = CLIMA.init(arg_settings = experiment_arg_settings)
```
And `parsed_args` is a `Dict` keyed by the arguments in `experiment_arg_settings`. An example will be added in a later PR.

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [X] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
