### PR TITLE
Switch LES timestepper (experiments/bomex.jl and tutorials/dry_rayleigh_benard.jl)

### DIFF
--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -415,8 +415,13 @@ function config_bomex(FT, N, resolution, xmax, ymax, zmax)
         BomexGeostrophic{FT}(f_coriolis, u_geostrophic, u_slope, v_geostrophic),
     )
 
-    # Assemble timestepper components
-    ode_solver_type = CLIMA.DefaultSolverType()
+    # Choose multi-rate explicit solver
+    ode_solver_type = CLIMA.MultirateSolverType(
+        linear_model = AtmosAcousticGravityLinearModel,
+        slow_method = LSRK144NiegemannDiehlBusch,
+        fast_method = LSRK144NiegemannDiehlBusch,
+        timestep_ratio = 10,
+    )
 
     # Assemble model components
     model = AtmosModel{FT}(
@@ -488,7 +493,7 @@ function main()
     # For the test we set this to == 30 minutes
     timeend = FT(1800)
     #timeend = FT(3600 * 6)
-    CFLmax = FT(1.0)
+    CFLmax = FT(8)
 
     driver_config = config_bomex(FT, N, resolution, xmax, ymax, zmax)
     solver_config = CLIMA.SolverConfiguration(

--- a/tutorials/Atmos/dry_rayleigh_benard.jl
+++ b/tutorials/Atmos/dry_rayleigh_benard.jl
@@ -145,8 +145,14 @@ function config_problem(FT, N, resolution, xmax, ymax, zmax)
         init_state = init_problem!,
         data_config = data_config,
     )
-    ode_solver =
-        CLIMA.ExplicitSolverType(solver_method = LSRK144NiegemannDiehlBusch)
+
+    ode_solver = CLIMA.MultirateSolverType(
+        linear_model = AtmosAcousticGravityLinearModel,
+        slow_method = LSRK144NiegemannDiehlBusch,
+        fast_method = LSRK144NiegemannDiehlBusch,
+        timestep_ratio = 10,
+    )
+
     config = CLIMA.AtmosLESConfiguration(
         "DryRayleighBenardConvection",
         N,
@@ -177,7 +183,8 @@ function main()
     Δh = FT(10)
     # Time integrator setup
     t0 = FT(0)
-    CFLmax = FT(0.90)
+    # Courant number
+    CFLmax = FT(5)
     timeend = FT(1000)
     xmax, ymax, zmax = FT(250), FT(250), FT(500)
 


### PR DESCRIPTION
# Description

Replaces IMEX time stepper with MRRK as the default in 2 LES experiments. 

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
