### PR TITLE
Fix docs `generate_tutorials` logic

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -1,68 +1,63 @@
 ####
-#### Defines list of tutorials given `tutorials_dir` and `generated_dir`
+#### Defines list of tutorials given `generated_dir`
 ####
 
-# generate tutorials
-import Literate
+generate_tutorials = true
 
-tutorials_files = [
-    joinpath(root, f)
-    for (root, dirs, files) in Base.Filesystem.walkdir(tutorials_dir)
-    for f in files
-]
-
-filter!(x -> !occursin("topo.jl", x), tutorials_files)                       # currently broken, TODO: Fix me!
-filter!(x -> !occursin("dry_rayleigh_benard.jl", x), tutorials_files)        # currently broken, TODO: Fix me!
-filter!(x -> !occursin("ex_001_periodic_advection.jl", x), tutorials_files)  # currently broken, TODO: Fix me!
-filter!(x -> !occursin("ex_002_solid_body_rotation.jl", x), tutorials_files) # currently broken, TODO: Fix me!
-filter!(x -> !occursin("ex_003_acoustic_wave.jl", x), tutorials_files)       # currently broken, TODO: Fix me!
-filter!(x -> !occursin("ex_004_nonnegative.jl", x), tutorials_files)         # currently broken, TODO: Fix me!
-filter!(x -> !occursin("KinematicModel.jl", x), tutorials_files)             # currently broken, TODO: Fix me!
-filter!(x -> !occursin("ex_1_saturation_adjustment.jl", x), tutorials_files) # currently broken, TODO: Fix me!
-filter!(x -> !occursin("ex_2_Kessler.jl", x), tutorials_files)               # currently broken, TODO: Fix me!
-
-println("Building literate tutorials:")
-for e in tutorials_files
-    println("    $(e)")
-end
-
-for tutorial in tutorials_files
-    gen_dir = joinpath(generated_dir, relpath(dirname(tutorial), tutorials_dir))
-    input = abspath(tutorial)
-    script = Literate.script(input, gen_dir)
-    code = strip(read(script, String))
-    mdpost(str) = replace(str, "@__CODE__" => code)
-    Literate.markdown(input, gen_dir, postprocess = mdpost)
-    # Literate.notebook(input, gen_dir, execute = true)
-end
-
-tutorials = [
-    joinpath(root, f)
-    for (root, dirs, files) in Base.Filesystem.walkdir(generated_dir)
-    for f in files
-]
-tutorials =
-    map(x -> last(split(x, joinpath("docs", "src", "generated"))), tutorials)
-# @show tutorials
-
-# TODO: Can/should we construct this Dict automatically?
-# We could use `titlecase(replace(basename(x), "_"=>" "))` such that
-# the title for `conjugate_gradient.jl` is `Conjugate Gradient`
-
-# These files mirror the .jl files in `CLIMA/tutorials/`:
-tutorials = Any[
-    "Atmos" => Any["Dry Idealized GCM" => "generated/Atmos/heldsuarez.md",],
-    "Ocean" => Any[],
-    "Numerics" => Any[
-        "LinearSolvers" => Any["Conjugate Gradient" => "generated/Numerics/LinearSolvers/cg.md",],
-        "Contributing" => Any["Notes on Literate" => "generated/literate_markdown.md",],
-    ],
-]
+tutorials = Any[]
 
 # Allow flag to skip generated
 # tutorials since this is by
 # far the slowest part of the
 # docs build.
-if !generate_tutorials
-    tutorials = Any[]
+if generate_tutorials
+
+    tutorials_dir = joinpath(@__DIR__, "..", "tutorials")      # julia src files
+
+    # generate tutorials
+    import Literate
+
+    tutorials_jl = [
+        joinpath(root, f)
+        for (root, dirs, files) in Base.Filesystem.walkdir(tutorials_dir)
+        for f in files
+    ]
+
+    filter!(x -> !occursin("topo.jl", x), tutorials_jl)                       # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("dry_rayleigh_benard.jl", x), tutorials_jl)        # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("ex_001_periodic_advection.jl", x), tutorials_jl)  # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("ex_002_solid_body_rotation.jl", x), tutorials_jl) # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("ex_003_acoustic_wave.jl", x), tutorials_jl)       # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("ex_004_nonnegative.jl", x), tutorials_jl)         # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("KinematicModel.jl", x), tutorials_jl)             # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("ex_1_saturation_adjustment.jl", x), tutorials_jl) # currently broken, TODO: Fix me!
+    filter!(x -> !occursin("ex_2_Kessler.jl", x), tutorials_jl)               # currently broken, TODO: Fix me!
+
+    println("Building literate tutorials:")
+    for tutorial in tutorials_jl
+        println("    $(tutorial)")
+    end
+
+    for tutorial in tutorials_jl
+        gen_dir = joinpath(generated_dir, relpath(dirname(tutorial), tutorials_dir))
+        input = abspath(tutorial)
+        script = Literate.script(input, gen_dir)
+        code = strip(read(script, String))
+        mdpost(str) = replace(str, "@__CODE__" => code)
+        Literate.markdown(input, gen_dir, postprocess = mdpost)
+        # Literate.notebook(input, gen_dir, execute = true)
+    end
+
+    # TODO: Should we use AutoPages.jl?
+
+    # These files mirror the .jl files in `CLIMA/tutorials/`:
+    tutorials = Any[
+        "Atmos" => Any["Dry Idealized GCM" => "generated/Atmos/heldsuarez.md",],
+        "Ocean" => Any[],
+        "Numerics" => Any[
+            "LinearSolvers" => Any["Conjugate Gradient" => "generated/Numerics/LinearSolvers/cg.md",],
+            "Contributing" => Any["Notes on Literate" => "generated/literate_markdown.md",],
+        ],
+    ]
+
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,12 +2,10 @@ Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[]) # JuliaLang/julia/pull/28625
 
 using CLIMA, Documenter, Literate
 
-tutorials_dir = joinpath(@__DIR__, "..", "tutorials")      # julia src files
 generated_dir = joinpath(@__DIR__, "src", "generated") # generated files directory
 mkpath(generated_dir)
-generate_tutorials = true
 
-include("list_of_tutorials.jl")           # defines a dict `tutorials`
+include("list_of_tutorials.jl")          # defines a dict `tutorials`
 include("list_of_extending_clima.jl")    # defines a dict `extending_clima`
 include("list_of_discussions.jl")        # defines a dict `apis`
 include("list_of_apis.jl")               # defines a dict `discussions`


### PR DESCRIPTION
# Description

Fixes logic of `generate_tutorials` Bool. Before this PR, tutorials are generated with `generate_tutorials=false`, but they are not included in the docs. After this PR, `generate_tutorials=false` will skip generating tutorials and the docs will reflect this.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
