### PR TITLE
Remove `PlanetParameters` from `SurfaceFluxes`

### DIFF
--- a/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
+++ b/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
@@ -56,7 +56,14 @@ Computes buoyancy flux given
  - `q` phase partition (see [`PhasePartition`](@ref))
  - `α_0` specific volume
 """
-function compute_buoyancy_flux(param_set::AbstractParameterSet, shf, lhf, T_b, q, α_0)
+function compute_buoyancy_flux(
+    param_set::AbstractParameterSet,
+    shf,
+    lhf,
+    T_b,
+    q,
+    α_0,
+)
     FT = typeof(shf)
     _molmass_ratio::FT = molmass_ratio(param_set)
     _grav::FT = grav(param_set)
@@ -126,13 +133,19 @@ function compute_friction_velocity(
     γ_m::FT,
     tol_abs::FT,
     iter_max::IT,
-) where {FT,IT}
+) where {FT, IT}
 
     _von_karman_const = FT(von_karman_const(param_set))
 
     ustar_0 = u_ave * _von_karman_const / log(z_1 / z_0)
     ustar = ustar_0
-    let u_ave = u_ave, flux = flux, z_0 = z_0, z_1 = z_1, β_m = β_m, γ_m = γ_m, param_set=param_set
+    let u_ave = u_ave,
+        flux = flux,
+        z_0 = z_0,
+        z_1 = z_1,
+        β_m = β_m,
+        γ_m = γ_m,
+        param_set = param_set
 
         # use neutral condition as first guess
         stable = z_1 / monin_obukhov_len(param_set, ustar_0, flux) >= 0
@@ -186,8 +199,8 @@ function compute_exchange_coefficients(
     γ_h::FT,
     β_m::FT,
     β_h::FT,
-    Pr_0::FT
-    ) where {FT}
+    Pr_0::FT,
+) where {FT}
     logz = log(z_b / z_0)
     zfactor = z_b / (z_b - z_0) * logz
     s_b = Ri / Pr_0
@@ -262,8 +275,8 @@ function compute_Ψ_m(ζ, L, a, tol)
         # Note that "1-f^3" in is a typo, it is supposed to be "1-f_m^3".
         # This was confirmed by communication with the author.
         return L >= 0 ? -a * ζ / 2 :
-               log((1 + f_m)^2 * (1 + f_m^2) / 8) - 2 * atan(f_m) + FT(π / 2) - 1 +
-               (1 - f_m^3) / (12 * ζ)
+               log((1 + f_m)^2 * (1 + f_m^2) / 8) - 2 * atan(f_m) + FT(π / 2) -
+               1 + (1 - f_m^3) / (12 * ζ)
     end
 end
 
@@ -312,12 +325,12 @@ function compute_friction_velocity(
     Ψ_m_tol::FT,
     tol_abs::FT,
     iter_max::IT,
-) where {FT,IT}
+) where {FT, IT}
     _von_karman_const::FT = von_karman_const(param_set)
     ustar_0 = u_ave * _von_karman_const / log(Δz / z_0)
     ustar = ustar_0
     let u_ave = u_ave,
-        _von_karman_const=_von_karman_const,
+        _von_karman_const = _von_karman_const,
         θ = θ,
         flux = flux,
         Δz = Δz,
@@ -374,8 +387,8 @@ function compute_exchange_coefficients(
     u_star::FT,
     θ::FT,
     flux::FT,
-    Pr::FT
-    ) where {FT}
+    Pr::FT,
+) where {FT}
 
     _von_karman_const::FT = von_karman_const(param_set)
     L_mo = monin_obukhov_len(param_set, u_star, θ, flux)

--- a/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
+++ b/src/Atmos/Parameterizations/SurfaceFluxes/SurfaceFluxes.jl
@@ -11,72 +11,76 @@
 ## Interface
   - [`compute_buoyancy_flux`](@ref) computes the buoyancy flux
   - In addition, each sub-module has the following functions:
-    - [`compute_MO_len`](@ref) computes the Monin-Obukhov length
+    - [`monin_obukhov_len`](@ref) computes the Monin-Obukhov length
     - [`compute_friction_velocity`](@ref) computes the friction velocity
     - [`compute_exchange_coefficients`](@ref) computes the exchange coefficients
 
 ## References
 
-  - Ref. Byun1990:
-    - Byun, Daewon W. "On the analytical solutions of flux-profile
-      relationships for the atmospheric surface layer." Journal of
-      Applied Meteorology 29.7 (1990): 652-657.
-      https://doi.org/10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2
+@article{nishizawa2018surface,
+  title={A Surface Flux Scheme Based on the Monin-Obukhov Similarity for Finite Volume Models},
+  author={Nishizawa, S and Kitamura, Y},
+  journal={Journal of Advances in Modeling Earth Systems},
+  volume={10},
+  number={12},
+  pages={3159--3175},
+  year={2018},
+  publisher={Wiley Online Library}
+}
 
-  - Ref. Wyngaard1975:
-    - Wyngaard, John C. "Modeling the planetary boundary layer-Extension
-      to the stable case." Boundary-Layer Meteorology 9.4 (1975): 441-460.
-      https://link.springer.com/article/10.1007/BF00223393
-
-  - Ref. Nishizawa2018:
-    - Nishizawa, S., and Y. Kitamura. "A Surface Flux Scheme Based on the
-      Monin-Obukhov Similarity for Finite Volume Models." Journal of
-      Advances in Modeling Earth Systems 10.12 (2018): 3159-3175.
-      https://doi.org/10.1029/2018MS001534
-
-  - Ref. Businger1971:
-    - Businger, Joost A., et al. "Flux-profile relationships in the
-      atmospheric surface layer." Journal of the atmospheric Sciences
-      28.2 (1971): 181-189.
+@article{byun1990analytical,
+  title={On the analytical solutions of flux-profile relationships for the atmospheric surface layer},
+  author={Byun, Daewon W},
+  journal={Journal of Applied Meteorology},
+  volume={29},
+  number={7},
+  pages={652--657},
+  year={1990}
+}
 
 """
 module SurfaceFluxes
 
 using RootSolvers
 using ..MoistThermodynamics
