### PR TITLE
More LES diagnostics

### DIFF
--- a/docs/src/ExtendingCLIMA/Diagnostics/DiagnosticVariables.md
+++ b/docs/src/ExtendingCLIMA/Diagnostics/DiagnosticVariables.md
@@ -8,41 +8,41 @@ This document contains the diagnostic variables in CliMA.
 
 | code name            | short name | description                                                                |
 |:---------------------|:-----------|:---------------------------------------------------------------------------|
-| ρ                    | rho        | density                                                                    |
 | u                    | u          | x-velocity                                                                 |
 | v                    | v          | y-velocity                                                                 |
 | w                    | w          | z-velocity                                                                 |
+| ρ                    | avg_rho    | density                                                                    |
+| ρ                    | rho        | (density-averaged) density                                                 |
 | q\_tot                | qt         | total specific humidity                                                    |
-| q\_vap                | qv         | total specific energy                                                      |
-| q\_vap                | qv         | water vapor specific humidity                                              |
 | q\_liq                | ql         | liquid water specific humidity                                             |
-| e\_int                | ei         | specific internal energy                                                   |
+| q\_vap                | qv         | water vapor specific humidity                                              |
 | θ\_dry                | thd        | potential temperature                                                      |
-| θ\_liq\_ice            | thl        | liquid-ice potential temperature                                           |
 | θ\_vir                | thv        | virtual potential temperature                                              |
-| h\_moi                | hm         | specific enthalpy                                                          |
+| θ\_liq\_ice            | thl        | liquid-ice potential temperature                                           |
+| e\_tot                | et         | total specific energy                                                      |
+| e\_int                | ei         | specific internal energy                                                   |
 | h\_tot                | ht         | total specific enthalpy                                                    |
+| h\_moi                | hm         | specific enthalpy                                                          |
 | u′u′                 | var\_u      | variance of x-velocity                                                     |
 | v′v′                 | var\_v      | variance of y-velocity                                                     |
-| w'w'                 | var\_w      | variance of z-velocity                                                     |
-| tke                  | tke        | turbulence kinetic energy                                                  |
-| q\_tot'q\_tot'         | var\_qt     | variance of total specific humidity                                        |
-| e\_int'e\_int'         | var\_ei     | variance of specific internal energy                                       |
-| θ\_liq\_ice'θ\_liq\_ice' | var\_thl    | variance of liquid-ice potential temperature                               |
+| w′w′                 | var\_w      | variance of z-velocity                                                     |
 | w′w′w′               | w3         | the third moment of z-velocity                                             |
-| q\_tot'θ\_liq\_ice'     | cov\_qt\_thl | covariance of total specific humidity and liquid-ice potential temperature |
-| q\_tot'e\_int'         | cov\_qt\_ei  | covariance of total specific humidity and specific internal energy         |
-| w′ρ′                 | cov\_w\_rho  | vertical eddy flux of mass                                                 |
+| tke                  | tke        | turbulence kinetic energy                                                  |
+| q\_tot′q\_tot′         | var\_qt     | variance of total specific humidity                                        |
+| θ\_liq\_ice′θ\_liq\_ice′ | var\_thl    | variance of liquid-ice potential temperature                               |
+| e\_int′e\_int′         | var\_ei     | variance of specific internal energy                                       |
 | w′u′                 | cov\_w\_u    | vertical eddy flux of x-velocity                                           |
 | w′v′                 | cov\_w\_v    | vertical eddy flux of y-velocity                                           |
-| wq\_tot               | w\_qt       | vertical flux of total specific humidity                                   |
-| w'q\_tot'             | cov\_w\_qt   | vertical eddy flux of total specific humidity                              |
-| w′q\_vap′             | cov\_w\_qv   | vertical eddy flux of water vapor specific humidity                        |
+| w′ρ′                 | cov\_w\_rho  | vertical eddy flux of mass                                                 |
+| w′q\_tot′             | cov\_w\_qt   | vertical eddy flux of total specific humidity                              |
 | w′q\_liq′             | cov\_w\_ql   | vertical eddy flux of liuqid water specific humidity                       |
+| w′q\_vap′             | cov\_w\_qv   | vertical eddy flux of water vapor specific humidity                        |
 | w′θ\_dry′             | cov\_w\_thd  | vertical eddy flux of potential temperature                                |
 | w′θ\_vir′             | cov\_w\_thv  | vertical eddy flux of virtual temperature                                  |
 | w′θ\_liq\_ice′         | cov\_w\_thl  | vertical eddy flux of liquid-ice potential temperature                     |
 | w′e\_int′             | cov\_w\_ei   | vertical eddy flux of specific internal energy                             |
+| q\_tot′θ\_liq\_ice′     | cov\_qt\_thl | covariance of total specific humidity and liquid-ice potential temperature |
+| q\_tot′e\_int′         | cov\_qt\_ei  | covariance of total specific humidity and specific internal energy         |
 | d\_q\_tot              | w\_qt\_sgs   | vertical sgs flux of total specific humidity                               |
 | d\_h\_tot              | w\_ht\_sgs   | vertical sgs flux of total specific enthalpy                               |
 | cld\_frac             | cld\_frac   | cloud fraction                                                             |
@@ -64,14 +64,14 @@ This document contains the diagnostic variables in CliMA.
 | θ\_liq\_ice                 | thl\_core        | cloud core liquid-ice potential temperature                                           |
 | u′u′\_core                 | var\_u\_core      | cloud core variance of x-velocity                                                     |
 | v′v′\_core                 | var\_v\_core      | cloud core variance of y-velocity                                                     |
-| w'w'\_core                 | var\_w\_core      | cloud core variance of z-velocity                                                     |
-| q\_tot'q\_tot'\_core         | var\_qt\_core     | cloud core variance of total specific humidity                                        |
-| e\_int'e\_int'\_core         | var\_ei\_core     | cloud core variance of specific internal energy                                       |
-| θ\_liq\_ice'θ\_liq\_ice'\_core | var\_thl\_core    | cloud core variance of liquid-ice potential temperature                               |
-| q\_tot'θ\_liq\_ice'\_core     | cov\_qt\_thl\_core | cloud core covariance of total specific humidity and liquid-ice potential temperature |
-| q\_tot'e\_int'\_core         | cov\_qt\_ei\_core  | cloud core covariance of total specific humidity and specific internal energy         |
+| w′w′\_core                 | var\_w\_core      | cloud core variance of z-velocity                                                     |
+| q\_tot′q\_tot′\_core         | var\_qt\_core     | cloud core variance of total specific humidity                                        |
+| e\_int′e\_int′\_core         | var\_ei\_core     | cloud core variance of specific internal energy                                       |
+| θ\_liq\_ice′θ\_liq\_ice′\_core | var\_thl\_core    | cloud core variance of liquid-ice potential temperature                               |
+| q\_tot′θ\_liq\_ice′\_core     | cov\_qt\_thl\_core | cloud core covariance of total specific humidity and liquid-ice potential temperature |
+| q\_tot′e\_int′\_core         | cov\_qt\_ei\_core  | cloud core covariance of total specific humidity and specific internal energy         |
 | w′ρ′\_core                 | cov\_w\_rho\_core  | cloud core vertical eddy flux of mass                                                 |
