### PR TITLE
Minor: Diagnostics naming correction

### DIFF
--- a/src/Diagnostics/atmos_default.jl
+++ b/src/Diagnostics/atmos_default.jl
@@ -248,8 +248,8 @@ function compute_diagnosticsums!(
     ds.vvariance += MH * (v - ṽ)^2
     ds.wvariance += MH * (w - w̃)^2
 
-    # skewness
-    ds.wskew += MH * (w - w̃)^3
+    # third moment of w'
+    ds.www += MH * (w - w̃)^3
 
     # turbulent kinetic energy
     ds.TKE = 0.5 * (ds.uvariance + ds.vvariance + ds.wvariance)

--- a/src/Diagnostics/diagnostic_vars.jl
+++ b/src/Diagnostics/diagnostic_vars.jl
@@ -36,8 +36,8 @@ function vars_diagnostic(FT)
         vvariance::FT          # v′v′
         wvariance::FT          # w′w′
 
-        # skewness
-        wskew::FT              # w′w′w′
+        # third moment of w'
+        www::FT              # w′w′w′
 
         # turbulent kinetic energy
         TKE::FT


### PR DESCRIPTION
Naming correction:  skewness --> www (third moment of w prime)
Skewness is www/ww^3/2 but we are not calculating it in diagnostics for now.

# Description

A clear and concise description of the code with usage.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
