### PR TITLE
Disable CUDA-aware MPI detection temporarily

### DIFF
--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -82,9 +82,12 @@ mutable struct MPIStateArray{
     ) where {FT, V}
         data = similar(DA, FT, Np, nstate, numelem)
 
+        #= TODO: might be the cause of #969
         if isnothing(mpi_knows_cuda)
             mpi_knows_cuda = MPI.has_cuda()
         end
+        =#
+        mpi_knows_cuda = false
 
         if data isa Array || mpi_knows_cuda
             kind = SingleCMBuffer


### PR DESCRIPTION
# Description

To try and fix #969. Until OpenMPI 4.0.3 is available.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