-| w'q\_tot'\_core             | cov\_w\_qt\_core   | cloud core vertical eddy flux of total specific humidity                              |
+| w′q\_tot′\_core             | cov\_w\_qt\_core   | cloud core vertical eddy flux of total specific humidity                              |
 | w′θ\_liq\_ice′\_core         | cov\_w\_thl\_core  | cloud core vertical eddy flux of liquid-ice potential temperature                     |
 | w′e\_int′\_core             | cov\_w\_ei\_core   | cloud core vertical eddy flux of specific internal energy                             |
 | core\_frac                 | core\_frac       | cloud core (q\_liq > 0 and w > 0) fraction                                             |

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -8,6 +8,7 @@ module Diagnostics
 
 export DiagnosticsGroup,
     setup_atmos_default_diagnostics,
+    setup_atmos_core_diagnostics,
     setup_dump_state_and_aux_diagnostics,
     VecGrad,
     compute_vec_grad,
@@ -127,12 +128,9 @@ end
     )
 
 Create and return a `DiagnosticsGroup` containing the "AtmosDefault"
-diagnostics, currently a set of diagnostics developed for DYCOMS. All
-the diagnostics in the group will run at the specified `interval`, be
-interpolated to the specified boundaries and resolution, and
-will be written to files prefixed by `out_prefix` using `writer`.
-
-TODO: this will be refactored soon.
+diagnostics. All the diagnostics in the group will run at the specified
+`interval`, be interpolated to the specified boundaries and resolution,
+and will be written to files prefixed by `out_prefix` using `writer`.
 """
 function setup_atmos_default_diagnostics(
     interval::String,
@@ -155,6 +153,40 @@ function setup_atmos_default_diagnostics(
 end
 
 """