-using ..PlanetParameters
-
-# export compute_buoyancy_flux
+using CLIMAParameters
+using CLIMAParameters.Planet: molmass_ratio, grav
 
 """
-    compute_buoyancy_flux(shf, lhf, T_b, qt_b, ql_b, qi_b, alpha0_0)
+    compute_buoyancy_flux(param_set, shf, lhf, T_b, q, α_0)
 
-Computes buoyancy flux given sensible heat flux `shf`,
-latent heat flux `lhf`, surface boundary temperature `T_b`,
-total specific humidity `qt_b`, liquid specific humidity `ql_b`,
-ice specific humidity `qi_b` and specific `alpha0_0`.
+Computes buoyancy flux given
+ - `shf` sensible heat flux
+ - `lhf` latent heat flux
+ - `T_b` surface boundary temperature
+ - `q` phase partition (see [`PhasePartition`](@ref))
+ - `α_0` specific volume
 """
-function compute_buoyancy_flux(shf, lhf, T_b, qt_b, ql_b, qi_b, alpha0_0)
-    cp_ = cp_m(PhasePartition(qt_b, ql_b, qi_b))
-    lv = latent_heat_vapor(T_b)
-    temp1 = (molmass_ratio - 1)
+function compute_buoyancy_flux(param_set::AbstractParameterSet, shf, lhf, T_b, q, α_0)
+    FT = typeof(shf)
+    _molmass_ratio::FT = molmass_ratio(param_set)
+    _grav::FT = grav(param_set)
+    cp_ = cp_m(q, param_set)
+    lv = latent_heat_vapor(T_b, param_set)
+    temp1 = (_molmass_ratio - 1)
     temp2 = (shf + temp1 * cp_ * T_b * lhf / lv)
-    return (grav * alpha0_0 / cp_ / T_b * temp2)
+    return (_grav * α_0 / cp_ / T_b * temp2)
 end
 
 module Byun1990
 
 using RootSolvers
 using ...MoistThermodynamics
-using ...PlanetParameters
+using CLIMAParameters
+using CLIMAParameters.SubgridScale: von_karman_const
 
-""" Computes ψ_m for stable case. See Eq. 12 Ref. Byun1990 """
+""" Computes ψ_m for stable case. See Eq. 12 """
 ψ_m_stable(ζ, ζ_0, β_m) = -β_m * (ζ - ζ_0)
 
-""" Computes ψ_h for stable case. See Eq. 13 Ref. Byun1990 """
+""" Computes ψ_h for stable case. See Eq. 13 """
 ψ_h_stable(ζ, ζ_0, β_h) = -β_h * (ζ - ζ_0)
 
-""" Computes ψ_m for unstable case. See Eq. 14 Ref. Byun1990 """
+""" Computes ψ_m for unstable case. See Eq. 14 """
 function ψ_m_unstable(ζ, ζ_0, γ_m)
     x(ζ) = sqrt(sqrt(1 - γ_m * ζ))
     temp(ζ, ζ_0) = log1p((ζ - ζ_0) / (1 + ζ_0))  # log((1 + ζ)/(1 + ζ_0))
@@ -87,7 +91,7 @@ function ψ_m_unstable(ζ, ζ_0, γ_m)
     return ψ_m
 end
 
-""" Computes ψ_h for unstable case. See Eq. 15 Ref. Byun1990 """
+""" Computes ψ_h for unstable case. See Eq. 15 """
 function ψ_h_unstable(ζ, ζ_0, γ_h)
     y(ζ) = sqrt(1 - γ_h * ζ)
     ψ_h = 2 * log1p((y(ζ) - y(ζ_0)) / (1 + y(ζ_0))) # log((1 + y(ζ))/(1 + y(ζ_0)))
@@ -95,44 +99,52 @@ function ψ_h_unstable(ζ, ζ_0, γ_h)
 end
 
 """
-    compute_MO_len(u, flux)
+    monin_obukhov_len(param_set, u, flux)
 
-Computes the Monin-Obukhov length (Eq. 3 Ref. Byun1990)
+Computes the Monin-Obukhov length (Eq. 3)
 """
