### PR TITLE
Disable Jupyter notebook Literate examples

### DIFF
--- a/docs/list_of_examples.jl
+++ b/docs/list_of_examples.jl
@@ -33,7 +33,7 @@ for example in examples_files
     code = strip(read(script, String))
     mdpost(str) = replace(str, "@__CODE__" => code)
     Literate.markdown(input, gen_dir, postprocess = mdpost)
-    Literate.notebook(input, gen_dir, execute = true)
+    #Literate.notebook(input, gen_dir, execute = true)
 end
 
 examples = [


### PR DESCRIPTION
Fixes doc builds due to relative path problem introduce in https://github.com/climate-machine/CLIMA/pull/988#discussion_r414274056.

The Jupyter notebooks weren't linked from the docs, so we can just disable them for now. Once we have a better solution to the paths, we can come up with something better.


# Description

A clear and concise description of the code with usage.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)