### PR TITLE
Bugfix -(issue #1009)

### DIFF
--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -72,8 +72,6 @@ function flux_radiation!(
     t::Real,
 ) end
 
-
-
 # ------------------------ Begin Radiation Model ---------------------- #
 """
   DYCOMSRadiation <: RadiationModel
@@ -112,9 +110,9 @@ function integral_load_aux!(
     FT = eltype(state)
     integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
 end
-function integral_set_aux!(m::DYCOMSRadiation, aux::Vars, integrand::Vars)
-    integrand = integrand.radiation.attenuation_coeff
-    aux.∫dz.radiation.attenuation_coeff = integrand
+function integral_set_aux!(m::DYCOMSRadiation, aux::Vars, integral::Vars)
+    integral = integral.radiation.attenuation_coeff
+    aux.∫dz.radiation.attenuation_coeff = integral
 end
 
 vars_reverse_integrals(m::DYCOMSRadiation, FT) = @vars(attenuation_coeff::FT)
@@ -125,14 +123,15 @@ function reverse_integral_load_aux!(
     aux::Vars,
 )
     FT = eltype(state)
-    integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
+    #integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
+    integrand.radiation.attenuation_coeff = aux.∫dz.radiation.attenuation_coeff
 end
 function reverse_integral_set_aux!(
     m::DYCOMSRadiation,
     aux::Vars,
-    integrand::Vars,
+    integral::Vars,
 )
-    aux.∫dnz.radiation.attenuation_coeff = integrand.radiation.attenuation_coeff
+    aux.∫dnz.radiation.attenuation_coeff = integral.radiation.attenuation_coeff
 end
 
 function flux_radiation!(

--- a/src/Numerics/DGmethods/DGmodel_kernels.jl
+++ b/src/Numerics/DGmethods/DGmodel_kernels.jl
@@ -1451,7 +1451,7 @@ end
                 reverse_integral_load_aux!(
                     bl,
                     Vars{vars_reverse_integrals(bl, FT)}(l_V),
-                    Vars{vars_state(bl, FT)}(view(state, ijk, :, et)),
+                    Vars{vars_state(bl, FT)}(view(state, ijk, :, e)),
                     Vars{vars_aux(bl, FT)}(view(auxstate, ijk, :, e)),
                 )
                 l_V .= l_T .- l_V


### PR DESCRIPTION
Bugfix - (var naming + assignment in integral_load_aux)	
        modified:   experiments/AtmosLES/dycoms.jl
Bugfix - (element access within reverse integral kernel)
	modified:   src/Numerics/DGmethods/DGmodel_kernels.jl

# Description

Fixes issue with `reverse_integral` #1009. 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
