### PR TITLE
Fix some diagnostics bugs

### DIFF
--- a/experiments/AtmosGCM/heldsuarez.jl
+++ b/experiments/AtmosGCM/heldsuarez.jl
@@ -150,7 +150,7 @@ function held_suarez_forcing!(
 end
 
 function config_diagnostics(FT, driver_config)
-    interval = "1000steps"
+    interval = "100000steps" # chosen to allow a single diagnostics collection
 
     _planet_radius = FT(planet_radius(param_set))
 

--- a/experiments/AtmosLES/bomex.jl
+++ b/experiments/AtmosLES/bomex.jl
@@ -465,8 +465,8 @@ end
 
 function config_diagnostics(driver_config)
     default_dgngrp =
-        setup_atmos_default_diagnostics("10000steps", driver_config.name)
-    core_dgngrp = setup_atmos_core_diagnostics("10000steps", driver_config.name)
+        setup_atmos_default_diagnostics("2500steps", driver_config.name)
+    core_dgngrp = setup_atmos_core_diagnostics("2500steps", driver_config.name)
     return CLIMA.DiagnosticsConfiguration([default_dgngrp, core_dgngrp])
 end
 

--- a/slurmci-test.toml
+++ b/slurmci-test.toml
@@ -1,6 +1,5 @@
 # Tests to be run by SLURM CI
 #
-# Each entry specifies the number of MPI ranks to use followed by the file to run
 
 cpu = [
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_advection_diffusion.jl", slurmargs = ["--ntasks=3"], args = [] },
@@ -49,11 +48,11 @@ gpu = [
   { file = "test/Numerics/DGmethods/advection_diffusion/pseudo1D_heat_eqn.jl", slurmargs = ["--ntasks=3"], args = ["--integration-testing"] },
   { file = "test/Numerics/DGmethods/advection_diffusion/periodic_3D_hyperdiffusion.jl", slurmargs = ["--ntasks=3"], args = ["--integration-testing"] },
   { file = "tutorials/Atmos/dry_rayleigh_benard.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = [] },
-  { file = "experiments/AtmosGCM/heldsuarez.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = [] },
+  { file = "experiments/AtmosGCM/heldsuarez.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = ["--diagnostics=default"] },
   { file = "experiments/AtmosLES/risingbubble.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "experiments/AtmosLES/surfacebubble.jl", slurmargs = ["--ntasks=3", "--time=01:30:00"], args = [] },
   { file = "experiments/AtmosLES/dycoms.jl", slurmargs = ["--ntasks=3"], args = [] },
-  { file = "experiments/AtmosLES/bomex.jl", slurmargs = ["--ntasks=3"], args = [] },
+  { file = "experiments/AtmosLES/bomex.jl", slurmargs = ["--ntasks=3"], args = ["--diagnostics=default"] },
   { file = "experiments/OceanBoxGCM/homogeneous_box.jl", slurmargs = ["--ntasks=3"], args = [] },
   { file = "experiments/OceanBoxGCM/ocean_gyre.jl", slurmargs = ["--ntasks=3"], args = [] },
 ]

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -248,36 +248,37 @@ macro visitQ(nhorzelem, nvertelem, Nqk, Nq, expr)
     end)
 end
 
-# Helpers to extract data from `Q`, etc.
-function extract_state(dg, localQ, ijk, e)
+# Helpers to extract data from the various state arrays
+function extract_state_conservative(dg, state_conservative, ijk, e)
     bl = dg.balancelaw
-    FT = eltype(localQ)
-    nstate = number_state_conservative(bl, FT)
-    l_Q = MArray{Tuple{nstate}, FT}(undef)
-    for s in 1:nstate
-        l_Q[s] = localQ[ijk, s, e]
+    FT = eltype(state_conservative)
+    num_state_conservative = number_state_conservative(bl, FT)
+    local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
+    for s in 1:num_state_conservative
+        local_state_conservative[s] = state_conservative[ijk, s, e]
     end
-    return Vars{vars_state_conservative(bl, FT)}(l_Q)
+    return Vars{vars_state_conservative(bl, FT)}(local_state_conservative)
 end
-function extract_aux(dg, state_auxiliary, ijk, e)
+function extract_state_auxiliary(dg, state_auxiliary, ijk, e)
     bl = dg.balancelaw
     FT = eltype(state_auxiliary)
-    nauxstate = number_state_auxiliary(bl, FT)
-    l_aux = MArray{Tuple{nauxstate}, FT}(undef)
-    for s in 1:nauxstate
-        l_aux[s] = state_auxiliary[ijk, s, e]
+    num_state_auxiliary = number_state_auxiliary(bl, FT)
+    local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+    for s in 1:num_state_auxiliary
+        local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
     end
-    return Vars{vars_state_auxiliary(bl, FT)}(l_aux)
+    return Vars{vars_state_auxiliary(bl, FT)}(local_state_auxiliary)
 end
-function extract_diffusion(dg, localdiff, ijk, e)
+function extract_state_gradient_flux(dg, state_gradient_flux, ijk, e)
     bl = dg.balancelaw
-    FT = eltype(localdiff)
-    ndiff = number_state_gradient_flux(bl, FT)
-    l_diff = MArray{Tuple{ndiff}, FT}(undef)
-    for s in 1:ndiff
-        l_diff[s] = localdiff[ijk, s, e]
+    FT = eltype(state_gradient_flux)
+    num_state_gradient_flux = number_state_gradient_flux(bl, FT)
+    local_state_gradient_flux =
+        MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+    for s in 1:num_state_gradient_flux
+        local_state_gradient_flux[s] = state_gradient_flux[ijk, s, e]
     end
-    return Vars{vars_state_gradient_flux(bl, FT)}(l_diff)
+    return Vars{vars_state_gradient_flux(bl, FT)}(local_state_gradient_flux)
 end
 
 include("atmos_common.jl")

--- a/src/Diagnostics/dump_state_and_aux.jl
+++ b/src/Diagnostics/dump_state_and_aux.jl
@@ -100,22 +100,24 @@ function dump_state_and_aux_collect(dgngrp, currtime)
         error("Dump of non-interpolated data currently unsupported")
     end
 
-    dims = get_dims(dgngrp)
+    if mpirank == 0
+        dims = get_dims(dgngrp)
+        dim_names = tuple(collect(keys(dims))...)
 
-    statevarvals = OrderedDict()
-    for i in 1:number_state_conservative(bl, FT)
-        statevarvals[statenames[i]] =
-            ((collect(keys(dims)),), all_state_data[:, :, :, i])
+        statevarvals = OrderedDict()
+        for i in 1:number_state_conservative(bl, FT)
+            statevarvals[statenames[i]] = (dim_names, all_state_data[:, :, :, i])
+        end
+        write_data(dgngrp.writer, statefilename, dims, statevarvals, currtime)
+
+        auxvarvals = OrderedDict()
+        for i in 1:number_state_auxiliary(bl, FT)
+            auxvarvals[auxnames[i]] = (dim_names, all_aux_data[:, :, :, i])
+        end
+        write_data(dgngrp.writer, auxfilename, dims, auxvarvals, currtime)
     end
-    write_data(dgngrp.writer, statefilename, dims, statevarvals, currtime)
 
-    auxvarvals = OrderedDict()
-    for i in 1:number_state_auxiliary(bl, FT)
-        auxvarvals[auxnames[i]] =
-            ((collect(keys(dims)),), all_aux_data[:, :, :, i])
-    end
-    write_data(dgngrp.writer, auxfilename, dims, auxvarvals, currtime)
-
+    MPI.Barrier(mpicomm)
     return nothing
 end
 

--- a/src/Driver/solver_configs.jl
+++ b/src/Driver/solver_configs.jl
@@ -104,7 +104,7 @@ function SolverConfiguration(
             Settings.restart_from_num,
         )
 
-        auxstate = restart_auxstate(bl, grid, s_aux)
+        state_auxiliary = restart_auxiliary_state(bl, grid, s_aux)
 
         dg = DGModel(
             bl,
@@ -112,7 +112,7 @@ function SolverConfiguration(
             numerical_flux_first_order,
             numerical_flux_second_order,
             numerical_flux_gradient,
-            state_auxiliary = auxstate,
+            state_auxiliary = state_auxiliary,
             diffusion_direction = diffdir,
             modeldata = modeldata,
         )

--- a/src/Numerics/DGmethods/DGmethods.jl
+++ b/src/Numerics/DGmethods/DGmethods.jl
@@ -10,7 +10,8 @@ using DocStringExtensions
 using KernelAbstractions
 using KernelAbstractions.Extras: @unroll
 
-export BalanceLaw, DGModel, init_ode_state, restart_ode_state, restart_auxstate
+export BalanceLaw,
+    DGModel, init_ode_state, restart_ode_state, restart_auxiliary_state
 
 include("balancelaw.jl")
 include("NumericalFluxes.jl")

--- a/src/Numerics/DGmethods/DGmodel.jl
+++ b/src/Numerics/DGmethods/DGmodel.jl
@@ -590,10 +590,10 @@ function restart_ode_state(dg::DGModel, state_data; init_on_cpu = false)
     return state
 end
 
-function restart_auxstate(bl, grid, aux_data)
-    auxstate = create_auxstate(bl, grid)
-    auxstate .= aux_data
-    return auxstate
+function restart_auxiliary_state(bl, grid, aux_data)
+    state_auxiliary = create_auxiliary_state(bl, grid)
+    state_auxiliary .= aux_data
+    return state_auxiliary
 end
 
 # fallback


### PR DESCRIPTION
# Description

A bug in 'DumpStateAndAux'. Also clean up some issues caused by the concurrent merge of 1019 and 961. Finally, enable diagnostics collection in two experiments on Slurm CI, to ensure all diagnostics groups run at least once on CI.

<!--- Please fill out the following section --->

I have

- [X] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [X] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