-compute_MO_len(u, flux) = -u^3 / (flux * k_Karman)
+function monin_obukhov_len(param_set::AbstractParameterSet, u, flux)
+    FT = typeof(u)
+    _von_karman_const::FT = von_karman_const(param_set)
+    return -u^3 / (flux * _von_karman_const)
+end
 
 """
-    compute_friction_velocity(u_ave, flux, z_0, z_1, β_m, γ_m, tol_abs, iter_max)
+    compute_friction_velocity(param_set, flux, z_0, z_1, β_m, γ_m, tol_abs, iter_max)
 
-Computes roots of friction velocity equation (Eq. 10 in Ref. Byun1990)
+Computes roots of friction velocity equation (Eq. 10)
 
-`u_ave = u_* ( ln(z/z_0) - ψ_m(z/L, z_0/L) ) /κ        Eq. 10 in Ref. Byun1990`
+`u_ave = u_* ( ln(z/z_0) - ψ_m(z/L, z_0/L) ) /κ`
 """
 function compute_friction_velocity(
-    u_ave,
-    flux,
-    z_0,
-    z_1,
-    β_m,
-    γ_m,
-    tol_abs,
-    iter_max,
-)
+    param_set::AbstractParameterSet,
+    u_ave::FT,
+    flux::FT,
+    z_0::FT,
+    z_1::FT,
+    β_m::FT,
+    γ_m::FT,
+    tol_abs::FT,
+    iter_max::IT,
+) where {FT,IT}
 
-    ustar_0 = u_ave * k_Karman / log(z_1 / z_0)
+    _von_karman_const = FT(von_karman_const(param_set))
+
+    ustar_0 = u_ave * _von_karman_const / log(z_1 / z_0)
     ustar = ustar_0
-    let u_ave = u_ave, flux = flux, z_0 = z_0, z_1 = z_1, β_m = β_m, γ_m = γ_m
+    let u_ave = u_ave, flux = flux, z_0 = z_0, z_1 = z_1, β_m = β_m, γ_m = γ_m, param_set=param_set
 
         # use neutral condition as first guess
-        stable = z_1 / compute_MO_len(ustar_0, flux) >= 0
+        stable = z_1 / monin_obukhov_len(param_set, ustar_0, flux) >= 0
         function compute_ψ_m(u)
-            L_MO = compute_MO_len(u, flux)
+            L_MO = monin_obukhov_len(param_set, u, flux)
             ζ = z_1 / L_MO
             ζ_0 = z_0 / L_MO
             return stable ? ψ_m_stable(ζ, ζ_0, β_m) : ψ_m_unstable(ζ, ζ_0, γ_m)
         end
         function compute_u_ave_over_ustar(u)
-            return (log(z_1 / z_0) - compute_ψ_m(u)) / k_Karman # Eq. 10 in Ref. Byun1990
+            _von_karman_const = FT(von_karman_const(param_set))
+            return (log(z_1 / z_0) - compute_ψ_m(u)) / _von_karman_const # Eq. 10
         end
         compute_ustar(u) = u_ave / compute_u_ave_over_ustar(u)
 
