### PR TITLE
potential fix for pcg test

### DIFF
--- a/test/Numerics/LinearSolvers/cg.jl
+++ b/test/Numerics/LinearSolvers/cg.jl
@@ -7,6 +7,7 @@ using CLIMA
 using CLIMA.LinearSolvers
 using CLIMA.ConjugateGradientSolver
 using CLIMA.MPIStateArrays
+using CUDAapi
 using Random
 Random.seed!(1235)
 
@@ -48,18 +49,22 @@ let
         @test norm(A * x - b) / norm(b) < err_thresh
     end
 
-    at_A = ArrayType(A)
-    at_b = ArrayType(b)
-    at_x = ArrayType(ones(n) * 1.0)
-    mulbyat_A!(y, x) = (y .= at_A * x)
-    at_method(b, tol) = ConjugateGradient(b, max_iter = n)
-    linearsolver = at_method(at_b, tol)
-    iters = linearsolve!(mulbyat_A!, linearsolver, at_x, at_b; max_iters = n)
-    exact = at_A \ at_b
+    # Testing for CuArrays
+    if CUDAapi.has_cuda_gpu()
+        at_A = ArrayType(A)
+        at_b = ArrayType(b)
+        at_x = ArrayType(ones(n) * 1.0)
+        mulbyat_A!(y, x) = (y .= at_A * x)
+        at_method(b, tol) = ConjugateGradient(b, max_iter = n)
+        linearsolver = at_method(at_b, tol)
+        iters =
+            linearsolve!(mulbyat_A!, linearsolver, at_x, at_b; max_iters = n)
+        exact = at_A \ at_b
 
-    @testset "Architecture-specific Array test" begin
-        @test norm(at_x - exact) / norm(exact) < err_thresh
-        @test norm(at_A * at_x - at_b) / norm(at_b) < err_thresh
+        @testset "CuArray test" begin
+            @test norm(at_x - exact) / norm(exact) < err_thresh
+            @test norm(at_A * at_x - at_b) / norm(at_b) < err_thresh
+        end
     end
 
     mpi_b = MPIStateArray{T}(mpicomm, ArrayType, 4, 4, 4)
@@ -75,6 +80,7 @@ let
     end
 
     mpi_b.data[:] .= ArrayType(randn(4^3))
+    mpi_x.data[:] .= ArrayType(randn(4^3))
 
     mpi_method(mpi_b, tol) = ConjugateGradient(mpi_b, max_iter = n)
     linearsolver = mpi_method(mpi_b, tol)


### PR DESCRIPTION
# Description

The CI was failing for the pcg test. This seems to be because the mpi_x variable was initialized with some NaNs already in it. This fixes that and also sets the "Architecture-specific Array test" to no longer run when Arrays have already been tested on CPU-only devices.

[Example for failed CI on Mac](https://dev.azure.com/climate-machine/CLIMA/_build/results?buildId=3445&view=results) (#998)

We might want to talk about how MPIStateArrays are initialized with whatever is in memory. Maybe they should be initialized as all 0s?

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
