### PR TITLE
Set random seed in cg test at start of file

### DIFF
--- a/test/LinearSolvers/cg.jl
+++ b/test/LinearSolvers/cg.jl
@@ -8,6 +8,7 @@ using CLIMA.LinearSolvers
 using CLIMA.ConjugateGradientSolver
 using CLIMA.MPIStateArrays
 using Random
+Random.seed!(1235)
 
 let
     CLIMA.init()
@@ -110,7 +111,6 @@ let
 
     tup = (3, 4, 7, 2, 20, 2)
 
-    Random.seed!(1235)
     B = [
         randn(tup[3] * tup[5], tup[3] * tup[5])
         for i1 in 1:tup[1], i2 in 1:tup[2], i4 in 1:tup[4], i6 in 1:tup[6]


### PR DESCRIPTION
The test is not reproducible because the seed is set after rand has been
called a few times.

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
