### PR TITLE
Add support for higher order DG on GPU

### DIFF
--- a/src/Numerics/DGmethods/DGmodel.jl
+++ b/src/Numerics/DGmethods/DGmodel.jl
@@ -115,7 +115,7 @@ function (dg::DGModel)(
 
     if num_state_gradient_flux > 0 || nhyperviscstate > 0
 
-        comp_stream = volume_gradients!(device, workgroups_volume)(
+        comp_stream = volume_gradients!(device, (Nq, Nq))(
             balance_law,
             Val(dim),
             Val(N),
@@ -129,7 +129,7 @@ function (dg::DGModel)(
             grid.D,
             hypervisc_indexmap,
             topology.realelems,
-            ndrange = ndrange_volume,
+            ndrange = (Nq * nrealelem, Nq),
             dependencies = (comp_stream,),
         )
 
@@ -385,7 +385,7 @@ function (dg::DGModel)(
     ###################
     # RHS Computation #
     ###################
-    comp_stream = volume_tendency!(device, workgroups_volume)(
+    comp_stream = volume_tendency!(device, (Nq, Nq))(
         balance_law,
         Val(dim),
         Val(N),
@@ -401,7 +401,7 @@ function (dg::DGModel)(
         grid.D,
         topology.realelems,
         increment;
-        ndrange = ndrange_volume,
+        ndrange = (nrealelem * Nq, Nq),
         dependencies = (comp_stream,),
     )
 
@@ -528,7 +528,7 @@ function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
 
     if !init_on_cpu
         event = Event(device)
-        event = kernel_init_state_conservative!(device, Np)(
+        event = kernel_init_state_conservative!(device, min(Np, 1024))(
             balance_law,
             Val(dim),
             Val(N),
@@ -723,7 +723,7 @@ function nodal_update_auxiliary_state!(
     Np = dofs_per_element(grid)
 
     nodal_update_auxiliary_state! =
-        kernel_nodal_update_auxiliary_state!(device, Np)
+        kernel_nodal_update_auxiliary_state!(device, min(Np, 1024))
     ### update state_auxiliary variables
     event = Event(device)
     if diffusive

--- a/src/Numerics/DGmethods/DGmodel_kernels.jl
+++ b/src/Numerics/DGmethods/DGmodel_kernels.jl
@@ -28,8 +28,9 @@ const _sM, _vMI = Grids._sM, Grids._vMI
 # }}}
 
 @doc """
-    volume_tendency!(balance_law::BalanceLaw, Val(polyorder), tendency, state_conservative, state_gradient_flux, state_auxiliary,
-               vgeo, t, D, elems)
+    volume_tendency!(balance_law::BalanceLaw, Val(polyorder),
+                     tendency, state_conservative, state_gradient_flux,
+                     state_auxiliary, vgeo, t, D, elems)
 
 Computational kernel: Evaluate the volume integrals on right-hand side of a
 `BalanceLaw` semi-discretization.
@@ -73,159 +74,180 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
         local_state_hyperdiffusion = MArray{Tuple{nhyperviscstate}, FT}(undef)
         local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_flux = MArray{Tuple{3, num_state_conservative}, FT}(undef)
+        local_flux_3 = MArray{Tuple{num_state_conservative}, FT}(undef)
     end
 
-    shared_flux = @localmem FT (3, Nq, Nq, Nqk, num_state_conservative)
-    s_ω = @localmem FT (Nq,)
+    shared_flux = @localmem FT (2, Nq, Nq, num_state_conservative)
     s_D = @localmem FT (Nq, Nq)
-    local_tendency = @private FT (num_state_conservative,)
+
+    local_tendency = @private FT (Nqk, num_state_conservative)
+    local_MI = @private FT (Nqk,)
 
     e = @index(Group, Linear)
-    ijk = @index(Local, Linear)
-    i, j, k = @index(Local, NTuple)
+    i, j = @index(Local, NTuple)
 
     @inbounds begin
-        s_ω[j] = ω[j]
         s_D[i, j] = D[i, j]
-
-        M = vgeo[ijk, _M, e]
-        ξ1x1 = vgeo[ijk, _ξ1x1, e]
-        ξ1x2 = vgeo[ijk, _ξ1x2, e]
-        ξ1x3 = vgeo[ijk, _ξ1x3, e]
-        if dim == 3 || (dim == 2 && direction isa EveryDirection)
-            ξ2x1 = vgeo[ijk, _ξ2x1, e]
-            ξ2x2 = vgeo[ijk, _ξ2x2, e]
-            ξ2x3 = vgeo[ijk, _ξ2x3, e]
-        end
-        if dim == 3 && direction isa EveryDirection
-            ξ3x1 = vgeo[ijk, _ξ3x1, e]
-            ξ3x2 = vgeo[ijk, _ξ3x2, e]
-            ξ3x3 = vgeo[ijk, _ξ3x3, e]
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            @unroll for s in 1:num_state_conservative
+                local_tendency[k, s] =
+                    increment ? tendency[ijk, s, e] : zero(FT)
+            end
+            local_MI[k] = vgeo[ijk, _MI, e]
         end
 
-        @unroll for s in 1:num_state_conservative
-            local_tendency[s] = increment ? tendency[ijk, s, e] : zero(FT)
-        end
+        @unroll for k in 1:Nqk
+            @synchronize
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
 
-        @unroll for s in 1:num_state_conservative
-            local_state_conservative[s] = state_conservative[ijk, s, e]
-        end
-
-        @unroll for s in 1:num_state_auxiliary
-            local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
-        end
-
-        @unroll for s in 1:num_state_gradient_flux
-            local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
-        end
-
-        @unroll for s in 1:nhyperviscstate
-            local_state_hyperdiffusion[s] = Qhypervisc_grad[ijk, s, e]
-        end
-
-        fill!(local_flux, -zero(eltype(local_flux)))
-        flux_first_order!(
-            balance_law,
-            Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(
-                local_state_conservative,
-            ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            t,
-        )
-
-        @unroll for s in 1:num_state_conservative
-            shared_flux[1, i, j, k, s] = local_flux[1, s]
-            shared_flux[2, i, j, k, s] = local_flux[2, s]
-            shared_flux[3, i, j, k, s] = local_flux[3, s]
-        end
-
-        fill!(local_flux, -zero(eltype(local_flux)))
-        flux_second_order!(
-            balance_law,
-            Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(
-                local_state_conservative,
-            ),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(
-                local_state_gradient_flux,
-            ),
-            Vars{vars_hyperdiffusive(balance_law, FT)}(
-                local_state_hyperdiffusion,
-            ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            t,
-        )
-
-        @unroll for s in 1:num_state_conservative
-            shared_flux[1, i, j, k, s] += local_flux[1, s]
-            shared_flux[2, i, j, k, s] += local_flux[2, s]
-            shared_flux[3, i, j, k, s] += local_flux[3, s]
-        end
-
-        # Build "inside metrics" flux
-        @unroll for s in 1:num_state_conservative
-            F1, F2, F3 = shared_flux[1, i, j, k, s],
-            shared_flux[2, i, j, k, s],
-            shared_flux[3, i, j, k, s]
-
-            shared_flux[1, i, j, k, s] = M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
+            M = vgeo[ijk, _M, e]
+            ξ1x1 = vgeo[ijk, _ξ1x1, e]
+            ξ1x2 = vgeo[ijk, _ξ1x2, e]
+            ξ1x3 = vgeo[ijk, _ξ1x3, e]
             if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                shared_flux[2, i, j, k, s] =
-                    M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
+                ξ2x1 = vgeo[ijk, _ξ2x1, e]
+                ξ2x2 = vgeo[ijk, _ξ2x2, e]
+                ξ2x3 = vgeo[ijk, _ξ2x3, e]
             end
             if dim == 3 && direction isa EveryDirection
-                shared_flux[3, i, j, k, s] =
-                    M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
+                ξ3x1 = vgeo[ijk, _ξ3x1, e]
+                ξ3x2 = vgeo[ijk, _ξ3x2, e]
+                ξ3x3 = vgeo[ijk, _ξ3x3, e]
             end
-        end
 
-        fill!(local_source, -zero(eltype(local_source)))
-        source!(
-            balance_law,
-            Vars{vars_state_conservative(balance_law, FT)}(local_source),
-            Vars{vars_state_conservative(balance_law, FT)}(
-                local_state_conservative,
-            ),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(
-                local_state_gradient_flux,
-            ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            t,
-            direction,
-        )
+            @unroll for s in 1:num_state_conservative
+                local_state_conservative[s] = state_conservative[ijk, s, e]
+            end
 
-        @unroll for s in 1:num_state_conservative
-            local_tendency[s] += local_source[s]
-        end
-        @synchronize
+            @unroll for s in 1:num_state_auxiliary
+                local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
+            end
 
-        # Weak "inside metrics" derivative
-        MI = vgeo[ijk, _MI, e]
-        @unroll for s in 1:num_state_conservative
-            @unroll for n in 1:Nq
-                # ξ1-grid lines
-                local_tendency[s] += MI * s_D[n, i] * shared_flux[1, n, j, k, s]
+            @unroll for s in 1:num_state_gradient_flux
+                local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
+            end
 
-                # ξ2-grid lines
+            @unroll for s in 1:nhyperviscstate
+                local_state_hyperdiffusion[s] = Qhypervisc_grad[ijk, s, e]
+            end
+
+            fill!(local_flux, -zero(eltype(local_flux)))
+            flux_first_order!(
+                balance_law,
+                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
+                t,
+            )
+
+            @unroll for s in 1:num_state_conservative
+                shared_flux[1, i, j, s] = local_flux[1, s]
+                shared_flux[2, i, j, s] = local_flux[2, s]
+                local_flux_3[s] = local_flux[3, s]
+            end
+
+            fill!(local_flux, -zero(eltype(local_flux)))
+            flux_second_order!(
+                balance_law,
+                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux,
+                ),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
+                t,
+            )
+
+            @unroll for s in 1:num_state_conservative
+                shared_flux[1, i, j, s] += local_flux[1, s]
+                shared_flux[2, i, j, s] += local_flux[2, s]
+                local_flux_3[s] += local_flux[3, s]
+            end
+
+            # Build "inside metrics" flux
+            @unroll for s in 1:num_state_conservative
+                F1, F2, F3 = shared_flux[1, i, j, s],
+                shared_flux[2, i, j, s],
+                local_flux_3[s]
+
+                shared_flux[1, i, j, s] =
+                    M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
                 if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                    local_tendency[s] +=
-                        MI * s_D[n, j] * shared_flux[2, i, n, k, s]
+                    shared_flux[2, i, j, s] =
+                        M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
                 end
-
-                # ξ3-grid lines
                 if dim == 3 && direction isa EveryDirection
-                    local_tendency[s] +=
-                        MI * s_D[n, k] * shared_flux[3, i, j, n, s]
+                    local_flux_3[s] = M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
+                end
+            end
+
+            if dim == 3 && direction isa EveryDirection
+                @unroll for n in 1:Nqk
+                    MI = local_MI[n]
+                    @unroll for s in 1:num_state_conservative
+                        local_tendency[n, s] += MI * s_D[k, n] * local_flux_3[s]
+                    end
+                end
+            end
+
+            fill!(local_source, -zero(eltype(local_source)))
+            source!(
+                balance_law,
+                Vars{vars_state_conservative(balance_law, FT)}(local_source),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
+                t,
+                direction,
+            )
+
+            @unroll for s in 1:num_state_conservative
+                local_tendency[k, s] += local_source[s]
+            end
+            @synchronize
+
+            # Weak "inside metrics" derivative
+            MI = local_MI[k]
+            @unroll for s in 1:num_state_conservative
+                @unroll for n in 1:Nq
+                    # ξ1-grid lines
+                    local_tendency[k, s] +=
+                        MI * s_D[n, i] * shared_flux[1, n, j, s]
+
+                    # ξ2-grid lines
+                    if dim == 3 || (dim == 2 && direction isa EveryDirection)
+                        local_tendency[k, s] +=
+                            MI * s_D[n, j] * shared_flux[2, i, n, s]
+                    end
                 end
             end
         end
-        ijk = i + Nq * ((j - 1) + Nq * (k - 1))
-        @unroll for s in 1:num_state_conservative
-            tendency[ijk, s, e] = local_tendency[s]
+
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            @unroll for s in 1:num_state_conservative
+                tendency[ijk, s, e] = local_tendency[k, s]
+            end
         end
     end
-    @synchronize
 end
 
 @kernel function volume_tendency!(
@@ -245,7 +267,6 @@ end
     elems,
     increment,
 ) where {dim, polyorder}
-
     @uniform begin
         N = polyorder
         FT = eltype(state_conservative)
@@ -268,135 +289,167 @@ end
         local_state_hyperdiffusion = MArray{Tuple{nhyperviscstate}, FT}(undef)
         local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_flux = MArray{Tuple{3, num_state_conservative}, FT}(undef)
+        local_flux_total = MArray{Tuple{3, num_state_conservative}, FT}(undef)
 
         _ζx1 = dim == 2 ? _ξ2x1 : _ξ3x1
         _ζx2 = dim == 2 ? _ξ2x2 : _ξ3x2
         _ζx3 = dim == 2 ? _ξ2x3 : _ξ3x3
+
+        shared_flux_size =
+            dim == 2 ? (Nq, Nq, num_state_conservative) : (0, 0, 0)
     end
 
-    shared_flux = @localmem FT (3, Nq, Nq, Nqk, num_state_conservative)
-    s_ω = @localmem FT (Nq,)
+    local_tendency = @private FT (Nqk, num_state_conservative)
+    local_MI = @private FT (Nqk,)
+
+    shared_flux = @localmem FT shared_flux_size
     s_D = @localmem FT (Nq, Nq)
-    local_tendency = @private FT (num_state_conservative,)
 
     e = @index(Group, Linear)
-    i, j, k = @index(Local, NTuple)
-    ijk = @index(Local, Linear)
+    i, j = @index(Local, NTuple)
 
     @inbounds begin
-        s_ω[j] = ω[j]
         s_D[i, j] = D[i, j]
 
-        M = vgeo[ijk, _M, e]
-        ζx1 = vgeo[ijk, _ζx1, e]
-        ζx2 = vgeo[ijk, _ζx2, e]
-        ζx3 = vgeo[ijk, _ζx3, e]
-
-        @unroll for s in 1:num_state_conservative
-            local_tendency[s] = increment ? tendency[ijk, s, e] : zero(FT)
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            @unroll for s in 1:num_state_conservative
+                local_tendency[k, s] =
+                    increment ? tendency[ijk, s, e] : zero(FT)
+            end
+            local_MI[k] = vgeo[ijk, _MI, e]
         end
 
-        @unroll for s in 1:num_state_conservative
-            local_state_conservative[s] = state_conservative[ijk, s, e]
-        end
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
 
-        @unroll for s in 1:num_state_auxiliary
-            local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
-        end
+            M = vgeo[ijk, _M, e]
+            ζx1 = vgeo[ijk, _ζx1, e]
+            ζx2 = vgeo[ijk, _ζx2, e]
+            ζx3 = vgeo[ijk, _ζx3, e]
 
-        @unroll for s in 1:num_state_gradient_flux
-            local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
-        end
+            @unroll for s in 1:num_state_conservative
+                local_state_conservative[s] = state_conservative[ijk, s, e]
+            end
 
-        @unroll for s in 1:nhyperviscstate
-            local_state_hyperdiffusion[s] = Qhypervisc_grad[ijk, s, e]
-        end
+            @unroll for s in 1:num_state_auxiliary
+                local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
+            end
 
-        fill!(local_flux, -zero(eltype(local_flux)))
-        flux_first_order!(
-            balance_law,
-            Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(
-                local_state_conservative,
-            ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            t,
-        )
+            @unroll for s in 1:num_state_gradient_flux
+                local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
+            end
 
-        @unroll for s in 1:num_state_conservative
-            shared_flux[1, i, j, k, s] = local_flux[1, s]
-            shared_flux[2, i, j, k, s] = local_flux[2, s]
-            shared_flux[3, i, j, k, s] = local_flux[3, s]
-        end
+            @unroll for s in 1:nhyperviscstate
+                local_state_hyperdiffusion[s] = Qhypervisc_grad[ijk, s, e]
+            end
 
-        fill!(local_flux, -zero(eltype(local_flux)))
-        flux_second_order!(
-            balance_law,
-            Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(
-                local_state_conservative,
-            ),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(
-                local_state_gradient_flux,
-            ),
-            Vars{vars_hyperdiffusive(balance_law, FT)}(
-                local_state_hyperdiffusion,
-            ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            t,
-        )
+            fill!(local_flux, -zero(eltype(local_flux)))
+            flux_first_order!(
+                balance_law,
+                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
+                t,
+            )
 
-        @unroll for s in 1:num_state_conservative
-            shared_flux[1, i, j, k, s] += local_flux[1, s]
-            shared_flux[2, i, j, k, s] += local_flux[2, s]
-            shared_flux[3, i, j, k, s] += local_flux[3, s]
-        end
+            @unroll for s in 1:num_state_conservative
+                local_flux_total[1, s] = local_flux[1, s]
+                local_flux_total[2, s] = local_flux[2, s]
+                local_flux_total[3, s] = local_flux[3, s]
+            end
 
-        # Build "inside metrics" flux
-        @unroll for s in 1:num_state_conservative
-            F1, F2, F3 = shared_flux[1, i, j, k, s],
-            shared_flux[2, i, j, k, s],
-            shared_flux[3, i, j, k, s]
-            shared_flux[3, i, j, k, s] = M * (ζx1 * F1 + ζx2 * F2 + ζx3 * F3)
-        end
+            fill!(local_flux, -zero(eltype(local_flux)))
+            flux_second_order!(
+                balance_law,
+                Grad{vars_state_conservative(balance_law, FT)}(local_flux),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux,
+                ),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
+                t,
+            )
 
-        fill!(local_source, -zero(eltype(local_source)))
-        source!(
-            balance_law,
-            Vars{vars_state_conservative(balance_law, FT)}(local_source),
-            Vars{vars_state_conservative(balance_law, FT)}(
-                local_state_conservative,
-            ),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(
-                local_state_gradient_flux,
-            ),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            t,
-            direction,
-        )
+            @unroll for s in 1:num_state_conservative
+                local_flux_total[1, s] += local_flux[1, s]
+                local_flux_total[2, s] += local_flux[2, s]
+                local_flux_total[3, s] += local_flux[3, s]
+            end
 
-        @unroll for s in 1:num_state_conservative
-            local_tendency[s] += local_source[s]
-        end
-        @synchronize
-
-        # Weak "inside metrics" derivative
-        MI = vgeo[ijk, _MI, e]
-        @unroll for s in 1:num_state_conservative
-            @unroll for n in 1:Nq
+            # Build "inside metrics" flux
+            @unroll for s in 1:num_state_conservative
+                F1, F2, F3 = local_flux_total[1, s],
+                local_flux_total[2, s],
+                local_flux_total[3, s]
+                Fv = M * (ζx1 * F1 + ζx2 * F2 + ζx3 * F3)
                 if dim == 2
-                    Dnj = s_D[n, j]
-                    local_tendency[s] += MI * Dnj * shared_flux[3, i, n, k, s]
+                    shared_flux[i, j, s] = Fv
                 else
-                    Dnk = s_D[n, k]
-                    local_tendency[s] += MI * Dnk * shared_flux[3, i, j, n, s]
+                    local_flux_total[1, s] = Fv
+                end
+            end
+
+            if dim == 3
+                @unroll for n in 1:Nqk
+                    MI = local_MI[n]
+                    @unroll for s in 1:num_state_conservative
+                        local_tendency[n, s] +=
+                            MI * s_D[k, n] * local_flux_total[1, s]
+                    end
+                end
+            end
+
+            fill!(local_source, -zero(eltype(local_source)))
+            source!(
+                balance_law,
+                Vars{vars_state_conservative(balance_law, FT)}(local_source),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
+                t,
+                direction,
+            )
+
+            @unroll for s in 1:num_state_conservative
+                local_tendency[k, s] += local_source[s]
+            end
+
+            @synchronize(dim == 2)
+            if dim == 2
+                MI = local_MI[k]
+                @unroll for n in 1:Nq
+                    @unroll for s in 1:num_state_conservative
+                        local_tendency[k, s] +=
+                            MI * s_D[n, j] * shared_flux[i, n, s]
+                    end
                 end
             end
         end
-        @unroll for s in 1:num_state_conservative
-            tendency[ijk, s, e] = local_tendency[s]
+
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            @unroll for s in 1:num_state_conservative
+                tendency[ijk, s, e] = local_tendency[k, s]
+            end
         end
-        @synchronize
     end
 end
 
@@ -735,116 +788,148 @@ end
         local_transform = MArray{Tuple{ngradstate}, FT}(undef)
         local_state_gradient_flux =
             MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_transform_gradient = MArray{Tuple{3, ngradstate}, FT}(undef)
     end
 
-    shared_transform = @localmem FT (Nq, Nq, Nqk, ngradstate)
+    shared_transform = @localmem FT (Nq, Nq, ngradstate)
     s_D = @localmem FT (Nq, Nq)
 
-    local_state_conservative = @private FT (ngradtransformstate,)
-    local_state_auxiliary = @private FT (num_state_auxiliary,)
+    local_state_conservative = @private FT (ngradtransformstate, Nqk)
+    local_state_auxiliary = @private FT (num_state_auxiliary, Nqk)
+    local_transform_gradient = @private FT (3, ngradstate, Nqk)
+    Gξ3 = @private FT (ngradstate, Nqk)
 
     e = @index(Group, Linear)
-    i, j, k = @index(Local, NTuple)
-    ijk = @index(Local, Linear)
+    i, j = @index(Local, NTuple)
 
     @inbounds @views begin
         s_D[i, j] = D[i, j]
 
-        @unroll for s in 1:ngradtransformstate
-            local_state_conservative[s] = state_conservative[ijk, s, e]
-        end
-
-        @unroll for s in 1:num_state_auxiliary
-            local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
-        end
-
-        fill!(local_transform, -zero(eltype(local_transform)))
-        compute_gradient_argument!(
-            balance_law,
-            Vars{vars_state_gradient(balance_law, FT)}(local_transform),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
-            t,
-        )
-        @unroll for s in 1:ngradstate
-            shared_transform[i, j, k, s] = local_transform[s]
-        end
-        @synchronize
-
-        # Compute gradient of each state
-        ξ1x1, ξ1x2, ξ1x3 =
-            vgeo[ijk, _ξ1x1, e], vgeo[ijk, _ξ1x2, e], vgeo[ijk, _ξ1x3, e]
-        if dim == 3 || (dim == 2 && direction isa EveryDirection)
-            ξ2x1, ξ2x2, ξ2x3 =
-                vgeo[ijk, _ξ2x1, e], vgeo[ijk, _ξ2x2, e], vgeo[ijk, _ξ2x3, e]
-        end
-        if dim == 3 && direction isa EveryDirection
-            ξ3x1, ξ3x2, ξ3x3 =
-                vgeo[ijk, _ξ3x1, e], vgeo[ijk, _ξ3x2, e], vgeo[ijk, _ξ3x3, e]
-        end
-
-        @unroll for s in 1:ngradstate
-            Gξ1 = Gξ2 = Gξ3 = zero(FT)
-            @unroll for n in 1:Nq
-                Gξ1 += s_D[i, n] * shared_transform[n, j, k, s]
-                if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                    Gξ2 += s_D[j, n] * shared_transform[i, n, k, s]
-                end
-                if dim == 3 && direction isa EveryDirection
-                    Gξ3 += s_D[k, n] * shared_transform[i, j, n, s]
-                end
+        @unroll for k in 1:Nqk
+            @unroll for s in 1:ngradstate
+                local_transform_gradient[1, s, k] = -zero(FT)
+                local_transform_gradient[2, s, k] = -zero(FT)
+                local_transform_gradient[3, s, k] = -zero(FT)
+                Gξ3[s, k] = -zero(FT)
             end
-            local_transform_gradient[1, s] = ξ1x1 * Gξ1
-            local_transform_gradient[2, s] = ξ1x2 * Gξ1
-            local_transform_gradient[3, s] = ξ1x3 * Gξ1
-
-            if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                local_transform_gradient[1, s] += ξ2x1 * Gξ2
-                local_transform_gradient[2, s] += ξ2x2 * Gξ2
-                local_transform_gradient[3, s] += ξ2x3 * Gξ2
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            @unroll for s in 1:ngradtransformstate
+                local_state_conservative[s, k] = state_conservative[ijk, s, e]
             end
-
-            if dim == 3 && direction isa EveryDirection
-                local_transform_gradient[1, s] += ξ3x1 * Gξ3
-                local_transform_gradient[2, s] += ξ3x2 * Gξ3
-                local_transform_gradient[3, s] += ξ3x3 * Gξ3
+            @unroll for s in 1:num_state_auxiliary
+                local_state_auxiliary[s, k] = state_auxiliary[ijk, s, e]
             end
         end
 
-        @unroll for s in 1:ngradlapstate
-            Qhypervisc_grad[ijk, 3 * (s - 1) + 1, e] =
-                local_transform_gradient[1, hypervisc_indexmap[s]]
-            Qhypervisc_grad[ijk, 3 * (s - 1) + 2, e] =
-                local_transform_gradient[2, hypervisc_indexmap[s]]
-            Qhypervisc_grad[ijk, 3 * (s - 1) + 3, e] =
-                local_transform_gradient[3, hypervisc_indexmap[s]]
-        end
-
-        if num_state_gradient_flux > 0
-            fill!(
-                local_state_gradient_flux,
-                -zero(eltype(local_state_gradient_flux)),
-            )
-            compute_gradient_flux!(
+        @unroll for k in 1:Nqk
+            fill!(local_transform, -zero(eltype(local_transform)))
+            compute_gradient_argument!(
                 balance_law,
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
-                    local_state_gradient_flux,
-                ),
-                Grad{vars_state_gradient(balance_law, FT)}(
-                    local_transform_gradient,
-                ),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
+                Vars{vars_state_gradient(balance_law, FT)}(local_transform),
+                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                    :,
+                    k,
+                ]),
+                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                    :,
+                    k,
+                ]),
                 t,
             )
+            @unroll for s in 1:ngradstate
+                shared_transform[i, j, s] = local_transform[s]
+            end
+            @synchronize
 
-            @unroll for s in 1:num_state_gradient_flux
-                state_gradient_flux[ijk, s, e] = local_state_gradient_flux[s]
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            ξ1x1, ξ1x2, ξ1x3 =
+                vgeo[ijk, _ξ1x1, e], vgeo[ijk, _ξ1x2, e], vgeo[ijk, _ξ1x3, e]
+
+            # Compute gradient of each state
+            @unroll for s in 1:ngradstate
+                Gξ1 = Gξ2 = zero(FT)
+
+                @unroll for n in 1:Nq
+                    Gξ1 += s_D[i, n] * shared_transform[n, j, s]
+                    if dim == 3 || (dim == 2 && direction isa EveryDirection)
+                        Gξ2 += s_D[j, n] * shared_transform[i, n, s]
+                    end
+                    if dim == 3 && direction isa EveryDirection
+                        Gξ3[s, n] += s_D[n, k] * shared_transform[i, j, s]
+                    end
+                end
+
+                local_transform_gradient[1, s, k] += ξ1x1 * Gξ1
+                local_transform_gradient[2, s, k] += ξ1x2 * Gξ1
+                local_transform_gradient[3, s, k] += ξ1x3 * Gξ1
+
+                if dim == 3 || (dim == 2 && direction isa EveryDirection)
+                    ξ2x1, ξ2x2, ξ2x3 = vgeo[ijk, _ξ2x1, e],
+                    vgeo[ijk, _ξ2x2, e],
+                    vgeo[ijk, _ξ2x3, e]
+                    local_transform_gradient[1, s, k] += ξ2x1 * Gξ2
+                    local_transform_gradient[2, s, k] += ξ2x2 * Gξ2
+                    local_transform_gradient[3, s, k] += ξ2x3 * Gξ2
+                end
+            end
+            @synchronize
+        end
+
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+
+            if dim == 3 && direction isa EveryDirection
+                ξ3x1, ξ3x2, ξ3x3 = vgeo[ijk, _ξ3x1, e],
+                vgeo[ijk, _ξ3x2, e],
+                vgeo[ijk, _ξ3x3, e]
+                @unroll for s in 1:ngradstate
+                    local_transform_gradient[1, s, k] += ξ3x1 * Gξ3[s, k]
+                    local_transform_gradient[2, s, k] += ξ3x2 * Gξ3[s, k]
+                    local_transform_gradient[3, s, k] += ξ3x3 * Gξ3[s, k]
+                end
+            end
+
+            @unroll for s in 1:ngradlapstate
+                Qhypervisc_grad[ijk, 3 * (s - 1) + 1, e] =
+                    local_transform_gradient[1, hypervisc_indexmap[s], k]
+                Qhypervisc_grad[ijk, 3 * (s - 1) + 2, e] =
+                    local_transform_gradient[2, hypervisc_indexmap[s], k]
+                Qhypervisc_grad[ijk, 3 * (s - 1) + 3, e] =
+                    local_transform_gradient[3, hypervisc_indexmap[s], k]
+            end
+
+            if num_state_gradient_flux > 0
+                fill!(
+                    local_state_gradient_flux,
+                    -zero(eltype(local_state_gradient_flux)),
+                )
+                compute_gradient_flux!(
+                    balance_law,
+                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                        local_state_gradient_flux,
+                    ),
+                    Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient[
+                        :,
+                        :,
+                        k,
+                    ]),
+                    Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                        :,
+                        k,
+                    ]),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                        :,
+                        k,
+                    ]),
+                    t,
+                )
+
+                @unroll for s in 1:num_state_gradient_flux
+                    state_gradient_flux[ijk, s, e] =
+                        local_state_gradient_flux[s]
+                end
             end
         end
     end
-    @synchronize
 end
 
 @kernel function volume_gradients!(
@@ -871,106 +956,156 @@ end
         ngradlapstate = num_gradient_laplacian(balance_law, FT)
         num_state_gradient_flux = number_state_gradient_flux(balance_law, FT)
         num_state_auxiliary = number_state_auxiliary(balance_law, FT)
-        ngradtransformstate = num_state_conservative
 
         Nq = N + 1
 
         Nqk = dim == 2 ? 1 : Nq
+
+        ngradtransformstate = num_state_conservative
+
         local_transform = MArray{Tuple{ngradstate}, FT}(undef)
         local_state_gradient_flux =
             MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_transform_gradient = MArray{Tuple{3, ngradstate}, FT}(undef)
 
         _ζx1 = dim == 2 ? _ξ2x1 : _ξ3x1
         _ζx2 = dim == 2 ? _ξ2x2 : _ξ3x2
         _ζx3 = dim == 2 ? _ξ2x3 : _ξ3x3
+
+        Gζ_size = dim == 3 ? (ngradstate, Nqk) : (0, 0)
     end
 
-    shared_transform = @localmem FT (Nq, Nq, Nqk, ngradstate)
+    shared_transform = @localmem FT (Nq, Nq, ngradstate)
     s_D = @localmem FT (Nq, Nq)
 
-    local_state_conservative = @private FT (ngradtransformstate,)
-    local_state_auxiliary = @private FT (num_state_auxiliary,)
+    local_state_conservative = @private FT (ngradtransformstate, Nqk)
+    local_state_auxiliary = @private FT (num_state_auxiliary, Nqk)
+    local_transform_gradient = @private FT (3, ngradstate, Nqk)
+
+    local_ζ = @private FT (3, Nqk)
+
+    Gζ = @private FT Gζ_size
 
     e = @index(Group, Linear)
-    i, j, k = @index(Local, NTuple)
-    ijk = @index(Local, Linear)
+    i, j = @index(Local, NTuple)
 
     @inbounds @views begin
         s_D[i, j] = D[i, j]
 
-        @unroll for s in 1:ngradtransformstate
-            local_state_conservative[s] = state_conservative[ijk, s, e]
-        end
-
-        @unroll for s in 1:num_state_auxiliary
-            local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
-        end
-
-        fill!(local_transform, -zero(eltype(local_transform)))
-        compute_gradient_argument!(
-            balance_law,
-            Vars{vars_state_gradient(balance_law, FT)}(local_transform),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
-            Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
-            t,
-        )
-        @unroll for s in 1:ngradstate
-            shared_transform[i, j, k, s] = local_transform[s]
-        end
-        @synchronize
-
-        # Compute gradient of each state
-        ζx1 = vgeo[ijk, _ζx1, e]
-        ζx2 = vgeo[ijk, _ζx2, e]
-        ζx3 = vgeo[ijk, _ζx3, e]
-
-        @unroll for s in 1:ngradstate
-            Gζ = zero(FT)
-            @unroll for n in 1:Nq
-                if dim == 2
-                    Gζ += s_D[j, n] * shared_transform[i, n, k, s]
-                elseif dim == 3
-                    Gζ += s_D[k, n] * shared_transform[i, j, n, s]
+        @unroll for k in 1:Nqk
+            @unroll for s in 1:ngradstate
+                local_transform_gradient[1, s, k] = -zero(FT)
+                local_transform_gradient[2, s, k] = -zero(FT)
+                local_transform_gradient[3, s, k] = -zero(FT)
+                if dim == 3
+                    Gζ[s, k] = -zero(FT)
                 end
             end
-            local_transform_gradient[1, s] = ζx1 * Gζ
-            local_transform_gradient[2, s] = ζx2 * Gζ
-            local_transform_gradient[3, s] = ζx3 * Gζ
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+            @unroll for s in 1:ngradtransformstate
+                local_state_conservative[s, k] = state_conservative[ijk, s, e]
+            end
+            @unroll for s in 1:num_state_auxiliary
+                local_state_auxiliary[s, k] = state_auxiliary[ijk, s, e]
+            end
+            local_ζ[1, k] = vgeo[ijk, _ζx1, e]
+            local_ζ[2, k] = vgeo[ijk, _ζx2, e]
+            local_ζ[3, k] = vgeo[ijk, _ζx3, e]
         end
 
-        @unroll for s in 1:ngradlapstate
-            Qhypervisc_grad[ijk, 3 * (s - 1) + 1, e] =
-                local_transform_gradient[1, hypervisc_indexmap[s]]
-            Qhypervisc_grad[ijk, 3 * (s - 1) + 2, e] =
-                local_transform_gradient[2, hypervisc_indexmap[s]]
-            Qhypervisc_grad[ijk, 3 * (s - 1) + 3, e] =
-                local_transform_gradient[3, hypervisc_indexmap[s]]
-        end
-
-        if num_state_gradient_flux > 0
-            fill!(
-                local_state_gradient_flux,
-                -zero(eltype(local_state_gradient_flux)),
-            )
-            compute_gradient_flux!(
+        @unroll for k in 1:Nqk
+            fill!(local_transform, -zero(eltype(local_transform)))
+            compute_gradient_argument!(
                 balance_law,
-                Vars{vars_state_gradient_flux(balance_law, FT)}(
-                    local_state_gradient_flux,
-                ),
-                Grad{vars_state_gradient(balance_law, FT)}(
-                    local_transform_gradient,
-                ),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
+                Vars{vars_state_gradient(balance_law, FT)}(local_transform),
+                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                    :,
+                    k,
+                ]),
+                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                    :,
+                    k,
+                ]),
                 t,
             )
+            @unroll for s in 1:ngradstate
+                shared_transform[i, j, s] = local_transform[s]
+            end
+            @synchronize
+
+            # Compute gradient of each state
+            @unroll for s in 1:ngradstate
+                if dim == 2
+                    Gζ = zero(FT)
+                    @unroll for n in 1:Nq
+                        Gζ += s_D[j, n] * shared_transform[i, n, s]
+                    end
+                    local_transform_gradient[1, s, k] += local_ζ[1, k] * Gζ
+                    local_transform_gradient[2, s, k] += local_ζ[2, k] * Gζ
+                    local_transform_gradient[3, s, k] += local_ζ[3, k] * Gζ
+                else
+                    @unroll for n in 1:Nq
+                        Gζ[s, n] += s_D[n, k] * shared_transform[i, j, s]
+                    end
+                end
+            end
+            @synchronize
         end
 
-        @unroll for s in 1:num_state_gradient_flux
-            state_gradient_flux[ijk, s, e] = local_state_gradient_flux[s]
+        @unroll for k in 1:Nqk
+            ijk = i + Nq * ((j - 1) + Nq * (k - 1))
+
+            if dim == 3
+                @unroll for s in 1:ngradstate
+                    local_transform_gradient[1, s, k] +=
+                        local_ζ[1, k] * Gζ[s, k]
+                    local_transform_gradient[2, s, k] +=
+                        local_ζ[2, k] * Gζ[s, k]
+                    local_transform_gradient[3, s, k] +=
+                        local_ζ[3, k] * Gζ[s, k]
+                end
+            end
+
+            @unroll for s in 1:ngradlapstate
+                Qhypervisc_grad[ijk, 3 * (s - 1) + 1, e] =
+                    local_transform_gradient[1, hypervisc_indexmap[s], k]
+                Qhypervisc_grad[ijk, 3 * (s - 1) + 2, e] =
+                    local_transform_gradient[2, hypervisc_indexmap[s], k]
+                Qhypervisc_grad[ijk, 3 * (s - 1) + 3, e] =
+                    local_transform_gradient[3, hypervisc_indexmap[s], k]
+            end
+
+            if num_state_gradient_flux > 0
+                fill!(
+                    local_state_gradient_flux,
+                    -zero(eltype(local_state_gradient_flux)),
+                )
+                compute_gradient_flux!(
+                    balance_law,
+                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                        local_state_gradient_flux,
+                    ),
+                    Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient[
+                        :,
+                        :,
+                        k,
+                    ]),
+                    Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[
+                        :,
+                        k,
+                    ]),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[
+                        :,
+                        k,
+                    ]),
+                    t,
+                )
+
+                @unroll for s in 1:num_state_gradient_flux
+                    state_gradient_flux[ijk, s, e] =
+                        local_state_gradient_flux[s]
+                end
+            end
         end
-        @synchronize
     end
 end
 
@@ -1281,8 +1416,9 @@ end
     l_state = MArray{Tuple{num_state_conservative}, FT}(undef)
     local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
 
-    e = @index(Group, Linear)
-    n = @index(Local, Linear)
+    I = @index(Global, Linear)
+    e = (I - 1) ÷ Np + 1
+    n = (I - 1) % Np + 1
 
     @inbounds begin
         coords = SVector(vgeo[n, _x1, e], vgeo[n, _x2, e], vgeo[n, _x3, e])
@@ -1331,8 +1467,9 @@ See [`BalanceLaw`](@ref) for usage.
 
     local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
 
-    e = @index(Group, Linear)
-    n = @index(Local, Linear)
+    I = @index(Global, Linear)
+    e = (I - 1) ÷ Np + 1
+    n = (I - 1) % Np + 1
 
     @inbounds begin
         @unroll for s in 1:num_state_auxiliary
@@ -1381,8 +1518,9 @@ Update the auxiliary state array
     local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
     local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
 
-    eI = @index(Group, Linear)
-    n = @index(Local, Linear)
+    I = @index(Global, Linear)
+    eI = (I - 1) ÷ Np + 1
+    n = (I - 1) % Np + 1
 
     @inbounds begin
         e = elems[eI]
@@ -1444,8 +1582,9 @@ end
     local_state_gradient_flux =
         MArray{Tuple{num_state_gradient_flux}, FT}(undef)
 
-    eI = @index(Group, Linear)
-    n = @index(Local, Linear)
+    I = @index(Global, Linear)
+    eI = (I - 1) ÷ Np + 1
+    n = (I - 1) % Np + 1
 
     @inbounds begin
         e = elems[eI]

--- a/src/Numerics/DGmethods/balancelaw.jl
+++ b/src/Numerics/DGmethods/balancelaw.jl
@@ -163,7 +163,7 @@ function create_auxiliary_state(balance_law, grid)
     device = typeof(state_auxiliary.data) <: Array ? CPU() : CUDA()
     nrealelem = length(topology.realelems)
     event = Event(device)
-    event = kernel_init_state_auxiliary!(device, Np, Np * nrealelem)(
+    event = kernel_init_state_auxiliary!(device, min(Np, 1024), Np * nrealelem)(
         balance_law,
         Val(dim),
         Val(polyorder),

--- a/src/Utilities/VariableTemplates/VariableTemplates.jl
+++ b/src/Utilities/VariableTemplates/VariableTemplates.jl
@@ -194,7 +194,11 @@ Base.similar(g::Grad{S, A, offset}) where {S, A, offset} =
     v::Grad{S, A, offset},
     sym::Symbol,
 ) where {S, A, offset}
-    M = size(A, 1)
+    if A <: SubArray
+        M = size(fieldtype(A, 1), 1)
+    else
+        M = size(A, 1)
+    end
     expr = quote
         Base.@_inline_meta
         array = parent(v)
@@ -231,7 +235,11 @@ end
     sym::Symbol,
     val,
 ) where {S, A, offset}
-    M = size(A, 1)
+    if A <: SubArray
+        M = size(fieldtype(A, 1), 1)
+    else
+        M = size(A, 1)
+    end
     expr = quote
         Base.@_inline_meta
         array = parent(v)

--- a/test/Numerics/DGmethods/advection_diffusion/pseudo1D_heat_eqn.jl
+++ b/test/Numerics/DGmethods/advection_diffusion/pseudo1D_heat_eqn.jl
@@ -218,15 +218,15 @@ let
     expected_result[2, 1, Float32, VerticalDirection] = 2.0514704287052155e-02
     expected_result[2, 2, Float32, VerticalDirection] = 5.6839984608814120e-04
     expected_result[2, 3, Float32, VerticalDirection] = 1.0241863492410630e-05
-    expected_result[3, 1, Float32, EveryDirection] = 1.2601226335391402e-03
-    expected_result[3, 2, Float32, EveryDirection] = 2.2367596102412790e-05
-    expected_result[3, 3, Float32, EveryDirection] = 1.1315821211610455e-05
-    expected_result[3, 1, Float32, HorizontalDirection] = 5.1570408977568150e-03
-    expected_result[3, 2, Float32, HorizontalDirection] = 6.6678490838967264e-05
-    expected_result[3, 3, Float32, HorizontalDirection] = 9.9300414149183780e-05
-    expected_result[3, 1, Float32, VerticalDirection] = 2.0514601841568947e-02
-    expected_result[3, 2, Float32, VerticalDirection] = 5.6837650481611490e-04
-    expected_result[3, 3, Float32, VerticalDirection] = 3.2248572097159922e-05
+    expected_result[3, 1, Float32, EveryDirection] = 1.2601461494341493e-03
+    expected_result[3, 2, Float32, EveryDirection] = 2.2380427253665403e-05
+    expected_result[3, 3, Float32, EveryDirection] = 1.1313175491522998e-05
+    expected_result[3, 1, Float32, HorizontalDirection] = 5.1570334471762180e-03
+    expected_result[3, 2, Float32, HorizontalDirection] = 6.6673339460976422e-05
+    expected_result[3, 3, Float32, HorizontalDirection] = 9.9301614682190120e-05
+    expected_result[3, 1, Float32, VerticalDirection] = 2.0514605566859245e-02
+    expected_result[3, 2, Float32, VerticalDirection] = 5.6837813463062048e-04
+    expected_result[3, 3, Float32, VerticalDirection] = 3.2253094104817137e-05
 
     @testset "$(@__FILE__)" begin
         for FT in (Float64, Float32)


### PR DESCRIPTION
# Description

Adds support for higher order (polynomial order up to 22) DG on the GPU. Closes #502.

- `volumerhs!` and `volumeviscterms!` DG kernels were modified to use less shared memory
- `Grad` wrapper was modified to support views
- Argument order of the main computational kernels was changed slightly to have output arrays near the beginning and all non-modified arrays afterwards
<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