+    setup_atmos_core_diagnostics(
+            interval::Int,
+            out_prefix::String;
+            writer::AbstractWriter,
+            interpol = nothing,
+            project  = true)
+
+Create and return a `DiagnosticsGroup` containing the "AtmosCore"
+diagnostics. All the diagnostics in the group will run at the
+specified `interval`, be interpolated to the specified boundaries
+and resolution, and will be written to files prefixed by `out_prefix`
+using `writer`.
+"""
+function setup_atmos_core_diagnostics(
+    interval::Int,
+    out_prefix::String;
+    writer = NetCDFWriter(),
+    interpol = nothing,
+    project = true,
+)
+    return DiagnosticsGroup(
+        "AtmosCore",
+        Diagnostics.atmos_core_init,
+        Diagnostics.atmos_core_fini,
+        Diagnostics.atmos_core_collect,
+        interval,
+        out_prefix,
+        writer,
+        interpol,
+        project,
+    )
+end
+
+"""
     setup_dump_state_and_aux_diagnostics(
         interval::String,
         out_prefix::String;
@@ -166,8 +198,6 @@ end
 Create and return a `DiagnosticsGroup` containing a diagnostic that
 simply dumps the state and aux variables at the specified `interval`
 after being interpolated, into NetCDF files prefixed by `out_prefix`.
-
-TODO: this will be refactored soon.
 """
 function setup_dump_state_and_aux_diagnostics(
     interval::String,
@@ -246,6 +276,8 @@ function extract_diffusion(dg, localdiff, ijk, e)
 end
 
 include("atmos_default.jl")
+include("atmos_core.jl")
 include("dump_state_and_aux.jl")
 include("diagnostic_fields.jl")
+
 end # module Diagnostics

--- a/src/Diagnostics/atmos_core.jl
+++ b/src/Diagnostics/atmos_core.jl
@@ -1,0 +1,93 @@
+using ..Atmos
+using ..Atmos: thermo_state, turbulence_tensors
+using ..Mesh.Topologies
+using ..Mesh.Grids
+using ..MoistThermodynamics
+using LinearAlgebra
+
+function atmos_core_init(dgngrp::DiagnosticsGroup, currtime)
+    mpicomm = Settings.mpicomm
+    dg = Settings.dg
+    Q = Settings.Q
+    FT = eltype(Q)
+    grid = dg.grid
+    topology = grid.topology
+    N = polynomialorder(grid)
+    Nq = N + 1
+    Nqk = dimensionality(grid) == 2 ? 1 : Nq
+    nrealelem = length(topology.realelems)
+    nvertelem = topology.stacksize
+    nhorzelem = div(nrealelem, nvertelem)
+
+    if Array ∈ typeof(Q).parameters
+        localvgeo = grid.vgeo
+    else
+        localvgeo = Array(grid.vgeo)
+    end
+
+    @warn """
+        Diagnostics ($dgngrp.name): not yet implemented
+        """
+
+    return nothing
+end
+
+"""
+    atmos_core_collect(bl, currtime)
+
+Perform a global grid traversal to compute various diagnostics.
+"""
+function atmos_core_collect(dgngrp::DiagnosticsGroup, currtime)
+    mpicomm = Settings.mpicomm
+    dg = Settings.dg
+    Q = Settings.Q
+    mpirank = MPI.Comm_rank(mpicomm)
+    current_time = string(currtime)
+
+    # extract grid information
+    bl = dg.balancelaw
+    grid = dg.grid
+    topology = grid.topology
+    N = polynomialorder(grid)
+    Nq = N + 1
+    Nqk = dimensionality(grid) == 2 ? 1 : Nq
+    npoints = Nq * Nq * Nqk
+    nrealelem = length(topology.realelems)
+    nvertelem = topology.stacksize
+    nhorzelem = div(nrealelem, nvertelem)
+
+    # get the state, auxiliary and geo variables onto the host if needed
+    if Array ∈ typeof(Q).parameters
+        localQ = Q.realdata
+        localaux = dg.auxstate.realdata
+        localvgeo = grid.vgeo
+        localdiff = dg.diffstate.realdata
+    else
+        localQ = Array(Q.realdata)
+        localaux = Array(dg.auxstate.realdata)
+        localvgeo = Array(grid.vgeo)
+        localdiff = Array(dg.diffstate.realdata)
+    end
+    FT = eltype(localQ)
+
+    nstate = num_state(bl, FT)
+    nauxstate = num_aux(bl, FT)
+    ndiff = num_diffusive(bl, FT)
+
+    # TODO
+
+    if mpirank == 0
+        dprefix = @sprintf(
+            "%s_%s-%s-num%04d",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+            dgngrp.num
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
+    end
+
+    return nothing
+end # function collect
+
+function atmos_core_fini(dgngrp::DiagnosticsGroup, currtime) end

--- a/src/Diagnostics/atmos_default.jl
+++ b/src/Diagnostics/atmos_default.jl
@@ -1,19 +1,21 @@
 using ..Atmos
-using ..Atmos: thermo_state, turbulence_tensors
+using ..Atmos: MoistureModel, thermo_state, turbulence_tensors
 using ..Mesh.Topologies
 using ..Mesh.Grids
 using ..MoistThermodynamics
-using CLIMAParameters.Atmos.SubgridScale: inv_Pr_turb
 using LinearAlgebra
 
-Base.@kwdef mutable struct AtmosCollectedDiagnostics
+Base.@kwdef mutable struct AtmosDefaultCollectedDiagnostics
     zvals::Union{Nothing, Array} = nothing
     repdvsr::Union{Nothing, Array} = nothing
 end
-const CollectedDiagnostics = AtmosCollectedDiagnostics()
+const AtmosDefaultCollected = AtmosDefaultCollectedDiagnostics()
 
-include("diagnostic_vars.jl")
+"""
+    atmos_default_init(bl, currtime)
 
+Initialize the 'AtmosDefault' diagnostics group.
+"""
 function atmos_default_init(dgngrp::DiagnosticsGroup, currtime)
     mpicomm = Settings.mpicomm
     dg = Settings.dg
@@ -34,268 +36,258 @@ function atmos_default_init(dgngrp::DiagnosticsGroup, currtime)
         localvgeo = Array(grid.vgeo)
     end
 
-    CollectedDiagnostics.zvals = zeros(FT, Nqk * nvertelem)
-    CollectedDiagnostics.repdvsr = zeros(FT, Nqk * nvertelem)
+    AtmosDefaultCollected.zvals = zeros(FT, Nqk * nvertelem)
+    AtmosDefaultCollected.repdvsr = zeros(FT, Nqk * nvertelem)
 
     @visitQ nhorzelem nvertelem Nqk Nq begin
         z = localvgeo[ijk, grid.x3id, e]
         MH = localvgeo[ijk, grid.MHid, e]
-        CollectedDiagnostics.zvals[Nqk * (ev - 1) + k] += MH * z
-        CollectedDiagnostics.repdvsr[Nqk * (ev - 1) + k] += MH
+        AtmosDefaultCollected.zvals[Nqk * (ev - 1) + k] += MH * z
+        AtmosDefaultCollected.repdvsr[Nqk * (ev - 1) + k] += MH
     end
 
     # compute the full number of points on a slab
-    MPI.Allreduce!(CollectedDiagnostics.repdvsr, +, mpicomm)
+    MPI.Allreduce!(AtmosDefaultCollected.repdvsr, +, mpicomm)
 
-    CollectedDiagnostics.zvals ./= CollectedDiagnostics.repdvsr
+    AtmosDefaultCollected.zvals ./= AtmosDefaultCollected.repdvsr
 end
 
-# thermodynamic variables of interest
-function vars_thermo(FT)
+include("thermo.jl")
+
+# Simple horizontal averages
+function vars_atmos_default_simple(m::AtmosModel, FT)
     @vars begin
-        q_liq::FT
-        q_ice::FT
-        q_vap::FT
-        T::FT
-        θ_liq_ice::FT
-        θ_dry::FT
-        θ_v::FT
-        e_int::FT
-        h_m::FT
-        h_t::FT
+        u::FT
+        v::FT
+        w::FT
+        avg_rho::FT             # ρ
+        rho::FT                 # ρρ
+        temp::FT
+        thd::FT                 # θ_dry
+        thv::FT                 # θ_vir
+        et::FT                  # e_tot
+        ei::FT                  # e_int
+        ht::FT
+        hm::FT
+        w_ht_sgs::FT
+
+        moisture::vars_atmos_default_simple(m.moisture, FT)
     end
 end
-num_thermo(FT) = varsize(vars_thermo(FT))
-thermo_vars(array) = Vars{vars_thermo(eltype(array))}(array)
-
-function compute_thermo!(bl, state, aux, ijk, e, thermoQ)
-    e_tot = state.ρe / state.ρ
-    ts = thermo_state(bl, state, aux)
-    e_int = internal_energy(ts)
-    Phpart = PhasePartition(ts)
-
-    th = thermo_vars(thermoQ[ijk, e])
-    th.q_liq = Phpart.liq
-    th.q_ice = Phpart.ice
-    th.q_vap = vapor_specific_humidity(ts)
-    th.T = air_temperature(ts)
-    th.θ_liq_ice = liquid_ice_pottemp(ts)
-    th.θ_dry = dry_pottemp(ts)
-    th.θ_v = virtual_pottemp(ts)
-    th.e_int = e_int
-
-    # Moist and total henthalpy
-    R_m = gas_constant_air(ts)
-    th.h_m = e_int + R_m * th.T
-    th.h_t = e_tot + R_m * th.T
-
-    return nothing
-end
-
-# horizontal averages
-function vars_horzavg(FT)
+vars_atmos_default_simple(::MoistureModel, FT) = @vars()
+function vars_atmos_default_simple(m::EquilMoist, FT)
     @vars begin
-        ρ::FT
-        ρu::FT
-        ρv::FT
-        ρw::FT
-        e_tot::FT
-        ρq_tot::FT
-        q_liq::FT
-        q_vap::FT
-        θ_liq_ice::FT
-        θ_dry::FT
-        θ_v::FT
-        e_int::FT
-        h_m::FT
-        h_t::FT
-        qt_sgs::FT
-        ht_sgs::FT
+        qt::FT                  # q_tot
+        ql::FT                  # q_liq
+        qv::FT                  # q_vap
+        thl::FT                 # θ_liq
+        w_qt_sgs::FT
     end
 end
-num_horzavg(FT) = varsize(vars_horzavg(FT))
-horzavg_vars(array) = Vars{vars_horzavg(eltype(array))}(array)
+num_atmos_default_simple_vars(m, FT) = varsize(vars_atmos_default_simple(m, FT))
+atmos_default_simple_vars(m, array) =
+    Vars{vars_atmos_default_simple(m, eltype(array))}(array)
 
-function compute_horzsums!(
+function compute_simple_sums!(
     atmos::AtmosModel,
     state,
     diffusive_flux,
     aux,
-    k,
-    ijk,
-    ev,
-    e,
-    Nqk,
-    nvertelem,
-    MH,
-    localaux,
-    thermoQ,
-    horzsums,
-    LWP,
+    thermo,
     currtime,
+    MH,
+    sums,
 )
-    th = thermo_vars(thermoQ[ijk, e])
-    hs = horzavg_vars(horzsums[Nqk * (ev - 1) + k])
-    hs.ρ += MH * state.ρ
-    hs.ρu += MH * state.ρu[1]
-    hs.ρv += MH * state.ρu[2]
-    hs.ρw += MH * state.ρu[3]
-    hs.e_tot += MH * state.ρe
-    hs.q_liq += MH * th.q_liq
-    hs.q_vap += MH * th.q_vap
-    hs.θ_liq_ice += MH * th.θ_liq_ice
-    hs.θ_dry += MH * th.θ_dry
-    hs.θ_v += MH * th.θ_v
-    hs.e_int += MH * th.e_int
-    hs.h_m += MH * th.h_m
-    hs.h_t += MH * th.h_t
-
-    # TODO: temporary fix
-    if isa(atmos.moisture, EquilMoist)
-        hs.ρq_tot += MH * state.moisture.ρq_tot
-    end
+    sums.u += MH * state.ρu[1]
+    sums.v += MH * state.ρu[2]
+    sums.w += MH * state.ρu[3]
+    sums.avg_rho += MH * state.ρ
+    sums.rho += MH * state.ρ * state.ρ
+    sums.temp += MH * thermo.T * state.ρ
+    sums.thd += MH * thermo.θ_dry * state.ρ
+    sums.thv += MH * thermo.θ_vir * state.ρ
+    sums.et += MH * state.ρe
+    sums.ei += MH * thermo.e_int * state.ρ
+    sums.ht += MH * thermo.h_tot * state.ρ
+    sums.hm += MH * thermo.h_moi * state.ρ
 
     ν, D_t, _ = turbulence_tensors(atmos, state, diffusive_flux, aux, currtime)
-
-    # TODO: temporary fix
-    if isa(atmos.moisture, EquilMoist)
-        d_q_tot = (-D_t) .* diffusive_flux.moisture.∇q_tot
-        hs.qt_sgs += MH * state.ρ * d_q_tot[end]
-    end
-
     d_h_tot = -D_t .* diffusive_flux.∇h_tot
-    hs.ht_sgs += MH * state.ρ * d_h_tot[end]
+    sums.w_ht_sgs += MH * d_h_tot[end] * state.ρ
 
-    # liquid water path
-    # this condition is also going to be used to get the number of points that
-    # exist on a horizontal plane provided all planes have the same number of
-    # points
-    # TODO adjust for possibility of non equivalent horizontal slabs
-    if ev == floor(nvertelem / 2) && k == floor(Nqk / 2)
-        # TODO: uncomment the line below after rewriting the LWP assignment below using aux.∫dz...?
-        # aux = extract_aux(dg, localaux, ijk, e)
-        LWP[1] += MH * (localaux[ijk, 1, e] + localaux[ijk, 2, e])
-    end
+    compute_simple_sums!(
+        atmos.moisture,
+        state,
+        diffusive_flux,
+        thermo,
+        MH,
+        D_t,
+        sums,
+    )
 
     return nothing
 end
-
-function compute_diagnosticsums!(
-    atmos,
+function compute_simple_sums!(
+    ::MoistureModel,
     state,
-    k,
-    ijk,
-    ev,
-    e,
-    Nqk,
-    nvertelem,
+    diffusive_flux,
+    thermo,
     MH,
-    thermoQ,
-    horzavgs,
-    dsums,
+    D_t,
+    sums,
 )
-    zvals = CollectedDiagnostics.zvals
-    th = thermo_vars(thermoQ[ijk, e])
-    ha = horzavg_vars(horzavgs[Nqk * (ev - 1) + k])
-    ds = diagnostic_vars(dsums[Nqk * (ev - 1) + k])
-
-    u = state.ρu[1] / state.ρ
-    v = state.ρu[2] / state.ρ
-    w = state.ρu[3] / state.ρ
-    ũ = ha.ρu / ha.ρ
-    ṽ = ha.ρv / ha.ρ
-    w̃ = ha.ρw / ha.ρ
-    ẽ = ha.e_tot / ha.ρ
-    q̃_tot = ha.ρq_tot / ha.ρ
-    # TODO: temporary fix
-    if isa(atmos.moisture, EquilMoist)
-        q_tot = state.moisture.ρq_tot / state.ρ
-    end
-
-    # state and functions of state
-    ds.u += MH * ũ
-    ds.v += MH * ṽ
-    ds.w += MH * w̃
-    ds.e_tot += MH * ẽ
-    ds.q_tot += MH * ha.ρq_tot / ha.ρ
-    ds.q_liq += MH * ha.q_liq
-    ds.thd += MH * ha.θ_dry
-    ds.thl += MH * ha.θ_liq_ice
-    ds.thv += MH * ha.θ_v
-    ds.e_int += MH * ha.e_int
-    ds.h_m += MH * ha.h_m
-    ds.h_t += MH * ha.h_t
-    ds.qt_sgs += MH * ha.qt_sgs
-    ds.ht_sgs += MH * ha.ht_sgs
-
-    # vertical fluxes
-    ds.vert_eddy_mass_flux += MH * (w - w̃) * (state.ρ - ha.ρ)
-    ds.vert_eddy_u_flux += MH * (w - w̃) * (u - ha.ρu / ha.ρ)
-    ds.vert_eddy_v_flux += MH * (w - w̃) * (v - ha.ρv / ha.ρ)
-    ds.vert_eddy_ql_flux += MH * (w - w̃) * (th.q_liq - ha.q_liq)
-    ds.vert_eddy_qv_flux += MH * (w - w̃) * (th.q_vap - ha.q_vap)
-    ds.vert_eddy_thd_flux += MH * (w - w̃) * (th.θ_dry - ha.θ_dry)
-    ds.vert_eddy_thv_flux += MH * (w - w̃) * (th.θ_v - ha.θ_v)
-    ds.vert_eddy_thl_flux += MH * (w - w̃) * (th.θ_liq_ice - ha.θ_liq_ice)
-    # TODO: temporary fix
-    if isa(atmos.moisture, EquilMoist)
-        ds.vert_eddy_qt_flux += MH * (w - w̃) * (q_tot - q̃_tot)
-        ds.vert_qt_flux += MH * w * q_tot
-    end
-
-    # variances
-    ds.uvariance += MH * (u - ũ)^2
-    ds.vvariance += MH * (v - ṽ)^2
-    ds.wvariance += MH * (w - w̃)^2
-
-    # skewness
-    ds.wskew += MH * (w - w̃)^3
-
-    # turbulent kinetic energy
-    ds.TKE = 0.5 * (ds.uvariance + ds.vvariance + ds.wvariance)
+    return nothing
+end
+function compute_simple_sums!(
+    moist::EquilMoist,
+    state,
+    diffusive_flux,
+    thermo,
+    MH,
+    D_t,
+    sums,
+)
+    sums.moisture.qt += MH * state.moisture.ρq_tot
+    sums.moisture.ql += MH * thermo.moisture.q_liq * state.ρ
+    sums.moisture.qv += MH * thermo.moisture.q_vap * state.ρ
+    sums.moisture.thl += MH * thermo.moisture.θ_liq_ice * state.ρ
+    d_q_tot = (-D_t) .* diffusive_flux.moisture.∇q_tot
+    sums.moisture.w_qt_sgs += MH * d_q_tot[end] * state.ρ
 
     return nothing
 end
+
+# Variances and covariances
+function vars_atmos_default_ho(m::AtmosModel, FT)
+    @vars begin
+        var_u::FT               # u′u′
+        var_v::FT               # v′v′
+        var_w::FT               # w′w′
+        w3::FT                  # w′w′w′
+        tke::FT
+        var_ei::FT              # e_int′e_int′
+
+        cov_w_u::FT             # w′u′
+        cov_w_v::FT             # w′v′
+        cov_w_rho::FT           # w′ρ′
+        cov_w_thd::FT           # w′θ_dry′
+        cov_w_thv::FT           # w′θ_v′
+        cov_w_ei::FT            # w′e_int′
+
+        moisture::vars_atmos_default_ho(m.moisture, FT)
+    end
+end
+vars_atmos_default_ho(::MoistureModel, FT) = @vars()
+function vars_atmos_default_ho(m::EquilMoist, FT)
+    @vars begin
+        var_qt::FT              # q_tot′q_tot′
+        var_thl::FT             # θ_liq_ice′θ_liq_ice′
+
+        cov_w_qt::FT            # w′q_tot′
+        cov_w_ql::FT            # w′q_liq′
+        cov_w_qv::FT            # w′q_vap′
+        cov_w_thl::FT           # w′θ_liq_ice′
+        cov_qt_thl::FT          # q_tot′θ_liq_ice′
+        cov_qt_ei::FT           # q_tot′e_int′
+    end
+end
+num_atmos_default_ho_vars(m, FT) = varsize(vars_atmos_default_ho(m, FT))
+atmos_default_ho_vars(m, array) =
+    Vars{vars_atmos_default_ho(m, eltype(array))}(array)
+
+function compute_ho_sums!(
+    atmos::AtmosModel,
+    state,
+    diffusive_flux,
+    aux,
+    thermo,
+    MH,
+    ha,
+    sums,
+)
+    u = state.ρu[1] / state.ρ
+    u′ = u - ha.u
+    v = state.ρu[2] / state.ρ
+    v′ = v - ha.v
+    w = state.ρu[3] / state.ρ
+    w′ = w - ha.w
+    e_int′ = thermo.e_int - ha.ei
+    θ_dry′ = thermo.θ_dry - ha.thd
+    θ_vir′ = thermo.θ_vir - ha.thv
+
+    sums.var_u += MH * u′^2 * state.ρ
+    sums.var_v += MH * v′^2 * state.ρ
+    sums.var_w += MH * w′^2 * state.ρ
+    sums.w3 += MH * w′^3 * state.ρ
+    sums.tke +=
+        0.5 * (MH * u′^2 * state.ρ + MH * v′^2 * state.ρ + MH * w′^2 * state.ρ)
+    sums.var_ei += MH * e_int′^2 * state.ρ
+
+    sums.cov_w_u += MH * w′ * u′ * state.ρ
+    sums.cov_w_v += MH * w′ * v′ * state.ρ
+    sums.cov_w_rho += MH * w′ * (state.ρ - ha.avg_rho) * state.ρ
+    sums.cov_w_thd += MH * w′ * θ_dry′ * state.ρ
+    sums.cov_w_thv += MH * w′ * θ_vir′ * state.ρ
+    sums.cov_w_ei += MH * w′ * e_int′ * state.ρ
+
+    compute_ho_sums!(atmos.moisture, state, thermo, MH, ha, w′, e_int′, sums)
+
+    return nothing
+end
+function compute_ho_sums!(
+    ::MoistureModel,
+    state,
+    thermo,
+    MH,
+    ha,
+    w′,
+    e_int′,
+    sums,
+)
+    return nothing
+end
+function compute_ho_sums!(
+    moist::EquilMoist,
+    state,
+    thermo,
+    MH,
+    ha,
+    w′,
+    e_int′,
+    sums,
+)
+    q_tot = state.moisture.ρq_tot / state.ρ
+    q_tot′ = q_tot - ha.moisture.qt
+    q_liq′ = thermo.moisture.q_liq - ha.moisture.ql
+    q_vap′ = thermo.moisture.q_vap - ha.moisture.qv
+    θ_liq_ice′ = thermo.moisture.θ_liq_ice - ha.moisture.thl
+
+    sums.moisture.var_qt += MH * q_tot′^2 * state.ρ
+    sums.moisture.var_thl += MH * θ_liq_ice′^2 * state.ρ
+
+    sums.moisture.cov_w_qt += MH * w′ * q_tot′ * state.ρ
+    sums.moisture.cov_w_ql += MH * w′ * q_liq′ * state.ρ
+    sums.moisture.cov_w_qv += MH * w′ * q_vap′ * state.ρ
+    sums.moisture.cov_w_thl += MH * w′ * θ_liq_ice′ * state.ρ
+    sums.moisture.cov_qt_thl += MH * q_tot′ * θ_liq_ice′ * state.ρ
+    sums.moisture.cov_qt_ei += MH * q_tot′ * e_int′ * state.ρ
+
+    return nothing
+end
+
+
 
 """
     atmos_default_collect(bl, currtime)
 
-Perform a global grid traversal to compute various diagnostics.
+Collect the various 'AtmosDefault' diagnostic variables for the
+current timestep and write them into a file.
 """
 function atmos_default_collect(dgngrp::DiagnosticsGroup, currtime)
     mpicomm = Settings.mpicomm
     dg = Settings.dg
     Q = Settings.Q
     mpirank = MPI.Comm_rank(mpicomm)
-    current_time = string(currtime)
-
-    # make sure this time step is not already recorded
-    dprefix = @sprintf(
-        "%s_%s-%s-num%04d",
-        dgngrp.out_prefix,
-        dgngrp.name,
-        Settings.starttime,
-        dgngrp.num
-    )
-    dfilename = joinpath(Settings.output_dir, dprefix)
-    docollect = [false]
-    if mpirank == 0
-        dfullname = full_name(dgngrp.writer, dfilename)
-        if isfile(dfullname)
-            @warn """
-Diagnostics $(dgngrp.name) collection
-    output file $dfullname exists
-    skipping collection at $current_time"""
-        else
-            docollect[1] = true
-        end
-    end
-    MPI.Bcast!(docollect, 0, mpicomm)
-    if !docollect[1]
-        return nothing
-    end
-
-    # extract grid information
     bl = dg.balancelaw
     grid = dg.grid
     topology = grid.topology
@@ -307,7 +299,9 @@ Diagnostics $(dgngrp.name) collection
     nvertelem = topology.stacksize
     nhorzelem = div(nrealelem, nvertelem)
 
-    # get the state, auxiliary and geo variables onto the host if needed
+    # Get the state, auxiliary, geo and diffusive variables onto
+    # the CPU if needed.
+    #
     if Array ∈ typeof(Q).parameters
         localQ = Q.realdata
         localaux = dg.auxstate.realdata
@@ -321,120 +315,183 @@ Diagnostics $(dgngrp.name) collection
     end
     FT = eltype(localQ)
 
-    nstate = num_state(bl, FT)
-    nauxstate = num_aux(bl, FT)
-    ndiff = num_diffusive(bl, FT)
-
-    # thermo variables
-    thermoQ = [zeros(FT, num_thermo(FT)) for _ in 1:npoints, _ in 1:nrealelem]
-
-    # horizontal sums and the liquid water path
-    l_LWP = zeros(FT, 1)
-    horzsums = [zeros(FT, num_horzavg(FT)) for _ in 1:(Nqk * nvertelem)]
-
-    # compute thermo variables and horizontal sums in a single pass
+    # Visit each node of the state variables array and:
+    # - generate and store the thermo variables,
+    # - accumulate the simple horizontal sums, and
+    # - determine the cloud fraction, top and base
+    #
+    thermo_array =
+        [zeros(FT, num_thermo(bl, FT)) for _ in 1:npoints, _ in 1:nrealelem]
+    simple_sums = [
+        zeros(FT, num_atmos_default_simple_vars(bl, FT))
+        for _ in 1:(Nqk * nvertelem)
+    ]
+    ql_gt_0 = [zeros(FT, (Nq * Nq * nhorzelem)) for _ in 1:(Nqk * nvertelem)]
+    cld_top = FT(-100000)
+    cld_base = FT(100000)
     @visitQ nhorzelem nvertelem Nqk Nq begin
+        evk = Nqk * (ev - 1) + k
+
         state = extract_state(dg, localQ, ijk, e)
-        aux = extract_aux(dg, localaux, ijk, e)
-
-        compute_thermo!(bl, state, aux, ijk, e, thermoQ)
-
         diffusive_flux = extract_diffusion(dg, localdiff, ijk, e)
+        aux = extract_aux(dg, localaux, ijk, e)
         MH = localvgeo[ijk, grid.MHid, e]
-        compute_horzsums!(
+
+        thermo = thermo_vars(bl, thermo_array[ijk, e])
+        compute_thermo!(bl, state, aux, thermo)
+
+        simple = atmos_default_simple_vars(bl, simple_sums[evk])
+        compute_simple_sums!(
             bl,
             state,
             diffusive_flux,
             aux,
-            k,
-            ijk,
-            ev,
-            e,
-            Nqk,
-            nvertelem,
-            MH,
-            localaux,
-            thermoQ,
-            horzsums,
-            l_LWP,
+            thermo,
             currtime,
+            MH,
+            simple,
         )
-    end
 
-    # compute the horizontal and LWP averages
-    repdvsr = CollectedDiagnostics.repdvsr
-    horzavgs = [zeros(FT, num_horzavg(FT)) for _ in 1:(Nqk * nvertelem)]
-    for ev in 1:nvertelem
-        for k in 1:Nqk
-            hsum = MPI.Allreduce(horzsums[Nqk * (ev - 1) + k], +, mpicomm)
-            horzavgs[Nqk * (ev - 1) + k] .= hsum ./ repdvsr[Nqk * (ev - 1) + k]
+        if !iszero(thermo.moisture.q_liq)
+            idx = (Nq * Nq * (eh - 1)) + (Nq * (j - 1)) + i
+            ql_gt_0[evk][idx] = one(FT)
+
+            z = AtmosDefaultCollected.zvals[evk]
+            cld_top = max(cld_top, z)
+            cld_base = min(cld_base, z)
         end
     end
-    LWP = zero(FT)
-    LWP = MPI.Reduce(l_LWP[1], +, 0, mpicomm)
-    if mpirank == 0
-        LWP /= repdvsr[1]
+
+    # reduce horizontal sums and cloud data across ranks and compute averages
+    repdvsr = AtmosDefaultCollected.repdvsr
+    simple_avgs = [
+        zeros(FT, num_atmos_default_simple_vars(bl, FT))
+        for _ in 1:(Nqk * nvertelem)
+    ]
+    cld_frac = zeros(FT, Nqk * nvertelem)
+    for evk in 1:(Nqk * nvertelem)
+        MPI.Allreduce!(simple_sums[evk], simple_avgs[evk], +, mpicomm)
+        simple_avgs[evk] .= simple_avgs[evk] ./ repdvsr[evk]
+
+        tot_ql_gt_0 = MPI.Reduce(sum(ql_gt_0[evk]), +, 0, mpicomm)
+        tot_horz = MPI.Reduce(length(ql_gt_0[evk]), +, 0, mpicomm)
+        if mpirank == 0
+            cld_frac[evk] = tot_ql_gt_0 / tot_horz
+        end
+    end
+    cld_top = MPI.Reduce(cld_top, MPI.MAX, 0, mpicomm)
+    if cld_top == FT(-100000)
+        cld_top = NaN
+    end
+    cld_base = MPI.Reduce(cld_base, MPI.MIN, 0, mpicomm)
+    if cld_base == FT(100000)
+        cld_base = NaN
     end
 
-    # compute the diagnostics using the previous computed values
-    dsums = [zeros(FT, num_diagnostic(FT)) for _ in 1:(Nqk * nvertelem)]
-    @visitQ nhorzelem nvertelem Nqk Nq begin
-        state = extract_state(dg, localQ, ijk, e)
-        MH = localvgeo[ijk, grid.MHid, e]
-        compute_diagnosticsums!(
-            bl,
-            state,
-            k,
-            ijk,
-            ev,
-            e,
-            Nqk,
-            nvertelem,
-            MH,
-            thermoQ,
-            horzavgs,
-            dsums,
-        )
-    end
-    varvals = OrderedDict()
-    varnames = flattenednames(vars_diagnostic(FT))
-    for vari in 1:length(varnames)
-        davg = zeros(FT, Nqk * nvertelem)
+    # complete density averaging
+    simple_varnames = map(
+        s -> startswith(s, "moisture.") ? s[10:end] : s,
+        flattenednames(vars_atmos_default_simple(bl, FT)),
+    )
+    for vari in 1:length(simple_varnames)
         for evk in 1:(Nqk * nvertelem)
-            dsum = MPI.Reduce(dsums[evk][vari], +, 0, mpicomm)
-            if mpirank == 0
-                davg[evk] = dsum / repdvsr[evk]
+            simple_ha = atmos_default_simple_vars(bl, simple_avgs[evk])
+            avg_rho = simple_ha.avg_rho
+            if simple_varnames[vari] != "avg_rho"
+                simple_avgs[evk][vari] /= avg_rho
             end
         end
+    end
+
+    # compute the variances and covariances
+    ho_sums = [
+        zeros(FT, num_atmos_default_ho_vars(bl, FT))
+        for _ in 1:(Nqk * nvertelem)
+    ]
+    @visitQ nhorzelem nvertelem Nqk Nq begin
+        evk = Nqk * (ev - 1) + k
+
+        state = extract_state(dg, localQ, ijk, e)
+        diffusive_flux = extract_diffusion(dg, localdiff, ijk, e)
+        aux = extract_aux(dg, localaux, ijk, e)
+        thermo = thermo_vars(bl, thermo_array[ijk, e])
+        MH = localvgeo[ijk, grid.MHid, e]
+
+        simple_ha = atmos_default_simple_vars(bl, simple_avgs[evk])
+        ho = atmos_default_ho_vars(bl, ho_sums[evk])
+        compute_ho_sums!(
+            bl,
+            state,
+            diffusive_flux,
+            aux,
+            thermo,
+            MH,
+            simple_ha,
+            ho,
+        )
+    end
+
+    # reduce across ranks and compute averages
+    repdvsr = AtmosDefaultCollected.repdvsr
+    ho_avgs = [
+        zeros(FT, num_atmos_default_ho_vars(bl, FT))
+        for _ in 1:(Nqk * nvertelem)
+    ]
+    for evk in 1:(Nqk * nvertelem)
+        MPI.Reduce!(ho_sums[evk], ho_avgs[evk], +, 0, mpicomm)
         if mpirank == 0
-            varvals[varnames[vari]] = davg
+            ho_avgs[evk] .= ho_avgs[evk] ./ repdvsr[evk]
         end
     end
 
-    # write diagnostics
+    # complete the density averaging and prepare output
     if mpirank == 0
+        varvals = OrderedDict()
+        for vari in 1:length(simple_varnames)
+            davg = zeros(FT, Nqk * nvertelem)
+            for evk in 1:(Nqk * nvertelem)
+                davg[evk] = simple_avgs[evk][vari]
+            end
+            varvals[simple_varnames[vari]] = (("z",), davg)
+        end
+
+        ho_varnames = map(
+            s -> startswith(s, "moisture.") ? s[10:end] : s,
+            flattenednames(vars_atmos_default_ho(bl, FT)),
+        )
+        for vari in 1:length(ho_varnames)
+            davg = zeros(FT, Nqk * nvertelem)
+            for evk in 1:(Nqk * nvertelem)
+                simple_ha = atmos_default_simple_vars(bl, simple_avgs[evk])
+                avg_rho = simple_ha.avg_rho
+                davg[evk] = ho_avgs[evk][vari] / avg_rho
+            end
+            varvals[ho_varnames[vari]] = (("z",), davg)
+        end
+
+        varvals["cld_frac"] = (("z",), cld_frac)
+        varvals["cld_top"] = (("t",), cld_top)
+        varvals["cld_base"] = (("t",), cld_base)
+
+        # write output
+        dprefix = @sprintf(
+            "%s_%s_%s_num%04d",
+            dgngrp.out_prefix,
+            dgngrp.name,
+            Settings.starttime,
+            dgngrp.num
+        )
+        dfilename = joinpath(Settings.output_dir, dprefix)
         write_data(
             dgngrp.writer,
             dfilename,
-            OrderedDict("z" => CollectedDiagnostics.zvals),
+            OrderedDict("z" => AtmosDefaultCollected.zvals),
             varvals,
             currtime,
         )
     end
 
-    # write LWP
-    if mpirank == 0
-        jldopen(
-            joinpath(
-                Settings.output_dir,
-                "liquid_water_path-$(Settings.starttime).jld2",
-            ),
-            "a+",
-        ) do file
-            file[current_time] = LWP
-        end
-    end
-
+    MPI.Barrier(mpicomm)
     return nothing
 end # function collect
 

--- a/src/Diagnostics/dump_state_and_aux.jl
+++ b/src/Diagnostics/dump_state_and_aux.jl
@@ -96,13 +96,15 @@ function dump_state_and_aux_collect(dgngrp, currtime)
 
     statevarvals = OrderedDict()
     for i in 1:num_state(bl, FT)
-        statevarvals[statenames[i]] = all_state_data[:, :, :, i]
+        statevarvals[statenames[i]] =
+            ((collect(keys(dims)),), all_state_data[:, :, :, i])
     end
     write_data(dgngrp.writer, statefilename, dims, statevarvals, currtime)
 
     auxvarvals = OrderedDict()
     for i in 1:num_aux(bl, FT)
-        auxvarvals[auxnames[i]] = all_aux_data[:, :, :, i]
+        auxvarvals[auxnames[i]] =
+            ((collect(keys(dims)),), all_aux_data[:, :, :, i])
     end
     write_data(dgngrp.writer, auxfilename, dims, auxvarvals, currtime)
 

--- a/src/Diagnostics/thermo.jl
+++ b/src/Diagnostics/thermo.jl
@@ -1,0 +1,60 @@
+# Helpers to gather the thermodynamic variables across the DG grid
+#
+
+function vars_thermo(m::AtmosModel, FT)
+    @vars begin
+        T::FT
+        θ_dry::FT
+        θ_vir::FT
+        e_int::FT
+        h_tot::FT
+        h_moi::FT
+
+        moisture::vars_thermo(m.moisture, FT)
+    end
+end
+vars_thermo(::MoistureModel, FT) = @vars()
+function vars_thermo(m::EquilMoist, FT)
+    @vars begin
+        q_liq::FT
+        q_ice::FT
+        q_vap::FT
+        θ_liq_ice::FT
+    end
+end
+num_thermo(bl, FT) = varsize(vars_thermo(bl, FT))
+thermo_vars(bl, array) = Vars{vars_thermo(bl, eltype(array))}(array)
+
+# visitor function, to use with `@visitQ`
+function compute_thermo!(atmos::AtmosModel, state, aux, thermo)
+    e_tot = state.ρe / state.ρ
+    ts = thermo_state(atmos, state, aux)
+    e_int = internal_energy(ts)
+
+    thermo.T = air_temperature(ts)
+    thermo.θ_dry = dry_pottemp(ts)
+    thermo.θ_vir = virtual_pottemp(ts)
+    thermo.e_int = e_int
+
+    # Moist and total henthalpy
+    R_m = gas_constant_air(ts)
+    thermo.h_tot = e_tot + R_m * thermo.T
+    thermo.h_moi = e_int + R_m * thermo.T
+
+    compute_thermo!(atmos.moisture, state, aux, ts, thermo)
+
+    return nothing
+end
+function compute_thermo!(::MoistureModel, state, aux, ts, thermo)
+    return nothing
+end
+function compute_thermo!(moist::EquilMoist, state, aux, ts, thermo)
+    Phpart = PhasePartition(ts)
+
+    thermo.moisture.q_liq = Phpart.liq
+    thermo.moisture.q_ice = Phpart.ice
+    thermo.moisture.q_vap = vapor_specific_humidity(ts)
+    thermo.moisture.θ_liq_ice = liquid_ice_pottemp(ts)
+
+    return nothing
+end

--- a/src/InputOutput/Writers/Writers.jl
+++ b/src/InputOutput/Writers/Writers.jl
@@ -1,3 +1,13 @@
+"""
+    Writers
+
+Abstracts writing dimensioned data so that output can be to a NetCDF
+file or to a JLD2 file.
+
+Currently, a single file per time of writing is envisioned. Thus, a
+`t` dimension is implicitly defined as `[1]`.
+"""
+
 module Writers
 
 export AbstractWriter, NetCDFWriter, JLD2Writer, write_data, full_name
@@ -20,7 +30,8 @@ and variable values to a file. Specialized by every `Writer` subtype.
 # - `writer`: instance of a subtype of `AbstractWriter`.
 # - `filename`: into which to write data (without extension).
 # - `dims`: Dict of dimension name to axis.
-# - `varvals`: Dict of variable name to array of values.
+# - `varvals`: Tuple of a k-tuple of dimension names and a Dict, of
+# variable name to k-dimensional array of values.
 # - `simtime`: Current simulation time.
 """
 function write_data end

--- a/src/InputOutput/Writers/jld2_writer.jl
+++ b/src/InputOutput/Writers/jld2_writer.jl
@@ -12,9 +12,9 @@ function write_data(jld::JLD2Writer, filename, dims, varvals, simtime)
         for (dn, dv) in dims
             ds[dn] = dv
         end
-        ds["time"] = [1]
+        ds["t"] = [1]
         for (vn, vv) in varvals
-            ds[vn] = vv
+            ds[vn] = vv[2]
         end
         ds["simtime"] = [simtime]
     end

--- a/src/InputOutput/Writers/netcdf_writer.jl
+++ b/src/InputOutput/Writers/netcdf_writer.jl
@@ -7,15 +7,15 @@ function write_data(nc::NetCDFWriter, filename, dims, varvals, simtime)
         for (dn, dv) in dims
             ds.dim[dn] = length(dv)
         end
-        ds.dim["time"] = 1
+        ds.dim["t"] = 1
         for (dn, dv) in dims
             defVar(ds, dn, dv, (dn,))
         end
-        defVar(ds, "time", 1, ("time",))
+        defVar(ds, "t", 1, ("t",))
         for (vn, vv) in varvals
-            defVar(ds, vn, vv, collect(keys(dims)))
+            defVar(ds, vn, vv[2], vv[1])
         end
-        defVar(ds, "simtime", [simtime], ("time",))
+        defVar(ds, "simtime", [simtime], ("t",))
     end
     return nothing
 end

--- a/test/InputOutput/Writers/runtests.jl
+++ b/test/InputOutput/Writers/runtests.jl
@@ -10,7 +10,10 @@ using CLIMA.Writers
         "y" => collect(1:5),
         "z" => collect(1010:10:1050),
     )
