### PR TITLE
Fix type instability in isentropic vortex test

### DIFF
--- a/test/DGmethods/Euler/isentropicvortex.jl
+++ b/test/DGmethods/Euler/isentropicvortex.jl
@@ -75,25 +75,25 @@ function main()
     expected_error[Float64, 3, Central, 3] = 1.1680141169828175e-01
     expected_error[Float64, 3, Central, 4] = 2.6414127301659534e-03
 
-    expected_error[Float32, 2, Rusanov, 1] = 1.1990854263305664e+01
-    expected_error[Float32, 2, Rusanov, 2] = 2.0812149047851563e+00
-    expected_error[Float32, 2, Rusanov, 3] = 6.6969044506549835e-02
-    expected_error[Float32, 2, Rusanov, 4] = 5.2888177335262299e-02
+    expected_error[Float32, 2, Rusanov, 1] = 1.1990781784057617e+01
+    expected_error[Float32, 2, Rusanov, 2] = 2.0813269615173340e+00
+    expected_error[Float32, 2, Rusanov, 3] = 6.7035309970378876e-02
+    expected_error[Float32, 2, Rusanov, 4] = 5.3008597344160080e-02
 
-    expected_error[Float32, 2, Central, 1] = 2.0840496063232422e+01
-    expected_error[Float32, 2, Central, 2] = 2.9250388145446777e+00
-    expected_error[Float32, 2, Central, 3] = 3.7026408314704895e-01
-    expected_error[Float32, 2, Central, 4] = 1.1543836444616318e-01
+    expected_error[Float32, 2, Central, 1] = 2.0840391159057617e+01
+    expected_error[Float32, 2, Central, 2] = 2.9256355762481689e+00
+    expected_error[Float32, 2, Central, 3] = 3.7092915177345276e-01
+    expected_error[Float32, 2, Central, 4] = 1.1543693393468857e-01
 
-    expected_error[Float32, 3, Rusanov, 1] = 3.7918324470520020e+00
-    expected_error[Float32, 3, Rusanov, 2] = 6.5811443328857422e-01
-    expected_error[Float32, 3, Rusanov, 3] = 2.0889002829790115e-02
-    expected_error[Float32, 3, Rusanov, 4] = 1.1552370153367519e-02
+    expected_error[Float32, 3, Rusanov, 1] = 3.7918186187744141e+00
+    expected_error[Float32, 3, Rusanov, 2] = 6.5816193819046021e-01
+    expected_error[Float32, 3, Rusanov, 3] = 2.0893247798085213e-02
+    expected_error[Float32, 3, Rusanov, 4] = 1.1554701253771782e-02
 
-    expected_error[Float32, 3, Central, 1] = 6.5902600288391113e+00
-    expected_error[Float32, 3, Central, 2] = 9.2505264282226563e-01
-    expected_error[Float32, 3, Central, 3] = 1.1701638251543045e-01
-    expected_error[Float32, 3, Central, 4] = 2.1023442968726158e-02
+    expected_error[Float32, 3, Central, 1] = 6.5903329849243164e+00
+    expected_error[Float32, 3, Central, 2] = 9.2512512207031250e-01
+    expected_error[Float32, 3, Central, 3] = 1.1707859486341476e-01
+    expected_error[Float32, 3, Central, 4] = 2.1001411601901054e-02
 
     @testset "$(@__FILE__)" begin
         for FT in (Float64, Float32), dims in (2, 3)
@@ -188,7 +188,7 @@ function run(
         param_set;
         orientation = NoOrientation(),
         ref_state = NoReferenceState(),
-        turbulence = ConstantViscosityWithDivergence(0.0),
+        turbulence = ConstantViscosityWithDivergence(FT(0)),
         moisture = DryModel(),
         source = nothing,
         boundarycondition = (),


### PR DESCRIPTION
Fixes type instability in the isentropic vortex test

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
