### PR TITLE
 experiments/AtmosLES/dycoms.jl

### DIFF
--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -216,7 +216,7 @@ function init_dycoms!(bl, state, aux, (x, y, z), t)
     u, v, w = ugeo, vgeo, FT(0)
 
     # Perturb initial state to break symmetry and trigger turbulent convection
-    r1 = FT(rand(Uniform(-0.002, 0.002)))
+    r1 = FT(rand(Uniform(-0.001, 0.001)))
     if z <= 200.0
         θ_liq += r1 * θ_liq
     end
@@ -302,7 +302,7 @@ function config_dycoms(FT, N, resolution, xmax, ymax, zmax)
         param_set;
         ref_state = ref_state,
         turbulence = SmagorinskyLilly{FT}(C_smag),
-        moisture = EquilMoist{FT}(; maxiter = 5),
+        moisture = EquilMoist{FT}(maxiter = 1, tolerance=FT(100)),
         radiation = radiation,
         source = source,
         boundarycondition = (


### PR DESCRIPTION
* Reduced initial random perturbation intensity for from +-0.002 to +-0.001
* Replaced: moisture = EquilMoist{FT}(; maxiter = 5), with moisture = EquilMoist{FT}(maxiter = 1, tolerance(FT(100)),

# Description

A clear and concise description of the code with usage.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