-    ovars = OrderedDict("v1" => rand(5, 5, 5), "v2" => rand(5, 5, 5))
+    ovars = OrderedDict(
+        "v1" => (("x", "y", "z"), rand(5, 5, 5)),
+        "v2" => (("x", "y", "z"), rand(5, 5, 5)),
+    )
     jfn, _ = mktemp()
     jfull = full_name(JLD2Writer(), jfn)
     write_data(JLD2Writer(), jfn, odims, ovars, 0.5)
@@ -26,9 +29,9 @@ using CLIMA.Writers
         @test jds["x"] == odims["x"]
         @test jds["y"] == odims["y"]
         @test jds["z"] == odims["z"]
-        @test jds["time"] == [1]
-        @test get(jds, "v1", []) == ovars["v1"]
-        @test get(jds, "v2", []) == ovars["v2"]
+        @test jds["t"] == [1]
+        @test get(jds, "v1", []) == ovars["v1"][2]
+        @test get(jds, "v2", []) == ovars["v2"][2]
         @test get(jds, "simtime", [1.0]) == [0.5]
     end
 
@@ -42,9 +45,9 @@ using CLIMA.Writers
         catch e
             true
         end
-        @test nds["time"] == [1]
-        @test nds["v1"] == ovars["v1"]
-        @test nds["v2"] == ovars["v2"]
+        @test nds["t"] == [1]
+        @test nds["v1"] == ovars["v1"][2]
+        @test nds["v2"] == ovars["v2"][2]
         @test nds["simtime"] == [0.5]
     end
 end


### PR DESCRIPTION
# Description

- Adds more of the `default` diagnostics from #943 (excluding LWP and cloud cover).
- Changes the variable names for the diagnostics according to the [variable list](https://climate-machine.github.io/CLIMA/latest/DiagnosticVariables/).
- Changes the computation of the vertical fluxes and variances to use density-weighted means.
- Applies the idea from and closes #739.
- Changed `Writers.write_data()` to allow specifying dimension names for a variable.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [X] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [X] CLIMA developers with relevant expertise have been assigned to review this submission
- [X] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