@@ -156,44 +168,57 @@ function compute_friction_velocity(
 end
 
 """
-    compute_exchange_coefficients(Ri, z_b, z_0, γ_m, γ_h, β_m, β_h, Pr_0)
+    compute_exchange_coefficients(param_set, Ri, z_b, z_0, γ_m, γ_h, β_m, β_h, Pr_0)
 
 Computes exchange transfer coefficients:
- - C_D  momentum exchange coefficient      (Eq. 36)
- - C_H  thermodynamic exchange coefficient (Eq. 37)
- - L_mo Monin-Obukhov length               (re-arranged Eq. 3)
+ - `C_D`  momentum exchange coefficient      (Eq. 36)
+ - `C_H`  thermodynamic exchange coefficient (Eq. 37)
+ - `L_mo` Monin-Obukhov length               (re-arranged Eq. 3)
+
+TODO: `Pr_0` should come from CLIMAParameters
 """
-function compute_exchange_coefficients(Ri, z_b, z_0, γ_m, γ_h, β_m, β_h, Pr_0)
+function compute_exchange_coefficients(
+    param_set::AbstractParameterSet,
+    Ri::FT,
+    z_b::FT,
+    z_0::FT,
+    γ_m::FT,
+    γ_h::FT,
+    β_m::FT,
+    β_h::FT,
+    Pr_0::FT
+    ) where {FT}
     logz = log(z_b / z_0)
     zfactor = z_b / (z_b - z_0) * logz
     s_b = Ri / Pr_0
+    _von_karman_const::FT = von_karman_const(param_set)
     if Ri > 0
         temp = ((1 - 2 * β_h * Ri) - sqrt(1 + 4 * (β_h - β_m) * s_b))
-        ζ = zfactor / (2 * β_h * (β_m * Ri - 1)) * temp                    # Eq. 19 in Ref. Byun1990
-        L_mo = z_b / ζ                                             # LHS of Eq. 3 in Byun1990
+        ζ = zfactor / (2 * β_h * (β_m * Ri - 1)) * temp                    # Eq. 19
+        L_mo = z_b / ζ                                             # LHS of Eq. 3
         ζ_0 = z_0 / L_mo
         ψ_m = ψ_m_stable(ζ, ζ_0, β_m)
         ψ_h = ψ_h_stable(ζ, ζ_0, β_h)
     else
-        Q_b = 1 / 9 * (1 / (γ_m^2) + 3 * γ_h / γ_m * s_b^2)           # Eq. 31 in Ref. Byun1990
-        P_b = 1 / 54 * (-2 / (γ_m^3) + 9 / γ_m * (-γ_h / γ_m + 3) * s_b^2) # Eq. 32 in Ref. Byun1990
+        Q_b = FT(1 / 9) * (1 / (γ_m^2) + 3 * γ_h / γ_m * s_b^2)           # Eq. 31
+        P_b = FT(1 / 54) * (-2 / (γ_m^3) + 9 / γ_m * (-γ_h / γ_m + 3) * s_b^2) # Eq. 32
         crit = Q_b^3 - P_b^2
         if crit < 0
-            T_b = cbrt(sqrt(-crit) + abs(P_b))                     # Eq. 34 in Ref. Byun1990
-            ζ = zfactor * (1 / (3 * γ_m) - (T_b + Q_b / T_b))              # Eq. 29 in Ref. Byun1990
+            T_b = cbrt(sqrt(-crit) + abs(P_b))                     # Eq. 34
+            ζ = zfactor * (1 / (3 * γ_m) - (T_b + Q_b / T_b))              # Eq. 29
         else
-            θ_b = acos(P_b / sqrt(Q_b^3))                            # Eq. 33 in Ref. Byun1990
-            ζ = zfactor * (-2 * sqrt(Q_b) * cos(θ_b / 3) + 1 / (3 * γ_m))  # Eq. 28 in Ref. Byun1990
+            θ_b = acos(P_b / sqrt(Q_b^3))                            # Eq. 33
+            ζ = zfactor * (-2 * sqrt(Q_b) * cos(θ_b / 3) + 1 / (3 * γ_m))  # Eq. 28
         end
-        L_mo = z_b / ζ                                             # LHS of Eq. 3 in Byun1990
+        L_mo = z_b / ζ                                             # LHS of Eq. 3
         ζ_0 = z_0 / L_mo
         ψ_m = ψ_m_unstable(ζ, ζ_0, γ_m)
         ψ_h = ψ_h_unstable(ζ, ζ_0, γ_h)
     end
-    cu = k_Karman / (logz - ψ_m)                  # Eq. 10 in Ref. Byun1990, solved for u^*
-    cth = k_Karman / (logz - ψ_h) / Pr_0            # Eq. 11 in Ref. Byun1990, solved for h^*
-    C_D = cu^2                                                 # Eq. 36 in Byun1990
-    C_H = cu * cth                                               # Eq. 37 in Byun1990
+    cu = _von_karman_const / (logz - ψ_m)            # Eq. 10, solved for u^*
+    cth = _von_karman_const / (logz - ψ_h) / Pr_0    # Eq. 11, solved for h^*
+    C_D = cu^2                                       # Eq. 36
+    C_H = cu * cth                                   # Eq. 37
     return C_D, C_H, L_mo
 end
 
@@ -202,46 +227,51 @@ end # Byun1990 module
 module Nishizawa2018
 using RootSolvers
 using ...MoistThermodynamics
-using ...PlanetParameters
+using CLIMAParameters
+using CLIMAParameters.Planet: grav
+using CLIMAParameters.SubgridScale: von_karman_const
 
-""" Computes R_z0 expression, defined after Eq. 15 Ref. Nishizawa2018 """
+""" Computes `R_z0` expression, defined after Eq. 15 """
 compute_R_z0(z_0, Δz) = 1 - z_0 / Δz
 
-""" Computes f_m in Eq. A7 Ref. Nishizawa2018 """
+""" Computes `f_m` in Eq. A7 """
 compute_f_m(ζ) = sqrt(sqrt(1 - 15 * ζ))
 
-""" Computes f_h in Eq. A8 Ref. Nishizawa2018 """
+""" Computes `f_h` in Eq. A8 """
 compute_f_h(ζ) = sqrt(1 - 9 * ζ)
 
-""" Computes ψ_m in Eq. A3 Ref. Nishizawa2018 """
+""" Computes `ψ_m` in Eq. A3 """
 function compute_ψ_m(ζ, L, a)
+    FT = typeof(ζ)
     f_m = compute_f_m(ζ)
     return L >= 0 ? -a * ζ :
-           log((1 + f_m)^2 * (1 + f_m^2) / 8) - 2 * atan(f_m) + π / 2
+           log((1 + f_m)^2 * (1 + f_m^2) / 8) - 2 * atan(f_m) + FT(π / 2)
 end
 
-""" Computes ψ_h in Eq. A4 Ref. Nishizawa2018 """
+""" Computes `ψ_h` in Eq. A4 """
 compute_ψ_h(ζ, L, a, Pr) =
     L >= 0 ? -a * ζ / Pr : 2 * log((1 + compute_f_h(ζ)) / 2)
 
-""" Computes Ψ_m in Eq. A5 Ref. Nishizawa2018 """
+""" Computes `Ψ_m` in Eq. A5 """
 function compute_Ψ_m(ζ, L, a, tol)
+    FT = typeof(ζ)
     if ζ < tol
-        return ζ >= 0 ? -a * ζ / 2 : -15 * ζ / 8 # Computes Ψ_m in Eq. A13 Ref. Nishizawa2018
+        return ζ >= 0 ? -a * ζ / 2 : -FT(15) * ζ / FT(8) # Computes Ψ_m in Eq. A13
     else
         f_m = compute_f_m(ζ)
-        # Note that "1-f^3" in Ref. Nishizawa2018 is a typo, it is supposed to be "1-f_m^3".
+        # Note that "1-f^3" in is a typo, it is supposed to be "1-f_m^3".
         # This was confirmed by communication with the author.
         return L >= 0 ? -a * ζ / 2 :
-               log((1 + f_m)^2 * (1 + f_m^2) / 8) - 2 * atan(f_m) + π / 2 - 1 +
+               log((1 + f_m)^2 * (1 + f_m^2) / 8) - 2 * atan(f_m) + FT(π / 2) - 1 +
                (1 - f_m^3) / (12 * ζ)
     end
 end
 
-""" Computes Ψ_h in Eq. A6 Ref. Nishizawa2018 """
+""" Computes `Ψ_h` in Eq. A6 """
 function compute_Ψ_h(ζ, L, a, Pr, tol)
+    FT = typeof(ζ)
     if ζ < tol
-        return ζ >= 0 ? -a * ζ / (2 * Pr) : -9 * ζ / 4 # Computes Ψ_h in Eq. A14 Ref. Nishizawa2018
+        return ζ >= 0 ? -a * ζ / (2 * Pr) : -9 * ζ / 4 # Computes Ψ_h in Eq. A14
     else
         f_h = compute_f_h(ζ)
         return L >= 0 ? -a * ζ / (2 * Pr) :
@@ -250,37 +280,44 @@ function compute_Ψ_h(ζ, L, a, Pr, tol)
 end
 
 """
-    compute_MO_len(u, θ, flux)
+    monin_obukhov_len(param_set, u, θ, flux)
 
-Computes Monin-Obukhov length. Eq. 3 Ref. Nishizawa2018
+Computes Monin-Obukhov length. Eq. 3
 """
-compute_MO_len(u, θ, flux) = -u^3 * θ / (k_Karman * grav * flux)
+function monin_obukhov_len(param_set::AbstractParameterSet, u, θ, flux)
+    FT = typeof(u)
+    _von_karman_const::FT = von_karman_const(param_set)
+    _grav::FT = grav(param_set)
+    return -u^3 * θ / (_von_karman_const * _grav * flux)
+end
 
 """
-    compute_friction_velocity(u_ave, θ, flux, Δz, z_0, a, Ψ_m_tol, tol_abs, iter_max)
+    compute_friction_velocity(param_set, u_ave, θ, flux, Δz, z_0, a, Ψ_m_tol, tol_abs, iter_max)
 
-Computes friction velocity, in Eq. 12 in
-Ref. Nishizawa2018, by solving the
+Computes friction velocity, in Eq. 12 in, by solving the
 non-linear equation:
 
 `u_ave = ustar/κ * ( ln(Δz/z_0) - Ψ_m(Δz/L) + z_0/Δz * Ψ_m(z_0/L) + R_z0 [ψ_m(z_0/L) - 1] )`
 
-where `L` is a non-linear function of `ustar` (see `compute_MO_len`).
+where `L` is a non-linear function of `ustar` (see [`monin_obukhov_len`](@ref)).
 """
 function compute_friction_velocity(
-    u_ave,
-    θ,
-    flux,
-    Δz,
-    z_0,
-    a,
-    Ψ_m_tol,
-    tol_abs,
-    iter_max,
-)
-    ustar_0 = u_ave * k_Karman / log(Δz / z_0)
+    param_set::AbstractParameterSet,
+    u_ave::FT,
+    θ::FT,
+    flux::FT,
+    Δz::FT,
+    z_0::FT,
+    a::FT,
+    Ψ_m_tol::FT,
+    tol_abs::FT,
+    iter_max::IT,
+) where {FT,IT}
+    _von_karman_const::FT = von_karman_const(param_set)
+    ustar_0 = u_ave * _von_karman_const / log(Δz / z_0)
     ustar = ustar_0
     let u_ave = u_ave,
