### PR TITLE
Make Bors depend on Docs

### DIFF
--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - master
+      - trying
+      - staging
     tags: '*'
   pull_request:
 
 jobs:
-  build:
+  docs-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
 status = [
   "CLIMA",
+  "docs-build",
   "ci/slurmci"
 ]
 delete_merged_branches = true


### PR DESCRIPTION
# Description

This PR tells Bors to check that the doc-build is passing.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