+        _von_karman_const=_von_karman_const,
         θ = θ,
         flux = flux,
         Δz = Δz,
@@ -293,13 +330,13 @@ function compute_friction_velocity(
         Ψ_m_closure(ζ, L) = compute_Ψ_m(ζ, L, a, Ψ_m_tol)
         ψ_m_closure(ζ, L) = compute_ψ_m(ζ, L, a)
         function compute_u_ave_over_ustar(u)
-            L = compute_MO_len(u, θ, flux)
+            L = monin_obukhov_len(param_set, u, θ, flux)
             R_z0 = compute_R_z0(z_0, Δz)
             temp1 = log(Δz / z_0)
             temp2 = -Ψ_m_closure(Δz / L, L)
             temp3 = z_0 / Δz * Ψ_m_closure(z_0 / L, L)
             temp4 = R_z0 * (ψ_m_closure(z_0 / L, L) - 1)
-            return (temp1 + temp2 + temp3 + temp4) / k_Karman
+            return (temp1 + temp2 + temp3 + temp4) / _von_karman_const
         end
         compute_ustar(u) = u_ave / compute_u_ave_over_ustar(u)
         ustar_1 = compute_ustar(ustar_0)
@@ -318,22 +355,35 @@ function compute_friction_velocity(
 end
 
 """
-    compute_exchange_coefficients(z, F_m, F_h, a, u_star, θ, flux, Pr)
+    compute_exchange_coefficients(param_set, z, F_m, F_h, a, u_star, θ, flux, Pr)
 
 Computes exchange transfer coefficients:
 
-  - K_D  momentum exchange coefficient
-  - K_H  thermodynamic exchange coefficient
-  - L_mo Monin-Obukhov length
-"""
-function compute_exchange_coefficients(z, F_m, F_h, a, u_star, θ, flux, Pr)
+  - `K_D`  momentum exchange coefficient
+  - `K_H`  thermodynamic exchange coefficient
+  - `L_mo` Monin-Obukhov length
 
-    L_mo = compute_MO_len(u_star, θ, flux)
+TODO: `Pr` should come from CLIMAParameters
+"""
+function compute_exchange_coefficients(
+    param_set::AbstractParameterSet,
+    z::FT,
+    F_m::FT,
+    F_h::FT,
+    a::FT,
+    u_star::FT,
+    θ::FT,
+    flux::FT,
+    Pr::FT
+    ) where {FT}
+
+    _von_karman_const::FT = von_karman_const(param_set)
+    L_mo = monin_obukhov_len(param_set, u_star, θ, flux)
     ψ_m = compute_ψ_m(z / L_mo, L_mo, a)
     ψ_h = compute_ψ_h(z / L_mo, L_mo, a, Pr)
 
-    K_m = -F_m * k_Karman * z / (u_star * ψ_m) # Eq. 19 in Ref. Nishizawa2018
-    K_h = -F_h * k_Karman * z / (Pr * θ * ψ_h) # Eq. 20 in Ref. Nishizawa2018
+    K_m = -F_m * _von_karman_const * z / (u_star * ψ_m) # Eq. 19
+    K_h = -F_h * _von_karman_const * z / (Pr * θ * ψ_h) # Eq. 20
 
     return K_m, K_h, L_mo
 end

--- a/test/Atmos/Parameterizations/SurfaceFluxes/runtests.jl
+++ b/test/Atmos/Parameterizations/SurfaceFluxes/runtests.jl
@@ -14,19 +14,13 @@ const param_set = EarthParameterSet()
 # but they need further testing for correctness.
 
 FT = Float32
-rtol = 10eps(FT)
+rtol = 10 * eps(FT)
 
 @testset "SurfaceFluxes" begin
     shf, lhf, T_b, q_pt, α_0 =
         FT(60), FT(50), FT(350), PhasePartition{FT}(0.01, 0.002, 0.0001), FT(1)
-    buoyancy_flux = SurfaceFluxes.compute_buoyancy_flux(
-        param_set,
-        shf,
-        lhf,
-        T_b,
-        q_pt,
-        α_0,
-    )
+    buoyancy_flux =
+        SurfaceFluxes.compute_buoyancy_flux(param_set, shf, lhf, T_b, q_pt, α_0)
     @test buoyancy_flux ≈ 0.0017808608107074118
     @test buoyancy_flux isa FT
 end
@@ -74,8 +68,8 @@ end
     @test ch isa FT
     @test L_mo isa FT
 
-    Ri, z_b, z_0, Pr_0 = FT(-10 ), FT(10.0), FT(1.0), FT(0.74)
-    γ_m, γ_h, β_m, β_h = FT(15.0), FT(9.0 ), FT(4.8), FT(7.8)
+    Ri, z_b, z_0, Pr_0 = FT(-10), FT(10.0), FT(1.0), FT(0.74)
+    γ_m, γ_h, β_m, β_h = FT(15.0), FT(9.0), FT(4.8), FT(7.8)
     cm, ch, L_mo = Byun1990.compute_exchange_coefficients(
         param_set,
         Ri,
@@ -87,9 +81,9 @@ end
         β_h,
         Pr_0,
     )
-    @test cm ≈ 0.33300280321092746 rtol=rtol
-    @test ch ≈ 1.131830939627489 rtol=rtol
-    @test L_mo ≈ -0.3726237964444814 rtol=rtol
+    @test cm ≈ 0.33300280321092746 rtol = rtol
+    @test ch ≈ 1.131830939627489 rtol = rtol
+    @test L_mo ≈ -0.3726237964444814 rtol = rtol
     @test cm isa FT
     @test ch isa FT
     @test L_mo isa FT
@@ -98,12 +92,13 @@ end
 
 @testset "SurfaceFluxes.Nishizawa2018" begin
     FT = Float32
-    rtol = 10eps(FT)
+    rtol = 10 * eps(FT)
     u, θ, flux = FT(2), FT(350), FT(20)
     MO_len = Nishizawa2018.monin_obukhov_len(param_set, u, θ, flux)
     @test MO_len ≈ -35.67787971457696
 
-    u_ave, θ, flux, Δz, z_0, a = FT(110.0), FT(350.0), FT(20.0), FT(100.0), FT(0.01), FT(5.0)
+    u_ave, θ, flux, Δz, z_0, a =
+        FT(110.0), FT(350.0), FT(20.0), FT(100.0), FT(0.01), FT(5.0)
     Ψ_m_tol, tol_abs, iter_max = FT(1e-3), FT(1e-3), 10
     u_star = Nishizawa2018.compute_friction_velocity(
         param_set,
@@ -121,8 +116,9 @@ end
     @test u_star isa FT
 
     FT = Float64
-    rtol = 10eps(FT)
-    z, F_m, F_h, a, u_star, θ, flux, Pr = FT(1), FT(2), FT(3), FT(5), FT(110), FT(350), FT(20), FT(0.74)
+    rtol = 10 * eps(FT)
+    z, F_m, F_h, a, u_star, θ, flux, Pr =
+        FT(1), FT(2), FT(3), FT(5), FT(110), FT(350), FT(20), FT(0.74)
 
     K_m, K_h, L_mo = Nishizawa2018.compute_exchange_coefficients(
         param_set,
@@ -135,14 +131,15 @@ end
         flux,
         Pr,
     )
-    @test K_m ≈ -11512.071612359368 rtol=rtol
-    @test K_h ≈ -6111.6196776263805 rtol=rtol
-    @test L_mo ≈ -5.935907237512742e6 rtol=rtol
+    @test K_m ≈ -11512.071612359368 rtol = rtol
+    @test K_h ≈ -6111.6196776263805 rtol = rtol
+    @test L_mo ≈ -5.935907237512742e6 rtol = rtol
 
     # Test type-stability:
     FT = Float32
-    rtol = 10eps(FT)
-    z, F_m, F_h, a, u_star, θ, flux, Pr = FT(1), FT(2), FT(3), FT(5), FT(110), FT(350), FT(20), FT(0.74)
+    rtol = 10 * eps(FT)
+    z, F_m, F_h, a, u_star, θ, flux, Pr =
+        FT(1), FT(2), FT(3), FT(5), FT(110), FT(350), FT(20), FT(0.74)
 
     K_m, K_h, L_mo = Nishizawa2018.compute_exchange_coefficients(
         param_set,

--- a/test/Atmos/Parameterizations/SurfaceFluxes/runtests.jl
+++ b/test/Atmos/Parameterizations/SurfaceFluxes/runtests.jl
@@ -5,36 +5,42 @@ using CLIMA.SurfaceFluxes.Nishizawa2018
 using CLIMA.SurfaceFluxes.Byun1990
 using CLIMA.MoistThermodynamics
 using RootSolvers
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
 
 # FIXME: Use realistic values / test for correctness
 # These tests have been run to ensure they do not fail,
 # but they need further testing for correctness.
 
-@testset "SurfaceFluxes" begin
+FT = Float32
+rtol = 10eps(FT)
 
-    shf, lhf, T_b, qt_b, ql_b, qi_b, alpha0_0 =
-        60.0, 50.0, 350.0, 0.01, 0.002, 0.0001, 1.0
+@testset "SurfaceFluxes" begin
+    shf, lhf, T_b, q_pt, α_0 =
+        FT(60), FT(50), FT(350), PhasePartition{FT}(0.01, 0.002, 0.0001), FT(1)
     buoyancy_flux = SurfaceFluxes.compute_buoyancy_flux(
+        param_set,
         shf,
         lhf,
         T_b,
-        qt_b,
-        ql_b,
-        qi_b,
-        alpha0_0,
+        q_pt,
+        α_0,
     )
     @test buoyancy_flux ≈ 0.0017808608107074118
+    @test buoyancy_flux isa FT
 end
 
 @testset "SurfaceFluxes.Byun1990" begin
-    u, flux = 0.1, 0.2
-    MO_len = Byun1990.compute_MO_len(u, flux)
+    u, flux = FT(0.1), FT(0.2)
+    MO_len = Byun1990.monin_obukhov_len(param_set, u, flux)
     @test MO_len ≈ -0.0125
 
-    u_ave, buoyancy_flux, z_0, z_1 = 0.1, 0.2, 2.0, 5.0
-    γ_m, β_m = 15.0, 4.8
-    tol_abs, iter_max = 1e-3, 10
+    u_ave, buoyancy_flux, z_0, z_1 = FT(0.1), FT(0.2), FT(2), FT(5)
+    γ_m, β_m = FT(15), FT(4.8)
+    tol_abs, iter_max = FT(1e-3), 10
     u_star = Byun1990.compute_friction_velocity(
+        param_set,
         u_ave,
         buoyancy_flux,
         z_0,
@@ -45,11 +51,13 @@ end
         iter_max,
     )
     @test u_star ≈ 0.201347256193615 atol = tol_abs
+    @test u_star isa FT
 
 
-    Ri, z_b, z_0, Pr_0 = 10, 2.0, 5.0, 0.74
-    γ_m, γ_h, β_m, β_h = 15.0, 9.0, 4.8, 7.8
+    Ri, z_b, z_0, Pr_0 = FT(10), FT(2), FT(5.0), FT(0.74)
+    γ_m, γ_h, β_m, β_h = FT(15), FT(9), FT(4.8), FT(7.8)
     cm, ch, L_mo = Byun1990.compute_exchange_coefficients(
+        param_set,
         Ri,
         z_b,
         z_0,
@@ -62,10 +70,14 @@ end
     @test cm ≈ 19.700348427787368
     @test ch ≈ 3.3362564728997803
     @test L_mo ≈ -14.308268023583906
+    @test cm isa FT
+    @test ch isa FT
+    @test L_mo isa FT
 
-    Ri, z_b, z_0, Pr_0 = -10, 10.0, 1.0, 0.74
-    γ_m, γ_h, β_m, β_h = 15.0, 9.0, 4.8, 7.8
+    Ri, z_b, z_0, Pr_0 = FT(-10 ), FT(10.0), FT(1.0), FT(0.74)
+    γ_m, γ_h, β_m, β_h = FT(15.0), FT(9.0 ), FT(4.8), FT(7.8)
     cm, ch, L_mo = Byun1990.compute_exchange_coefficients(
+        param_set,
         Ri,
         z_b,
         z_0,
@@ -75,20 +87,26 @@ end
         β_h,
         Pr_0,
     )
-    @test cm ≈ 0.33300280321092746
-    @test ch ≈ 1.131830939627489
-    @test L_mo ≈ -0.3726237964444814
+    @test cm ≈ 0.33300280321092746 rtol=rtol
+    @test ch ≈ 1.131830939627489 rtol=rtol
+    @test L_mo ≈ -0.3726237964444814 rtol=rtol
+    @test cm isa FT
+    @test ch isa FT
+    @test L_mo isa FT
 
 end
 
 @testset "SurfaceFluxes.Nishizawa2018" begin
-    u, θ, flux = 2, 350, 20
-    MO_len = Nishizawa2018.compute_MO_len(u, θ, flux)
+    FT = Float32
+    rtol = 10eps(FT)
+    u, θ, flux = FT(2), FT(350), FT(20)
+    MO_len = Nishizawa2018.monin_obukhov_len(param_set, u, θ, flux)
     @test MO_len ≈ -35.67787971457696
 
-    u_ave, θ, flux, Δz, z_0, a = 110, 350, 20, 100, 0.01, 5
-    Ψ_m_tol, tol_abs, iter_max = 1e-3, 1e-3, 10
+    u_ave, θ, flux, Δz, z_0, a = FT(110.0), FT(350.0), FT(20.0), FT(100.0), FT(0.01), FT(5.0)
+    Ψ_m_tol, tol_abs, iter_max = FT(1e-3), FT(1e-3), 10
     u_star = Nishizawa2018.compute_friction_velocity(
+        param_set,
         u_ave,
         θ,
         flux,
@@ -100,10 +118,14 @@ end
         iter_max,
     )
     @test u_star ≈ 5.526644550864822 atol = tol_abs
+    @test u_star isa FT
 
-    z, F_m, F_h, a, u_star, θ, flux, Pr = 1.0, 2.0, 3.0, 5, 110, 350, 20, 0.74
+    FT = Float64
+    rtol = 10eps(FT)
+    z, F_m, F_h, a, u_star, θ, flux, Pr = FT(1), FT(2), FT(3), FT(5), FT(110), FT(350), FT(20), FT(0.74)
 
     K_m, K_h, L_mo = Nishizawa2018.compute_exchange_coefficients(
+        param_set,
         z,
         F_m,
         F_h,
@@ -113,8 +135,28 @@ end
         flux,
         Pr,
     )
-    @test K_m ≈ -11512.071612359368
-    @test K_h ≈ -6111.6196776263805
-    @test L_mo ≈ -5.935907237512742e6
+    @test K_m ≈ -11512.071612359368 rtol=rtol
+    @test K_h ≈ -6111.6196776263805 rtol=rtol
+    @test L_mo ≈ -5.935907237512742e6 rtol=rtol
+
+    # Test type-stability:
+    FT = Float32
+    rtol = 10eps(FT)
+    z, F_m, F_h, a, u_star, θ, flux, Pr = FT(1), FT(2), FT(3), FT(5), FT(110), FT(350), FT(20), FT(0.74)
+
+    K_m, K_h, L_mo = Nishizawa2018.compute_exchange_coefficients(
+        param_set,
+        z,
+        F_m,
+        F_h,
+        a,
+        u_star,
+        θ,
+        flux,
+        Pr,
+    )
+    @test K_m isa FT
+    @test K_h isa FT
+    @test L_mo isa FT
 
 end


### PR DESCRIPTION
# Description

 - Removes `PlanetParameters` from `SurfaceFluxes`
 - Cleans up some docs/naming conventions
 - Adds type stability tests (and fixes some type instabilities)
 - Applies formatter

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
