### PR TITLE
Apply formatter to files modified in #961

### DIFF
--- a/experiments/AtmosLES/dycoms.jl
+++ b/experiments/AtmosLES/dycoms.jl
@@ -63,7 +63,11 @@ function reverse_integral_load_auxiliary_state!(
     state::Vars,
     aux::Vars,
 ) end
-function reverse_integral_set_auxiliary_state!(::RadiationModel, aux::Vars, integ::Vars) end
+function reverse_integral_set_auxiliary_state!(
+    ::RadiationModel,
+    aux::Vars,
+    integ::Vars,
+) end
 function flux_radiation!(
     ::RadiationModel,
     flux::Grad,
@@ -110,7 +114,11 @@ function integral_load_auxiliary_state!(
     FT = eltype(state)
     integrand.radiation.attenuation_coeff = state.ρ * m.κ * aux.moisture.q_liq
 end
-function integral_set_auxiliary_state!(m::DYCOMSRadiation, aux::Vars, integral::Vars)
+function integral_set_auxiliary_state!(
+    m::DYCOMSRadiation,
+    aux::Vars,
+    integral::Vars,
+)
     integral = integral.radiation.attenuation_coeff
     aux.∫dz.radiation.attenuation_coeff = integral
 end

--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -506,19 +506,36 @@ function update_auxiliary_state!(
         reverse_indefinite_stack_integral!(dg, m, Q, state_auxiliary, t, elems)
     end
 
-    nodal_update_auxiliary_state!(atmos_nodal_update_auxiliary_state!, dg, m, Q, t, elems)
+    nodal_update_auxiliary_state!(
+        atmos_nodal_update_auxiliary_state!,
+        dg,
+        m,
+        Q,
+        t,
+        elems,
+    )
 
     return true
 end
 
-function atmos_nodal_update_auxiliary_state!(m::AtmosModel, state::Vars, aux::Vars, t::Real)
+function atmos_nodal_update_auxiliary_state!(
+    m::AtmosModel,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
     atmos_nodal_update_auxiliary_state!(m.moisture, m, state, aux, t)
     atmos_nodal_update_auxiliary_state!(m.radiation, m, state, aux, t)
     atmos_nodal_update_auxiliary_state!(m.turbulence, m, state, aux, t)
     atmos_nodal_update_auxiliary_state!(m.tracers, m, state, aux, t)
 end
 
-function integral_load_auxiliary_state!(m::AtmosModel, integ::Vars, state::Vars, aux::Vars)
+function integral_load_auxiliary_state!(
+    m::AtmosModel,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+)
     integral_load_auxiliary_state!(m.radiation, integ, state, aux)
 end
 
@@ -535,7 +552,11 @@ function reverse_integral_load_auxiliary_state!(
     reverse_integral_load_auxiliary_state!(m.radiation, integ, state, aux)
 end
 
-function reverse_integral_set_auxiliary_state!(m::AtmosModel, aux::Vars, integ::Vars)
+function reverse_integral_set_auxiliary_state!(
+    m::AtmosModel,
+    aux::Vars,
+    integ::Vars,
+)
     reverse_integral_set_auxiliary_state!(m.radiation, aux, integ)
 end
 
@@ -599,7 +620,14 @@ Initialise state variables.
 `args...` provides an option to include configuration data
 (current use cases include problem constants, spline-interpolants)
 """ init_state_conservative!
-function init_state_conservative!(m::AtmosModel, state::Vars, aux::Vars, coords, t, args...)
+function init_state_conservative!(
+    m::AtmosModel,
+    state::Vars,
+    aux::Vars,
+    coords,
+    t,
+    args...,
+)
     m.init_state_conservative(m, state, aux, coords, t, args...)
 end
 end # module

--- a/src/Atmos/Model/boundaryconditions.jl
+++ b/src/Atmos/Model/boundaryconditions.jl
@@ -181,14 +181,24 @@ function atmos_normal_boundary_flux_second_order!(
         atmos,
         args...,
     )
-    atmos_energy_normal_boundary_flux_second_order!(nf, bc.energy, atmos, args...)
+    atmos_energy_normal_boundary_flux_second_order!(
+        nf,
+        bc.energy,
+        atmos,
+        args...,
+    )
     atmos_moisture_normal_boundary_flux_second_order!(
         nf,
         bc.moisture,
         atmos,
         args...,
     )
-    atmos_tracer_normal_boundary_flux_second_order!(nf, bc.tracer, atmos, args...)
+    atmos_tracer_normal_boundary_flux_second_order!(
+        nf,
+        bc.tracer,
+        atmos,
+        args...,
+    )
 end
 
 include("bc_momentum.jl")

--- a/src/Atmos/Model/linear.jl
+++ b/src/Atmos/Model/linear.jl
@@ -64,10 +64,12 @@ end
 
 abstract type AtmosLinearModel <: BalanceLaw end
 
-vars_state_conservative(lm::AtmosLinearModel, FT) = vars_state_conservative(lm.atmos, FT)
+vars_state_conservative(lm::AtmosLinearModel, FT) =
+    vars_state_conservative(lm.atmos, FT)
 vars_state_gradient(lm::AtmosLinearModel, FT) = @vars()
 vars_state_gradient_flux(lm::AtmosLinearModel, FT) = @vars()
-vars_state_auxiliary(lm::AtmosLinearModel, FT) = vars_state_auxiliary(lm.atmos, FT)
+vars_state_auxiliary(lm::AtmosLinearModel, FT) =
+    vars_state_auxiliary(lm.atmos, FT)
 vars_integrals(lm::AtmosLinearModel, FT) = @vars()
 vars_reverse_integrals(lm::AtmosLinearModel, FT) = @vars()
 
@@ -92,17 +94,25 @@ function flux_second_order!(
 )
     nothing
 end
-integral_load_auxiliary_state!(lm::AtmosLinearModel, integ::Vars, state::Vars, aux::Vars) =
+integral_load_auxiliary_state!(
+    lm::AtmosLinearModel,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+) = nothing
+integral_set_auxiliary_state!(lm::AtmosLinearModel, aux::Vars, integ::Vars) =
     nothing
-integral_set_auxiliary_state!(lm::AtmosLinearModel, aux::Vars, integ::Vars) = nothing
 reverse_integral_load_auxiliary_state!(
     lm::AtmosLinearModel,
     integ::Vars,
     state::Vars,
     aux::Vars,
 ) = nothing
-reverse_integral_set_auxiliary_state!(lm::AtmosLinearModel, aux::Vars, integ::Vars) =
-    nothing
+reverse_integral_set_auxiliary_state!(
+    lm::AtmosLinearModel,
+    aux::Vars,
+    integ::Vars,
+) = nothing
 flux_second_order!(
     lm::AtmosLinearModel,
     flux::Grad,
@@ -130,8 +140,15 @@ function boundary_state!(
 )
     nothing
 end
-init_state_auxiliary!(lm::AtmosLinearModel, aux::Vars, geom::LocalGeometry) = nothing
-init_state_conservative!(lm::AtmosLinearModel, state::Vars, aux::Vars, coords, t) = nothing
+init_state_auxiliary!(lm::AtmosLinearModel, aux::Vars, geom::LocalGeometry) =
+    nothing
+init_state_conservative!(
+    lm::AtmosLinearModel,
+    state::Vars,
+    aux::Vars,
+    coords,
+    t,
+) = nothing
 
 
 struct AtmosAcousticLinearModel{M} <: AtmosLinearModel

--- a/src/Atmos/Model/moisture.jl
+++ b/src/Atmos/Model/moisture.jl
@@ -23,7 +23,14 @@ function flux_moisture!(
     aux::Vars,
     t::Real,
 ) end
-function compute_gradient_flux!(::MoistureModel, diffusive, ∇transform, state, aux, t) end
+function compute_gradient_flux!(
+    ::MoistureModel,
+    diffusive,
+    ∇transform,
+    state,
+    aux,
+    t,
+) end
 function flux_second_order!(
     ::MoistureModel,
     flux::Grad,
@@ -141,7 +148,8 @@ EquilMoist{FT}(;
 vars_state_conservative(::EquilMoist, FT) = @vars(ρq_tot::FT)
 vars_state_gradient(::EquilMoist, FT) = @vars(q_tot::FT)
 vars_state_gradient_flux(::EquilMoist, FT) = @vars(∇q_tot::SVector{3, FT})
-vars_state_auxiliary(::EquilMoist, FT) = @vars(temperature::FT, θ_v::FT, q_liq::FT)
+vars_state_auxiliary(::EquilMoist, FT) =
+    @vars(temperature::FT, θ_v::FT, q_liq::FT)
 
 @inline function atmos_nodal_update_auxiliary_state!(
     moist::EquilMoist,

--- a/src/Atmos/Model/precipitation.jl
+++ b/src/Atmos/Model/precipitation.jl
@@ -75,7 +75,8 @@ struct Rain <: PrecipitationModel end
 vars_state_conservative(::Rain, FT) = @vars(ρq_rain::FT)
 vars_state_gradient(::Rain, FT) = @vars(q_rain::FT)
 vars_state_gradient_flux(::Rain, FT) = @vars(ρd_q_rain::SVector{3, FT})
-vars_state_auxiliary(::Rain, FT) = @vars(terminal_velocity::FT, src_q_rai_tot::FT)
+vars_state_auxiliary(::Rain, FT) =
+    @vars(terminal_velocity::FT, src_q_rai_tot::FT)
 
 function atmos_nodal_update_auxiliary_state!(
     rain::Rain,

--- a/src/Atmos/Model/radiation.jl
+++ b/src/Atmos/Model/radiation.jl
@@ -20,14 +20,22 @@ function integral_set_auxiliary_state!(
     state::Vars,
     aux::Vars,
 ) end
-function integral_load_auxiliary_state!(::RadiationModel, aux::Vars, integ::Vars) end
+function integral_load_auxiliary_state!(
+    ::RadiationModel,
+    aux::Vars,
+    integ::Vars,
+) end
 function reverse_integral_set_auxiliary_state!(
     ::RadiationModel,
     integ::Vars,
     state::Vars,
     aux::Vars,
 ) end
-function reverse_integral_load_auxiliary_state!(::RadiationModel, aux::Vars, integ::Vars) end
+function reverse_integral_load_auxiliary_state!(
+    ::RadiationModel,
+    aux::Vars,
+    integ::Vars,
+) end
 function flux_radiation!(
     ::RadiationModel,
     atmos::AtmosModel,

--- a/src/Atmos/Model/remainder.jl
+++ b/src/Atmos/Model/remainder.jl
@@ -8,10 +8,13 @@ struct RemainderModel{M, S} <: BalanceLaw
     subs::S
 end
 
-vars_state_conservative(rem::RemainderModel, FT) = vars_state_conservative(rem.main, FT)
+vars_state_conservative(rem::RemainderModel, FT) =
+    vars_state_conservative(rem.main, FT)
 vars_state_gradient(rem::RemainderModel, FT) = vars_state_gradient(rem.main, FT)
-vars_state_gradient_flux(rem::RemainderModel, FT) = vars_state_gradient_flux(rem.main, FT)
-vars_state_auxiliary(rem::RemainderModel, FT) = vars_state_auxiliary(rem.main, FT)
+vars_state_gradient_flux(rem::RemainderModel, FT) =
+    vars_state_gradient_flux(rem.main, FT)
+vars_state_auxiliary(rem::RemainderModel, FT) =
+    vars_state_auxiliary(rem.main, FT)
 vars_integrals(rem::RemainderModel, FT) = vars_integrals(rem.main, FT)
 vars_reverse_integrals(rem::RemainderModel, FT) = vars_integrals(rem.main, FT)
 vars_gradient_laplacian(rem::RemainderModel, FT) =
@@ -26,8 +29,12 @@ update_auxiliary_state!(
     elems::UnitRange,
 ) = update_auxiliary_state!(dg, rem.main, Q, t, elems)
 
-integral_load_auxiliary_state!(rem::RemainderModel, integ::Vars, state::Vars, aux::Vars) =
-    integral_load_auxiliary_state!(rem.main, integ, state, aux)
+integral_load_auxiliary_state!(
+    rem::RemainderModel,
+    integ::Vars,
+    state::Vars,
+    aux::Vars,
+) = integral_load_auxiliary_state!(rem.main, integ, state, aux)
 
 integral_set_auxiliary_state!(rem::RemainderModel, aux::Vars, integ::Vars) =
     integral_set_auxiliary_state!(rem.main, aux, integ)
@@ -39,8 +46,11 @@ reverse_integral_load_auxiliary_state!(
     aux::Vars,
 ) = reverse_integral_load_auxiliary_state!(rem.main, integ, state, aux)
 
-reverse_integral_set_auxiliary_state!(rem::RemainderModel, aux::Vars, integ::Vars) =
-    reverse_integral_set_auxiliary_state!(rem.main, aux, integ)
+reverse_integral_set_auxiliary_state!(
+    rem::RemainderModel,
+    aux::Vars,
+    integ::Vars,
+) = reverse_integral_set_auxiliary_state!(rem.main, aux, integ)
 
 function transform_post_gradient_laplacian!(
     rem::RemainderModel,
@@ -50,7 +60,14 @@ function transform_post_gradient_laplacian!(
     aux::Vars,
     t::Real,
 )
-    transform_post_gradient_laplacian!(rem.main, hyperdiffusive, hypertransform, state, aux, t)
+    transform_post_gradient_laplacian!(
+        rem.main,
+        hyperdiffusive,
+        hypertransform,
+        state,
+        aux,
+        t,
+    )
 end
 function flux_second_order!(
     rem::RemainderModel,
@@ -125,8 +142,15 @@ function normal_boundary_flux_second_order!(
     )
 end
 
-init_state_auxiliary!(rem::RemainderModel, aux::Vars, geom::LocalGeometry) = nothing
-init_state_conservative!(rem::RemainderModel, state::Vars, aux::Vars, coords, t) = nothing
+init_state_auxiliary!(rem::RemainderModel, aux::Vars, geom::LocalGeometry) =
+    nothing
+init_state_conservative!(
+    rem::RemainderModel,
+    state::Vars,
+    aux::Vars,
+    coords,
+    t,
+) = nothing
 
 function flux_first_order!(
     rem::RemainderModel,

--- a/src/Atmos/Model/turbulence.jl
+++ b/src/Atmos/Model/turbulence.jl
@@ -570,7 +570,8 @@ struct AnisoMinDiss{FT} <: TurbulenceClosure
 end
 vars_state_auxiliary(::AnisoMinDiss, FT) = @vars(Δ::FT)
 vars_state_gradient(::AnisoMinDiss, FT) = @vars(θ_v::FT)
-vars_state_gradient_flux(::AnisoMinDiss, FT) = @vars(∇u::SMatrix{3, 3, FT, 9}, N²::FT)
+vars_state_gradient_flux(::AnisoMinDiss, FT) =
+    @vars(∇u::SMatrix{3, 3, FT, 9}, N²::FT)
 function atmos_init_aux!(
     ::AnisoMinDiss,
     ::AtmosModel,

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -28,7 +28,12 @@ using StaticArrays
 using CLIMA
 using ..DGmethods
 using ..DGmethods:
-    number_state_conservative, vars_state_conservative, number_state_auxiliary, vars_state_auxiliary, vars_state_gradient_flux, number_state_gradient_flux
+    number_state_conservative,
+    vars_state_conservative,
+    number_state_auxiliary,
+    vars_state_auxiliary,
+    vars_state_gradient_flux,
+    number_state_gradient_flux
 using ..Mesh.Interpolation
 using ..MPIStateArrays
 using ..VariableTemplates

--- a/src/Diagnostics/dump_state_and_aux.jl
+++ b/src/Diagnostics/dump_state_and_aux.jl
@@ -67,7 +67,11 @@ function dump_state_and_aux_collect(dgngrp, currtime)
     all_state_data = nothing
     all_aux_data = nothing
     if dgngrp.interpol !== nothing
-        istate = DA(Array{FT}(undef, dgngrp.interpol.Npl, number_state_conservative(bl, FT)))
+        istate = DA(Array{FT}(
+            undef,
+            dgngrp.interpol.Npl,
+            number_state_conservative(bl, FT),
+        ))
         interpolate_local!(dgngrp.interpol, Q.data, istate)
 
         if dgngrp.project
@@ -83,7 +87,11 @@ function dump_state_and_aux_collect(dgngrp, currtime)
         all_state_data =
             accumulate_interpolated_data(mpicomm, dgngrp.interpol, istate)
 
-        iaux = DA(Array{FT}(undef, dgngrp.interpol.Npl, number_state_auxiliary(bl, FT)))
+        iaux = DA(Array{FT}(
+            undef,
+            dgngrp.interpol.Npl,
+            number_state_auxiliary(bl, FT),
+        ))
         interpolate_local!(dgngrp.interpol, dg.state_auxiliary.data, iaux)
 
         all_aux_data =

--- a/src/Driver/Driver.jl
+++ b/src/Driver/Driver.jl
@@ -14,7 +14,8 @@ using ..ColumnwiseLUSolver
 using ..ConfigTypes
 using ..Diagnostics
 using ..DGmethods
-using ..DGmethods: vars_state_conservative, vars_state_auxiliary, update_auxiliary_state!
+using ..DGmethods:
+    vars_state_conservative, vars_state_auxiliary, update_auxiliary_state!
 using ..DGmethods.NumericalFluxes
 using ..HydrostaticBoussinesq
 using ..Mesh.Grids
@@ -249,7 +250,8 @@ function init(; disable_gpu = false, arg_settings = nothing)
 
     # set up the array type appropriately depending on whether we're using GPUs
     if get(ENV, "CLIMA_GPU", "") != "false" &&
-       !Settings.disable_gpu && CUDAapi.has_cuda_gpu()
+       !Settings.disable_gpu &&
+       CUDAapi.has_cuda_gpu()
         atyp = CuArrays.CuArray
     else
         atyp = Array

--- a/src/Numerics/DGmethods/DGmodel.jl
+++ b/src/Numerics/DGmethods/DGmodel.jl
@@ -1,4 +1,5 @@
-using .NumericalFluxes: CentralNumericalFluxHigherOrder, CentralNumericalFluxDivergence
+using .NumericalFluxes:
+    CentralNumericalFluxHigherOrder, CentralNumericalFluxDivergence
 
 struct DGModel{BL, G, NFND, NFD, GNF, AS, DS, HDS, D, DD, MD}
     balancelaw::BL
@@ -41,7 +42,13 @@ function DGModel(
     )
 end
 
-function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = false)
+function (dg::DGModel)(
+    tendency,
+    state_conservative,
+    ::Nothing,
+    t;
+    increment = false,
+)
 
     balance_law = dg.balancelaw
     device = typeof(state_conservative.data) <: Array ? CPU() : CUDA()
@@ -75,7 +82,13 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
     communicate =
         !(isstacked(topology) && typeof(dg.direction) <: VerticalDirection)
 
-    update_auxiliary_state!(dg, balance_law, state_conservative, t, dg.grid.topology.realelems)
+    update_auxiliary_state!(
+        dg,
+        balance_law,
+        state_conservative,
+        t,
+        dg.grid.topology.realelems,
+    )
 
     if nhyperviscstate > 0
         hypervisc_indexmap = create_hypervisc_indexmap(balance_law)
@@ -94,8 +107,10 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
     # Gradient Computation #
     ########################
     if communicate
-        exchange_state_conservative =
-            MPIStateArrays.begin_ghost_exchange!(state_conservative; dependencies = comp_stream)
+        exchange_state_conservative = MPIStateArrays.begin_ghost_exchange!(
+            state_conservative;
+            dependencies = comp_stream,
+        )
     end
 
     if num_state_gradient_flux > 0 || nhyperviscstate > 0
@@ -141,13 +156,21 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
         )
 
         if communicate
-            exchange_state_conservative =
-                MPIStateArrays.end_ghost_exchange!(state_conservative; dependencies = exchange_state_conservative)
+            exchange_state_conservative = MPIStateArrays.end_ghost_exchange!(
+                state_conservative;
+                dependencies = exchange_state_conservative,
+            )
 
             # update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
             wait(device, exchange_state_conservative)
-            update_auxiliary_state!(dg, balance_law, state_conservative, t, dg.grid.topology.ghostelems)
+            update_auxiliary_state!(
+                dg,
+                balance_law,
+                state_conservative,
+                t,
+                dg.grid.topology.ghostelems,
+            )
             exchange_state_conservative = Event(device)
         end
 
@@ -175,10 +198,11 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
 
         if communicate
             if num_state_gradient_flux > 0
-                exchange_state_gradient_flux = MPIStateArrays.begin_ghost_exchange!(
-                    state_gradient_flux,
-                    dependencies = comp_stream,
-                )
+                exchange_state_gradient_flux =
+                    MPIStateArrays.begin_ghost_exchange!(
+                        state_gradient_flux,
+                        dependencies = comp_stream,
+                    )
             end
             if nhyperviscstate > 0
                 exchange_Qhypervisc_grad = MPIStateArrays.begin_ghost_exchange!(
@@ -192,7 +216,13 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
             # update_aux_diffusive may start asynchronous work on the compute device
             # and we synchronize those here through a device event.
             wait(device, comp_stream)
-            update_auxiliary_state_gradient!(dg, balance_law, state_conservative, t, dg.grid.topology.realelems)
+            update_auxiliary_state_gradient!(
+                dg,
+                balance_law,
+                state_conservative,
+                t,
+                dg.grid.topology.realelems,
+            )
             comp_stream = Event(device)
         end
     end
@@ -202,37 +232,39 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
         # Laplacian Computation #
         #########################
 
-        comp_stream = volume_divergence_of_gradients!(device, workgroups_volume)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            grid.vgeo,
-            grid.D,
-            topology.realelems;
-            ndrange = ndrange_volume,
-            dependencies = (comp_stream,),
-        )
+        comp_stream =
+            volume_divergence_of_gradients!(device, workgroups_volume)(
+                balance_law,
+                Val(dim),
+                Val(N),
+                dg.diffusion_direction,
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                grid.vgeo,
+                grid.D,
+                topology.realelems;
+                ndrange = ndrange_volume,
+                dependencies = (comp_stream,),
+            )
 
-        comp_stream = interface_divergence_of_gradients!(device, workgroups_surface)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            CentralNumericalFluxDivergence(),
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            grid.vgeo,
-            grid.sgeo,
-            grid.vmap⁻,
-            grid.vmap⁺,
-            grid.elemtobndy,
-            grid.interiorelems;
-            ndrange = ndrange_interior_surface,
-            dependencies = (comp_stream,),
-        )
+        comp_stream =
+            interface_divergence_of_gradients!(device, workgroups_surface)(
+                balance_law,
+                Val(dim),
+                Val(N),
+                dg.diffusion_direction,
+                CentralNumericalFluxDivergence(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                grid.vgeo,
+                grid.sgeo,
+                grid.vmap⁻,
+                grid.vmap⁺,
+                grid.elemtobndy,
+                grid.interiorelems;
+                ndrange = ndrange_interior_surface,
+                dependencies = (comp_stream,),
+            )
 
         if communicate
             exchange_Qhypervisc_grad = MPIStateArrays.end_ghost_exchange!(
@@ -241,23 +273,24 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
             )
         end
 
-        comp_stream = interface_divergence_of_gradients!(device, workgroups_surface)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            CentralNumericalFluxDivergence(),
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            grid.vgeo,
-            grid.sgeo,
-            grid.vmap⁻,
-            grid.vmap⁺,
-            grid.elemtobndy,
-            grid.exteriorelems;
-            ndrange = ndrange_exterior_surface,
-            dependencies = (comp_stream, exchange_Qhypervisc_grad),
-        )
+        comp_stream =
+            interface_divergence_of_gradients!(device, workgroups_surface)(
+                balance_law,
+                Val(dim),
+                Val(N),
+                dg.diffusion_direction,
+                CentralNumericalFluxDivergence(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                grid.vgeo,
+                grid.sgeo,
+                grid.vmap⁻,
+                grid.vmap⁺,
+                grid.elemtobndy,
+                grid.exteriorelems;
+                ndrange = ndrange_exterior_surface,
+                dependencies = (comp_stream, exchange_Qhypervisc_grad),
+            )
 
         if communicate
             exchange_Qhypervisc_div = MPIStateArrays.begin_ghost_exchange!(
@@ -270,44 +303,46 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
         # Hyperdiffusive terms computation #
         ####################################
 
-        comp_stream = volume_gradients_of_laplacians!(device, workgroups_volume)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            state_conservative.data,
-            state_auxiliary.data,
-            grid.vgeo,
-            grid.ω,
-            grid.D,
-            topology.realelems,
-            t;
-            ndrange = ndrange_volume,
-            dependencies = (comp_stream,),
-        )
+        comp_stream =
+            volume_gradients_of_laplacians!(device, workgroups_volume)(
+                balance_law,
+                Val(dim),
+                Val(N),
+                dg.diffusion_direction,
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                state_conservative.data,
+                state_auxiliary.data,
+                grid.vgeo,
+                grid.ω,
+                grid.D,
+                topology.realelems,
+                t;
+                ndrange = ndrange_volume,
+                dependencies = (comp_stream,),
+            )
 
-        comp_stream = interface_gradients_of_laplacians!(device, workgroups_surface)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            CentralNumericalFluxHigherOrder(),
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            state_conservative.data,
-            state_auxiliary.data,
-            grid.vgeo,
-            grid.sgeo,
-            grid.vmap⁻,
-            grid.vmap⁺,
-            grid.elemtobndy,
-            grid.interiorelems,
-            t;
-            ndrange = ndrange_interior_surface,
-            dependencies = (comp_stream,),
-        )
+        comp_stream =
+            interface_gradients_of_laplacians!(device, workgroups_surface)(
+                balance_law,
+                Val(dim),
+                Val(N),
+                dg.diffusion_direction,
+                CentralNumericalFluxHigherOrder(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                state_conservative.data,
+                state_auxiliary.data,
+                grid.vgeo,
+                grid.sgeo,
+                grid.vmap⁻,
+                grid.vmap⁺,
+                grid.elemtobndy,
+                grid.interiorelems,
+                t;
+                ndrange = ndrange_interior_surface,
+                dependencies = (comp_stream,),
+            )
 
         if communicate
             exchange_Qhypervisc_div = MPIStateArrays.end_ghost_exchange!(
@@ -316,26 +351,27 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
             )
         end
 
-        comp_stream = interface_gradients_of_laplacians!(device, workgroups_surface)(
-            balance_law,
-            Val(dim),
-            Val(N),
-            dg.diffusion_direction,
-            CentralNumericalFluxHigherOrder(),
-            Qhypervisc_grad.data,
-            Qhypervisc_div.data,
-            state_conservative.data,
-            state_auxiliary.data,
-            grid.vgeo,
-            grid.sgeo,
-            grid.vmap⁻,
-            grid.vmap⁺,
-            grid.elemtobndy,
-            grid.exteriorelems,
-            t;
-            ndrange = ndrange_exterior_surface,
-            dependencies = (comp_stream, exchange_Qhypervisc_div),
-        )
+        comp_stream =
+            interface_gradients_of_laplacians!(device, workgroups_surface)(
+                balance_law,
+                Val(dim),
+                Val(N),
+                dg.diffusion_direction,
+                CentralNumericalFluxHigherOrder(),
+                Qhypervisc_grad.data,
+                Qhypervisc_div.data,
+                state_conservative.data,
+                state_auxiliary.data,
+                grid.vgeo,
+                grid.sgeo,
+                grid.vmap⁻,
+                grid.vmap⁺,
+                grid.elemtobndy,
+                grid.exteriorelems,
+                t;
+                ndrange = ndrange_exterior_surface,
+                dependencies = (comp_stream, exchange_Qhypervisc_div),
+            )
 
         if communicate
             exchange_Qhypervisc_grad = MPIStateArrays.begin_ghost_exchange!(
@@ -395,16 +431,23 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
     if communicate
         if num_state_gradient_flux > 0 || nhyperviscstate > 0
             if num_state_gradient_flux > 0
-                exchange_state_gradient_flux = MPIStateArrays.end_ghost_exchange!(
-                    state_gradient_flux;
-                    dependencies = exchange_state_gradient_flux,
-                )
+                exchange_state_gradient_flux =
+                    MPIStateArrays.end_ghost_exchange!(
+                        state_gradient_flux;
+                        dependencies = exchange_state_gradient_flux,
+                    )
 
                 # update_aux_diffusive may start asynchronous work on the
                 # compute device and we synchronize those here through a device
                 # event.
                 wait(device, exchange_state_gradient_flux)
-                update_auxiliary_state_gradient!(dg, balance_law, state_conservative, t, dg.grid.topology.ghostelems)
+                update_auxiliary_state_gradient!(
+                    dg,
+                    balance_law,
+                    state_conservative,
+                    t,
+                    dg.grid.topology.ghostelems,
+                )
                 exchange_state_gradient_flux = Event(device)
             end
             if nhyperviscstate > 0
@@ -414,13 +457,21 @@ function (dg::DGModel)(tendency, state_conservative, ::Nothing, t; increment = f
                 )
             end
         else
-            exchange_state_conservative =
-                MPIStateArrays.end_ghost_exchange!(state_conservative; dependencies = exchange_state_conservative)
+            exchange_state_conservative = MPIStateArrays.end_ghost_exchange!(
+                state_conservative;
+                dependencies = exchange_state_conservative,
+            )
 
             # update_aux may start asynchronous work on the compute device and
             # we synchronize those here through a device event.
             wait(device, exchange_state_conservative)
-            update_auxiliary_state!(dg, balance_law, state_conservative, t, dg.grid.topology.ghostelems)
+            update_auxiliary_state!(
+                dg,
+                balance_law,
+                state_conservative,
+                t,
+                dg.grid.topology.ghostelems,
+            )
             exchange_state_conservative = Event(device)
         end
     end
@@ -510,8 +561,14 @@ function init_ode_state(dg::DGModel, args...; init_on_cpu = false)
     end
 
     event = Event(device)
-    event = MPIStateArrays.begin_ghost_exchange!(state_conservative; dependencies = event)
-    event = MPIStateArrays.end_ghost_exchange!(state_conservative; dependencies = event)
+    event = MPIStateArrays.begin_ghost_exchange!(
+        state_conservative;
+        dependencies = event,
+    )
+    event = MPIStateArrays.end_ghost_exchange!(
+        state_conservative;
+        dependencies = event,
+    )
     wait(device, event)
 
     return state_conservative
@@ -665,7 +722,8 @@ function nodal_update_auxiliary_state!(
 
     Np = dofs_per_element(grid)
 
-    nodal_update_auxiliary_state! = kernel_nodal_update_auxiliary_state!(device, Np)
+    nodal_update_auxiliary_state! =
+        kernel_nodal_update_auxiliary_state!(device, Np)
     ### update state_auxiliary variables
     event = Event(device)
     if diffusive

--- a/src/Numerics/DGmethods/DGmodel_kernels.jl
+++ b/src/Numerics/DGmethods/DGmodel_kernels.jl
@@ -66,8 +66,10 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
         Nqk = dim == 2 ? 1 : Nq
 
         local_source = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_gradient_flux = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_conservative =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
         local_state_hyperdiffusion = MArray{Tuple{nhyperviscstate}, FT}(undef)
         local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_flux = MArray{Tuple{3, num_state_conservative}, FT}(undef)
@@ -125,7 +127,9 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
         flux_first_order!(
             balance_law,
             Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
             t,
         )
@@ -140,9 +144,15 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
         flux_second_order!(
             balance_law,
             Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
-            Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative,
+            ),
+            Vars{vars_state_gradient_flux(balance_law, FT)}(
+                local_state_gradient_flux,
+            ),
+            Vars{vars_hyperdiffusive(balance_law, FT)}(
+                local_state_hyperdiffusion,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
             t,
         )
@@ -155,15 +165,18 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
 
         # Build "inside metrics" flux
         @unroll for s in 1:num_state_conservative
-            F1, F2, F3 =
-                shared_flux[1, i, j, k, s], shared_flux[2, i, j, k, s], shared_flux[3, i, j, k, s]
+            F1, F2, F3 = shared_flux[1, i, j, k, s],
+            shared_flux[2, i, j, k, s],
+            shared_flux[3, i, j, k, s]
 
             shared_flux[1, i, j, k, s] = M * (ξ1x1 * F1 + ξ1x2 * F2 + ξ1x3 * F3)
             if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                shared_flux[2, i, j, k, s] = M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
+                shared_flux[2, i, j, k, s] =
+                    M * (ξ2x1 * F1 + ξ2x2 * F2 + ξ2x3 * F3)
             end
             if dim == 3 && direction isa EveryDirection
-                shared_flux[3, i, j, k, s] = M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
+                shared_flux[3, i, j, k, s] =
+                    M * (ξ3x1 * F1 + ξ3x2 * F2 + ξ3x3 * F3)
             end
         end
 
@@ -171,8 +184,12 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
         source!(
             balance_law,
             Vars{vars_state_conservative(balance_law, FT)}(local_source),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative,
+            ),
+            Vars{vars_state_gradient_flux(balance_law, FT)}(
+                local_state_gradient_flux,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
             t,
             direction,
@@ -192,12 +209,14 @@ Computational kernel: Evaluate the volume integrals on right-hand side of a
 
                 # ξ2-grid lines
                 if dim == 3 || (dim == 2 && direction isa EveryDirection)
-                    local_tendency[s] += MI * s_D[n, j] * shared_flux[2, i, n, k, s]
+                    local_tendency[s] +=
+                        MI * s_D[n, j] * shared_flux[2, i, n, k, s]
                 end
 
                 # ξ3-grid lines
                 if dim == 3 && direction isa EveryDirection
-                    local_tendency[s] += MI * s_D[n, k] * shared_flux[3, i, j, n, s]
+                    local_tendency[s] +=
+                        MI * s_D[n, k] * shared_flux[3, i, j, n, s]
                 end
             end
         end
@@ -242,8 +261,10 @@ end
         Nqk = dim == 2 ? 1 : Nq
 
         local_source = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_gradient_flux = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_conservative =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
         local_state_hyperdiffusion = MArray{Tuple{nhyperviscstate}, FT}(undef)
         local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_flux = MArray{Tuple{3, num_state_conservative}, FT}(undef)
@@ -295,7 +316,9 @@ end
         flux_first_order!(
             balance_law,
             Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
             t,
         )
@@ -310,9 +333,15 @@ end
         flux_second_order!(
             balance_law,
             Grad{vars_state_conservative(balance_law, FT)}(local_flux),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
-            Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative,
+            ),
+            Vars{vars_state_gradient_flux(balance_law, FT)}(
+                local_state_gradient_flux,
+            ),
+            Vars{vars_hyperdiffusive(balance_law, FT)}(
+                local_state_hyperdiffusion,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
             t,
         )
@@ -325,8 +354,9 @@ end
 
         # Build "inside metrics" flux
         @unroll for s in 1:num_state_conservative
-            F1, F2, F3 =
-                shared_flux[1, i, j, k, s], shared_flux[2, i, j, k, s], shared_flux[3, i, j, k, s]
+            F1, F2, F3 = shared_flux[1, i, j, k, s],
+            shared_flux[2, i, j, k, s],
+            shared_flux[3, i, j, k, s]
             shared_flux[3, i, j, k, s] = M * (ζx1 * F1 + ζx2 * F2 + ζx3 * F3)
         end
 
@@ -334,8 +364,12 @@ end
         source!(
             balance_law,
             Vars{vars_state_conservative(balance_law, FT)}(local_source),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative,
+            ),
+            Vars{vars_state_gradient_flux(balance_law, FT)}(
+                local_state_gradient_flux,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
             t,
             direction,
@@ -430,25 +464,35 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
         Nq = N + 1
         Nqk = dim == 2 ? 1 : Nq
 
-        local_state_conservative⁻ = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_gradient_flux⁻ = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_conservative⁻ =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_gradient_flux⁻ =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
         local_state_hyperdiffusion⁻ = MArray{Tuple{nhyperviscstate}, FT}(undef)
         local_state_auxiliary⁻ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
 
         # Need two copies since numerical_flux_first_order! can modify state_conservative⁺
-        local_state_conservative⁺nondiff = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_conservative⁺diff = MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_conservative⁺nondiff =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_conservative⁺diff =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
 
         # Need two copies since numerical_flux_first_order! can modify state_auxiliary⁺
-        local_state_auxiliary⁺nondiff = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_auxiliary⁺diff = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_auxiliary⁺nondiff =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_auxiliary⁺diff =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
 
-        local_state_gradient_flux⁺ = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_gradient_flux⁺ =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
         local_state_hyperdiffusion⁺ = MArray{Tuple{nhyperviscstate}, FT}(undef)
 
-        local_state_conservative_bottom1 = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_gradient_flux_bottom1 = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
-        local_state_auxiliary_bottom1 = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_conservative_bottom1 =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_gradient_flux_bottom1 =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_auxiliary_bottom1 =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
 
         local_flux = MArray{Tuple{num_state_conservative}, FT}(undef)
     end
@@ -491,7 +535,9 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
 
         # Load plus side data
         @unroll for s in 1:num_state_conservative
-            local_state_conservative⁺diff[s] = local_state_conservative⁺nondiff[s] = state_conservative[vid⁺, s, e⁺]
+            local_state_conservative⁺diff[s] =
+                local_state_conservative⁺nondiff[s] =
+                    state_conservative[vid⁺, s, e⁺]
         end
 
         @unroll for s in 1:num_state_gradient_flux
@@ -503,7 +549,8 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
         end
 
         @unroll for s in 1:num_state_auxiliary
-            local_state_auxiliary⁺diff[s] = local_state_auxiliary⁺nondiff[s] = state_auxiliary[vid⁺, s, e⁺]
+            local_state_auxiliary⁺diff[s] =
+                local_state_auxiliary⁺nondiff[s] = state_auxiliary[vid⁺, s, e⁺]
         end
 
         bctype = elemtobndy[f, e⁻]
@@ -514,10 +561,18 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
                 balance_law,
                 Vars{vars_state_conservative(balance_law, FT)}(local_flux),
                 SVector(normal_vector),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺nondiff),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺nondiff),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺nondiff,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺nondiff,
+                ),
                 t,
             )
             numerical_flux_second_order!(
@@ -525,27 +580,46 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
                 balance_law,
                 Vars{vars_state_conservative(balance_law, FT)}(local_flux),
                 normal_vector,
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux⁻),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺diff),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux⁺),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion⁺),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺diff),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux⁻,
+                ),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺diff,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux⁺,
+                ),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion⁺,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺diff,
+                ),
                 t,
             )
         else
             if (dim == 2 && f == 3) || (dim == 3 && f == 5)
                 # Loop up the first element along all horizontal elements
                 @unroll for s in 1:num_state_conservative
-                    local_state_conservative_bottom1[s] = state_conservative[n + Nqk^2, s, e⁻]
+                    local_state_conservative_bottom1[s] =
+                        state_conservative[n + Nqk^2, s, e⁻]
                 end
                 @unroll for s in 1:num_state_gradient_flux
-                    local_state_gradient_flux_bottom1[s] = state_gradient_flux[n + Nqk^2, s, e⁻]
+                    local_state_gradient_flux_bottom1[s] =
+                        state_gradient_flux[n + Nqk^2, s, e⁻]
                 end
                 @unroll for s in 1:num_state_auxiliary
-                    local_state_auxiliary_bottom1[s] = state_auxiliary[n + Nqk^2, s, e⁻]
+                    local_state_auxiliary_bottom1[s] =
+                        state_auxiliary[n + Nqk^2, s, e⁻]
                 end
             end
             numerical_boundary_flux_first_order!(
@@ -553,33 +627,67 @@ Computational kernel: Evaluate the surface integrals on right-hand side of a
                 balance_law,
                 Vars{vars_state_conservative(balance_law, FT)}(local_flux),
                 SVector(normal_vector),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺nondiff),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺nondiff),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺nondiff,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺nondiff,
+                ),
                 bctype,
                 t,
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative_bottom1),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary_bottom1),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative_bottom1,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary_bottom1,
+                ),
             )
             numerical_boundary_flux_second_order!(
                 numerical_flux_second_order,
                 balance_law,
                 Vars{vars_state_conservative(balance_law, FT)}(local_flux),
                 normal_vector,
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux⁻),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺diff),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux⁺),
-                Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion⁺),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺diff),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux⁻,
+                ),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺diff,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux⁺,
+                ),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion⁺,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺diff,
+                ),
                 bctype,
                 t,
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative_bottom1),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux_bottom1),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary_bottom1),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative_bottom1,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux_bottom1,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary_bottom1,
+                ),
             )
         end
 
@@ -625,7 +733,8 @@ end
         ngradtransformstate = num_state_conservative
 
         local_transform = MArray{Tuple{ngradstate}, FT}(undef)
-        local_state_gradient_flux = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
         local_transform_gradient = MArray{Tuple{3, ngradstate}, FT}(undef)
     end
 
@@ -713,11 +822,18 @@ end
         end
 
         if num_state_gradient_flux > 0
-            fill!(local_state_gradient_flux, -zero(eltype(local_state_gradient_flux)))
+            fill!(
+                local_state_gradient_flux,
+                -zero(eltype(local_state_gradient_flux)),
+            )
             compute_gradient_flux!(
                 balance_law,
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
-                Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux,
+                ),
+                Grad{vars_state_gradient(balance_law, FT)}(
+                    local_transform_gradient,
+                ),
                 Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
                 Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
                 t,
@@ -761,7 +877,8 @@ end
 
         Nqk = dim == 2 ? 1 : Nq
         local_transform = MArray{Tuple{ngradstate}, FT}(undef)
-        local_state_gradient_flux = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
         local_transform_gradient = MArray{Tuple{3, ngradstate}, FT}(undef)
 
         _ζx1 = dim == 2 ? _ξ2x1 : _ξ3x1
@@ -832,11 +949,18 @@ end
         end
 
         if num_state_gradient_flux > 0
-            fill!(local_state_gradient_flux, -zero(eltype(local_state_gradient_flux)))
+            fill!(
+                local_state_gradient_flux,
+                -zero(eltype(local_state_gradient_flux)),
+            )
             compute_gradient_flux!(
                 balance_law,
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
-                Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux,
+                ),
+                Grad{vars_state_gradient(balance_law, FT)}(
+                    local_transform_gradient,
+                ),
                 Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
                 Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
                 t,
@@ -903,22 +1027,28 @@ end
 
         ngradtransformstate = num_state_conservative
 
-        local_state_conservative⁻ = MArray{Tuple{ngradtransformstate}, FT}(undef)
+        local_state_conservative⁻ =
+            MArray{Tuple{ngradtransformstate}, FT}(undef)
         local_state_auxiliary⁻ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_transform⁻ = MArray{Tuple{ngradstate}, FT}(undef)
         l_nG⁻ = MArray{Tuple{3, ngradstate}, FT}(undef)
 
-        local_state_conservative⁺ = MArray{Tuple{ngradtransformstate}, FT}(undef)
+        local_state_conservative⁺ =
+            MArray{Tuple{ngradtransformstate}, FT}(undef)
         local_state_auxiliary⁺ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_transform⁺ = MArray{Tuple{ngradstate}, FT}(undef)
 
         # FIXME state_gradient_flux is sort of a terrible name...
-        local_state_gradient_flux = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
         local_transform_gradient = MArray{Tuple{3, ngradstate}, FT}(undef)
-        local_state_conservative⁻visc = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_conservative⁻visc =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
 
-        local_state_conservative_bottom1 = MArray{Tuple{num_state_conservative}, FT}(undef)
-        local_state_auxiliary_bottom1 = MArray{Tuple{num_state_auxiliary}, FT}(undef)
+        local_state_conservative_bottom1 =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_auxiliary_bottom1 =
+            MArray{Tuple{num_state_auxiliary}, FT}(undef)
     end
 
     eI = @index(Group, Linear)
@@ -953,7 +1083,9 @@ end
         compute_gradient_argument!(
             balance_law,
             Vars{vars_state_gradient(balance_law, FT)}(local_transform⁻),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative⁻,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
             t,
         )
@@ -971,13 +1103,18 @@ end
         compute_gradient_argument!(
             balance_law,
             Vars{vars_state_gradient(balance_law, FT)}(local_transform⁺),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative⁺,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺),
             t,
         )
 
         bctype = elemtobndy[f, e⁻]
-        fill!(local_state_gradient_flux, -zero(eltype(local_state_gradient_flux)))
+        fill!(
+            local_state_gradient_flux,
+            -zero(eltype(local_state_gradient_flux)),
+        )
         if bctype == 0
             numerical_flux_gradient!(
                 numerical_flux_gradient,
@@ -985,20 +1122,36 @@ end
                 local_transform_gradient,
                 SVector(normal_vector),
                 Vars{vars_state_gradient(balance_law, FT)}(local_transform⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
                 Vars{vars_state_gradient(balance_law, FT)}(local_transform⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺,
+                ),
                 t,
             )
             if num_state_gradient_flux > 0
                 compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
-                    Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient),
-                    Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                        local_state_gradient_flux,
+                    ),
+                    Grad{vars_state_gradient(balance_law, FT)}(
+                        local_transform_gradient,
+                    ),
+                    Vars{vars_state_conservative(balance_law, FT)}(
+                        local_state_conservative⁻,
+                    ),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(
+                        local_state_auxiliary⁻,
+                    ),
                     t,
                 )
             end
@@ -1006,10 +1159,12 @@ end
             if (dim == 2 && f == 3) || (dim == 3 && f == 5)
                 # Loop up the first element along all horizontal elements
                 @unroll for s in 1:num_state_conservative
-                    local_state_conservative_bottom1[s] = state_conservative[n + Nqk^2, s, e⁻]
+                    local_state_conservative_bottom1[s] =
+                        state_conservative[n + Nqk^2, s, e⁻]
                 end
                 @unroll for s in 1:num_state_auxiliary
-                    local_state_auxiliary_bottom1[s] = state_auxiliary[n + Nqk^2, s, e⁻]
+                    local_state_auxiliary_bottom1[s] =
+                        state_auxiliary[n + Nqk^2, s, e⁻]
                 end
             end
             numerical_boundary_flux_gradient!(
@@ -1018,23 +1173,43 @@ end
                 local_transform_gradient,
                 SVector(normal_vector),
                 Vars{vars_state_gradient(balance_law, FT)}(local_transform⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
                 Vars{vars_state_gradient(balance_law, FT)}(local_transform⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺,
+                ),
                 bctype,
                 t,
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative_bottom1),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary_bottom1),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative_bottom1,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary_bottom1,
+                ),
             )
             if num_state_gradient_flux > 0
                 compute_gradient_flux!(
                     balance_law,
-                    Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
-                    Grad{vars_state_gradient(balance_law, FT)}(local_transform_gradient),
-                    Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+                    Vars{vars_state_gradient_flux(balance_law, FT)}(
+                        local_state_gradient_flux,
+                    ),
+                    Grad{vars_state_gradient(balance_law, FT)}(
+                        local_transform_gradient,
+                    ),
+                    Vars{vars_state_conservative(balance_law, FT)}(
+                        local_state_conservative⁻,
+                    ),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(
+                        local_state_auxiliary⁻,
+                    ),
                     t,
                 )
             end
@@ -1058,16 +1233,26 @@ end
 
         compute_gradient_flux!(
             balance_law,
-            Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_conservative⁻visc),
+            Vars{vars_state_gradient_flux(balance_law, FT)}(
+                local_state_conservative⁻visc,
+            ),
             Grad{vars_state_gradient(balance_law, FT)}(l_nG⁻),
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative⁻,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
             t,
         )
 
 
         @unroll for s in 1:num_state_gradient_flux
-            state_gradient_flux[vid⁻, s, e⁻] += vMI * sM * (local_state_gradient_flux[s] - local_state_conservative⁻visc[s])
+            state_gradient_flux[vid⁻, s, e⁻] +=
+                vMI *
+                sM *
+                (
+                    local_state_gradient_flux[s] -
+                    local_state_conservative⁻visc[s]
+                )
         end
         # Need to wait after even faces to avoid race conditions
         @synchronize(f % 2 == 0)
@@ -1215,8 +1400,12 @@ Update the auxiliary state array
 
             f!(
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
                 t,
             )
 
@@ -1252,7 +1441,8 @@ end
 
     local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
     local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-    local_state_gradient_flux = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+    local_state_gradient_flux =
+        MArray{Tuple{num_state_gradient_flux}, FT}(undef)
 
     eI = @index(Group, Linear)
     n = @index(Local, Linear)
@@ -1277,9 +1467,15 @@ end
 
             f!(
                 balance_law,
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-                Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary,
+                ),
+                Vars{vars_state_gradient_flux(balance_law, FT)}(
+                    local_state_gradient_flux,
+                ),
                 t,
             )
 
@@ -1317,7 +1513,8 @@ See [`BalanceLaw`](@ref) for usage.
         Nq = N + 1
         Nqj = dim == 2 ? 1 : Nq
 
-        local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_conservative =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
         local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
         local_kernel = MArray{Tuple{nout, Nq}, FT}(undef)
     end
@@ -1362,9 +1559,17 @@ See [`BalanceLaw`](@ref) for usage.
 
                 integral_load_auxiliary_state!(
                     balance_law,
-                    Vars{vars_integrals(balance_law, FT)}(view(local_kernel, :, k)),
-                    Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
+                    Vars{vars_integrals(balance_law, FT)}(view(
+                        local_kernel,
+                        :,
+                        k,
+                    )),
+                    Vars{vars_state_conservative(balance_law, FT)}(
+                        local_state_conservative,
+                    ),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(
+                        local_state_auxiliary,
+                    ),
                 )
 
                 # multiply in the curve jacobian
@@ -1390,8 +1595,17 @@ See [`BalanceLaw`](@ref) for usage.
                 ijk = i + Nq * ((j - 1) + Nqj * (k - 1))
                 integral_set_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state_auxiliary(balance_law, FT)}(view(state_auxiliary, ijk, :, e)),
-                    Vars{vars_integrals(balance_law, FT)}(view(local_kernel, :, k)),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(view(
+                        state_auxiliary,
+                        ijk,
+                        :,
+                        e,
+                    )),
+                    Vars{vars_integrals(balance_law, FT)}(view(
+                        local_kernel,
+                        :,
+                        k,
+                    )),
                 )
                 @unroll for ind_out in 1:nout
                     local_integral[ind_out, k] = local_integral[ind_out, Nq]
@@ -1435,8 +1649,18 @@ end
         reverse_integral_load_auxiliary_state!(
             balance_law,
             Vars{vars_reverse_integrals(balance_law, FT)}(l_T),
-            Vars{vars_state_conservative(balance_law, FT)}(view(state, ijk, :, et)),
-            Vars{vars_state_auxiliary(balance_law, FT)}(view(state_auxiliary, ijk, :, et)),
+            Vars{vars_state_conservative(balance_law, FT)}(view(
+                state,
+                ijk,
+                :,
+                et,
+            )),
+            Vars{vars_state_auxiliary(balance_law, FT)}(view(
+                state_auxiliary,
+                ijk,
+                :,
+                et,
+            )),
         )
 
         # Loop up the stack of elements
@@ -1447,13 +1671,28 @@ end
                 reverse_integral_load_auxiliary_state!(
                     balance_law,
                     Vars{vars_reverse_integrals(balance_law, FT)}(l_V),
-                    Vars{vars_state_conservative(balance_law, FT)}(view(state, ijk, :, e)),
-                    Vars{vars_state_auxiliary(balance_law, FT)}(view(state_auxiliary, ijk, :, e)),
+                    Vars{vars_state_conservative(balance_law, FT)}(view(
+                        state,
+                        ijk,
+                        :,
+                        e,
+                    )),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(view(
+                        state_auxiliary,
+                        ijk,
+                        :,
+                        e,
+                    )),
                 )
                 l_V .= l_T .- l_V
                 reverse_integral_set_auxiliary_state!(
                     balance_law,
-                    Vars{vars_state_auxiliary(balance_law, FT)}(view(state_auxiliary, ijk, :, e)),
+                    Vars{vars_state_auxiliary(balance_law, FT)}(view(
+                        state_auxiliary,
+                        ijk,
+                        :,
+                        e,
+                    )),
                     Vars{vars_reverse_integrals(balance_law, FT)}(l_V),
                 )
             end
@@ -1885,10 +2124,15 @@ end
             end
         end
 
-        fill!(local_state_hyperdiffusion, -zero(eltype(local_state_hyperdiffusion)))
+        fill!(
+            local_state_hyperdiffusion,
+            -zero(eltype(local_state_hyperdiffusion)),
+        )
         transform_post_gradient_laplacian!(
             balance_law,
-            Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion),
+            Vars{vars_hyperdiffusive(balance_law, FT)}(
+                local_state_hyperdiffusion,
+            ),
             Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad_lap),
             Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
@@ -1988,10 +2232,15 @@ end
             l_grad_lap[3, s] = -ξvx3 * lap_ξv
         end
 
-        fill!(local_state_hyperdiffusion, -zero(eltype(local_state_hyperdiffusion)))
+        fill!(
+            local_state_hyperdiffusion,
+            -zero(eltype(local_state_hyperdiffusion)),
+        )
         transform_post_gradient_laplacian!(
             balance_law,
-            Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion),
+            Vars{vars_hyperdiffusive(balance_law, FT)}(
+                local_state_hyperdiffusion,
+            ),
             Grad{vars_gradient_laplacian(balance_law, FT)}(l_grad_lap),
             Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative[:]),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary[:]),
@@ -2058,10 +2307,12 @@ end
         l_lap⁺ = MArray{Tuple{ngradlapstate}, FT}(undef)
         local_state_hyperdiffusion = MArray{Tuple{nhyperviscstate}, FT}(undef)
 
-        local_state_conservative⁻ = MArray{Tuple{ngradtransformstate}, FT}(undef)
+        local_state_conservative⁻ =
+            MArray{Tuple{ngradtransformstate}, FT}(undef)
         local_state_auxiliary⁻ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
 
-        local_state_conservative⁺ = MArray{Tuple{ngradtransformstate}, FT}(undef)
+        local_state_conservative⁺ =
+            MArray{Tuple{ngradtransformstate}, FT}(undef)
         local_state_auxiliary⁺ = MArray{Tuple{num_state_auxiliary}, FT}(undef)
     end
 
@@ -2115,35 +2366,56 @@ end
             numerical_flux_higher_order!(
                 hyperviscnumflux,
                 balance_law,
-                Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion,
+                ),
                 normal_vector,
                 Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
                 Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺,
+                ),
                 t,
             )
         else
             numerical_boundary_flux_higher_order!(
                 hyperviscnumflux,
                 balance_law,
-                Vars{vars_hyperdiffusive(balance_law, FT)}(local_state_hyperdiffusion),
+                Vars{vars_hyperdiffusive(balance_law, FT)}(
+                    local_state_hyperdiffusion,
+                ),
                 normal_vector,
                 Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁻),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁻),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁻),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁻,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁻,
+                ),
                 Vars{vars_gradient_laplacian(balance_law, FT)}(l_lap⁺),
-                Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative⁺),
-                Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary⁺),
+                Vars{vars_state_conservative(balance_law, FT)}(
+                    local_state_conservative⁺,
+                ),
+                Vars{vars_state_auxiliary(balance_law, FT)}(
+                    local_state_auxiliary⁺,
+                ),
                 bctype,
                 t,
             )
         end
 
         @unroll for s in 1:nhyperviscstate
-            Qhypervisc_grad[vid⁻, s, e⁻] += vMI * sM * local_state_hyperdiffusion[s]
+            Qhypervisc_grad[vid⁻, s, e⁻] +=
+                vMI * sM * local_state_hyperdiffusion[s]
         end
         # Need to wait after even faces to avoid race conditions
         @synchronize(f % 2 == 0)
@@ -2176,9 +2448,11 @@ end
 
         Np = Nq * Nq * Nqk
 
-        local_state_conservative = MArray{Tuple{num_state_conservative}, FT}(undef)
+        local_state_conservative =
+            MArray{Tuple{num_state_conservative}, FT}(undef)
         local_state_auxiliary = MArray{Tuple{num_state_auxiliary}, FT}(undef)
-        local_state_gradient_flux = MArray{Tuple{num_state_gradient_flux}, FT}(undef)
+        local_state_gradient_flux =
+            MArray{Tuple{num_state_gradient_flux}, FT}(undef)
     end
 
     e = @index(Group, Linear)
@@ -2199,9 +2473,13 @@ end
         Δx = pointwise_courant[n, e]
         c = local_courant(
             balance_law,
-            Vars{vars_state_conservative(balance_law, FT)}(local_state_conservative),
+            Vars{vars_state_conservative(balance_law, FT)}(
+                local_state_conservative,
+            ),
             Vars{vars_state_auxiliary(balance_law, FT)}(local_state_auxiliary),
-            Vars{vars_state_gradient_flux(balance_law, FT)}(local_state_gradient_flux),
+            Vars{vars_state_gradient_flux(balance_law, FT)}(
+                local_state_gradient_flux,
+            ),
             Δx,
             Δt,
             simtime,

--- a/src/Numerics/DGmethods/balancelaw.jl
+++ b/src/Numerics/DGmethods/balancelaw.jl
@@ -45,11 +45,13 @@ vars_hyperdiffusive(::BalanceLaw, FT) = @vars()
 vars_integrals(::BalanceLaw, FT) = @vars()
 vars_reverse_integrals(::BalanceLaw, FT) = @vars()
 
-number_state_conservative(m::BalanceLaw, FT) = varsize(vars_state_conservative(m, FT))
+number_state_conservative(m::BalanceLaw, FT) =
+    varsize(vars_state_conservative(m, FT))
 number_state_auxiliary(m::BalanceLaw, FT) = varsize(vars_state_auxiliary(m, FT))
 
 number_state_gradient(m::BalanceLaw, FT) = varsize(vars_state_gradient(m, FT))
-number_state_gradient_flux(m::BalanceLaw, FT) = varsize(vars_state_gradient_flux(m, FT))
+number_state_gradient_flux(m::BalanceLaw, FT) =
+    varsize(vars_state_gradient_flux(m, FT))
 
 num_gradient_laplacian(m::BalanceLaw, FT) =
     varsize(vars_gradient_laplacian(m, FT))
@@ -170,8 +172,14 @@ function create_auxiliary_state(balance_law, grid)
         topology.realelems,
         dependencies = (event,),
     )
-    event = MPIStateArrays.begin_ghost_exchange!(state_auxiliary; dependencies = event)
-    event = MPIStateArrays.end_ghost_exchange!(state_auxiliary; dependencies = event)
+    event = MPIStateArrays.begin_ghost_exchange!(
+        state_auxiliary;
+        dependencies = event,
+    )
+    event = MPIStateArrays.end_ghost_exchange!(
+        state_auxiliary;
+        dependencies = event,
+    )
     wait(device, event)
 
     return state_auxiliary

--- a/src/Numerics/LinearSolvers/ColumnwiseLUSolver.jl
+++ b/src/Numerics/LinearSolvers/ColumnwiseLUSolver.jl
@@ -5,7 +5,8 @@ export ManyColumnLU, SingleColumnLU
 using ..Mesh.Grids
 using ..Mesh.Topologies
 using ..DGmethods
-using ..DGmethods: BalanceLaw, DGModel, number_state_conservative, number_state_gradient_flux
+using ..DGmethods:
+    BalanceLaw, DGModel, number_state_conservative, number_state_gradient_flux
 using ..LinearSolvers
 const LS = LinearSolvers
 using ..MPIStateArrays

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -246,7 +246,14 @@ this computation is done pointwise at each nodal point
 - `A`: array of aux variables
 - `t`: time, not used
 """
-@inline function compute_gradient_flux!(m::HBModel, D::Vars, G::Grad, Q::Vars, A::Vars, t)
+@inline function compute_gradient_flux!(
+    m::HBModel,
+    D::Vars,
+    G::Grad,
+    Q::Vars,
+    A::Vars,
+    t,
+)
     ν = viscosity_tensor(m)
     D.ν∇u = ν * G.∇u
 
@@ -308,7 +315,12 @@ I -> array of integrand variables
 Q -> array of state variables
 A -> array of aux variables
 """
-@inline function integral_load_auxiliary_state!(m::HBModel, I::Vars, Q::Vars, A::Vars)
+@inline function integral_load_auxiliary_state!(
+    m::HBModel,
+    I::Vars,
+    Q::Vars,
+    A::Vars,
+)
     I.∇hu = A.w # borrow the w value from A...
     I.αᵀθ = -m.αᵀ * Q.θ # integral will be reversed below
 
@@ -378,7 +390,11 @@ m -> model in this case HBModel
 A -> array of aux variables
 I -> array of integrand variables
 """
-@inline function reverse_integral_set_auxiliary_state!(m::HBModel, A::Vars, I::Vars)
+@inline function reverse_integral_set_auxiliary_state!(
+    m::HBModel,
+    A::Vars,
+    I::Vars,
+)
     A.pkin = I.αᵀθ
 
     return nothing

--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -24,9 +24,11 @@ end
 """
     Copy over state, aux, and diff variables from HBModel
 """
-vars_state_conservative(lm::LinearHBModel, FT) = vars_state_conservative(lm.ocean, FT)
+vars_state_conservative(lm::LinearHBModel, FT) =
+    vars_state_conservative(lm.ocean, FT)
 vars_state_gradient(lm::LinearHBModel, FT) = vars_state_gradient(lm.ocean, FT)
-vars_state_gradient_flux(lm::LinearHBModel, FT) = vars_state_gradient_flux(lm.ocean, FT)
+vars_state_gradient_flux(lm::LinearHBModel, FT) =
+    vars_state_gradient_flux(lm.ocean, FT)
 vars_state_auxiliary(lm::LinearHBModel, FT) = vars_state_auxiliary(lm.ocean, FT)
 vars_integrals(lm::LinearHBModel, FT) = @vars()
 
@@ -41,7 +43,8 @@ vars_integrals(lm::LinearHBModel, FT) = @vars()
     No need to init, initialize by full model
 """
 init_state_auxiliary!(lm::LinearHBModel, A::Vars, geom::LocalGeometry) = nothing
-init_state_conservative!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) = nothing
+init_state_conservative!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) =
+    nothing
 
 """
     compute_gradient_argument!(::LinearHBModel)
@@ -56,7 +59,13 @@ this computation is done pointwise at each nodal point
 - `A`: array of aux variables
 - `t`: time, not used
 """
-@inline function compute_gradient_argument!(m::LinearHBModel, G::Vars, Q::Vars, A, t)
+@inline function compute_gradient_argument!(
+    m::LinearHBModel,
+    G::Vars,
+    Q::Vars,
+    A,
+    t,
+)
     G.∇u = Q.u
     G.∇θ = Q.θ
 

--- a/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
+++ b/src/Ocean/HydrostaticBoussinesq/OceanBoundaryConditions.jl
@@ -1,5 +1,7 @@
 using ..DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxGradient, CentralNumericalFluxSecondOrder
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
 
 abstract type OceanBoundaryCondition end
 

--- a/src/Ocean/ShallowWater/ShallowWaterModel.jl
+++ b/src/Ocean/ShallowWater/ShallowWaterModel.jl
@@ -117,7 +117,13 @@ advective_flux!(::SWModel, ::Nothing, _...) = nothing
     return nothing
 end
 
-function compute_gradient_argument!(m::SWModel, f::Vars, q::Vars, α::Vars, t::Real)
+function compute_gradient_argument!(
+    m::SWModel,
+    f::Vars,
+    q::Vars,
+    α::Vars,
+    t::Real,
+)
     compute_gradient_argument!(m.turbulence, f, q, α, t)
 end
 
@@ -135,7 +141,14 @@ compute_gradient_argument!(::LinearDrag, _...) = nothing
     return nothing
 end
 
-function compute_gradient_flux!(m::SWModel, σ::Vars, δ::Grad, q::Vars, α::Vars, t::Real)
+function compute_gradient_flux!(
+    m::SWModel,
+    σ::Vars,
+    δ::Grad,
+    q::Vars,
+    α::Vars,
+    t::Real,
+)
     compute_gradient_flux!(m.turbulence, σ, δ, q, α, t)
 end
 

--- a/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
+++ b/test/Numerics/DGmethods/Euler/acousticwave_1d_imex.jl
@@ -5,7 +5,9 @@ using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid, VerticalDirection
 using CLIMA.Mesh.Filters
 using CLIMA.DGmethods: DGModel, init_ode_state
 using CLIMA.DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxGradient, CentralNumericalFluxSecondOrder
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
 using CLIMA.ODESolvers
 using CLIMA.GeneralizedMinimalResidualSolver
 using CLIMA.ColumnwiseLUSolver: ManyColumnLU

--- a/test/Numerics/DGmethods/Euler/isentropicvortex_imex.jl
+++ b/test/Numerics/DGmethods/Euler/isentropicvortex_imex.jl
@@ -4,7 +4,9 @@ using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
 using CLIMA.DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxGradient, CentralNumericalFluxSecondOrder
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
 using CLIMA.ODESolvers
 using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu

--- a/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark.jl
+++ b/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark.jl
@@ -4,7 +4,9 @@ using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
 using CLIMA.DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxGradient, CentralNumericalFluxSecondOrder
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
 using CLIMA.ODESolvers
 using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu

--- a/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark_implicit.jl
+++ b/test/Numerics/DGmethods/Euler/isentropicvortex_mrigark_implicit.jl
@@ -4,7 +4,9 @@ using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
 using CLIMA.DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxGradient, CentralNumericalFluxSecondOrder
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
 using CLIMA.ODESolvers
 using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu

--- a/test/Numerics/DGmethods/Euler/isentropicvortex_multirate.jl
+++ b/test/Numerics/DGmethods/Euler/isentropicvortex_multirate.jl
@@ -4,7 +4,9 @@ using CLIMA.Mesh.Topologies: BrickTopology
 using CLIMA.Mesh.Grids: DiscontinuousSpectralElementGrid
 using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry
 using CLIMA.DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxGradient, CentralNumericalFluxSecondOrder
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
 using CLIMA.ODESolvers
 using CLIMA.GeneralizedMinimalResidualSolver: GeneralizedMinimalResidual
 using CLIMA.VTK: writevtk, writepvtu

--- a/test/Numerics/DGmethods/advection_diffusion/advection_diffusion_model.jl
+++ b/test/Numerics/DGmethods/advection_diffusion/advection_diffusion_model.jl
@@ -209,7 +209,11 @@ end
 
 initialize the auxiliary state
 """
-function init_state_auxiliary!(m::AdvectionDiffusion, aux::Vars, geom::LocalGeometry)
+function init_state_auxiliary!(
+    m::AdvectionDiffusion,
+    aux::Vars,
+    geom::LocalGeometry,
+)
     aux.coord = geom.coord
     init_velocity_diffusion!(m.problem, aux, geom)
 end
@@ -286,8 +290,10 @@ function boundary_state!(
     elseif bctype == 2 # Neumann with data
         FT = eltype(diff⁺)
         ngrad = number_state_gradient(m, FT)
-        ∇state =
-            Grad{vars_state_gradient(m, FT)}(similar(parent(diff⁺), Size(3, ngrad)))
+        ∇state = Grad{vars_state_gradient(m, FT)}(similar(
+            parent(diff⁺),
+            Size(3, ngrad),
+        ))
         # Get analytic gradient
         Neumann_data!(m.problem, ∇state, aux⁻, aux⁻.coord, t)
         compute_gradient_flux!(m, diff⁺, ∇state, aux⁻)
@@ -295,8 +301,10 @@ function boundary_state!(
     elseif bctype == 4 # zero Neumann
         FT = eltype(diff⁺)
         ngrad = number_state_gradient(m, FT)
-        ∇state =
-            Grad{vars_state_gradient(m, FT)}(similar(parent(diff⁺), Size(3, ngrad)))
+        ∇state = Grad{vars_state_gradient(m, FT)}(similar(
+            parent(diff⁺),
+            Size(3, ngrad),
+        ))
         # Get analytic gradient
         ∇state.ρ = SVector{3, FT}(0, 0, 0)
         # convert to auxDG variables
@@ -344,8 +352,10 @@ function boundary_flux_second_order!(
     elseif bctype == 2 # Neumann data
         FT = eltype(diff⁺)
         ngrad = number_state_gradient(m, FT)
-        ∇state =
-            Grad{vars_state_gradient(m, FT)}(similar(parent(diff⁺), Size(3, ngrad)))
+        ∇state = Grad{vars_state_gradient(m, FT)}(similar(
+            parent(diff⁺),
+            Size(3, ngrad),
+        ))
         # Get analytic gradient
         Neumann_data!(m.problem, ∇state, aux⁻, aux⁻.coord, t)
         # get the diffusion coefficient

--- a/test/Numerics/DGmethods/advection_diffusion/direction_splitting_advection_diffusion.jl
+++ b/test/Numerics/DGmethods/advection_diffusion/direction_splitting_advection_diffusion.jl
@@ -27,116 +27,152 @@ struct Diffusion end
 
 struct TestProblem{adv, diff, dir, topo} <: AdvectionDiffusionProblem end
 
-function init_velocity_diffusion!(::TestProblem{adv, diff, dir, topo}, aux::Vars,
-                                  geom::LocalGeometry) where {adv, diff, dir, topo}
-  k = vertical_unit_vector(topo, geom.coord)
-  P = projection(dir, k)
-  aux.u = !isnothing(adv) ? P * sin.(geom.coord) : zeros(SVector{3})
-  aux.D = !isnothing(diff) ? SMatrix{3, 3}(P) / 200 : zeros(SMatrix{3, 3})
+function init_velocity_diffusion!(
+    ::TestProblem{adv, diff, dir, topo},
+    aux::Vars,
+    geom::LocalGeometry,
+) where {adv, diff, dir, topo}
+    k = vertical_unit_vector(topo, geom.coord)
+    P = projection(dir, k)
+    aux.u = !isnothing(adv) ? P * sin.(geom.coord) : zeros(SVector{3})
+    aux.D = !isnothing(diff) ? SMatrix{3, 3}(P) / 200 : zeros(SMatrix{3, 3})
 end
 
 function initial_condition!(::AdvectionDiffusionProblem, state, aux, x, t)
-  # random perturbation to trigger numerical fluxes
-  state.ρ = prod(sin.(x)) + rand() / 10
+    # random perturbation to trigger numerical fluxes
+    state.ρ = prod(sin.(x)) + rand() / 10
 end
 
 function create_topology(::Box{dim}, mpicomm, Ne, FT) where {dim}
-  brickrange = ntuple(j->range(FT(0); length=Ne+1, stop=1), dim)
-  periodicity = ntuple(j->false, dim)
-  bc = ntuple(j->(3, 3), dim)
-  StackedBrickTopology(mpicomm, brickrange;
-                       periodicity=periodicity,
-                       boundary=bc)
+    brickrange = ntuple(j -> range(FT(0); length = Ne + 1, stop = 1), dim)
+    periodicity = ntuple(j -> false, dim)
+    bc = ntuple(j -> (3, 3), dim)
+    StackedBrickTopology(
+        mpicomm,
+        brickrange;
+        periodicity = periodicity,
+        boundary = bc,
+    )
 end
 
 function create_topology(::Sphere, mpicomm, Ne, FT)
-  vert_range = grid1d(FT(1), FT(2), nelem=Ne)
-  StackedCubedSphereTopology(mpicomm, Ne, vert_range, boundary=(3, 3))
+    vert_range = grid1d(FT(1), FT(2), nelem = Ne)
+    StackedCubedSphereTopology(mpicomm, Ne, vert_range, boundary = (3, 3))
 end
 
-create_dg(model, grid, direction) =
-  DGModel(model,
-          grid,
-          RusanovNumericalFlux(),
-          CentralNumericalFluxSecondOrder(),
-          CentralNumericalFluxGradient(),
-          direction=direction)
+create_dg(model, grid, direction) = DGModel(
+    model,
+    grid,
+    RusanovNumericalFlux(),
+    CentralNumericalFluxSecondOrder(),
+    CentralNumericalFluxGradient(),
+    direction = direction,
+)
 
-function run(adv, diff, topo, mpicomm, ArrayType, FT, polynomialorder, Ne, level)
-  topology = create_topology(topo(), mpicomm, Ne, FT)
-  grid = DiscontinuousSpectralElementGrid(topology,
-                                          FloatType = FT,
-                                          DeviceArray = ArrayType,
-                                          polynomialorder = polynomialorder,
-                                          meshwarp = topo == Sphere ?
-                                            cubedshellwarp : (x...)->identity(x)
-                                         )
+function run(
+    adv,
+    diff,
+    topo,
+    mpicomm,
+    ArrayType,
+    FT,
+    polynomialorder,
+    Ne,
+    level,
+)
+    topology = create_topology(topo(), mpicomm, Ne, FT)
+    grid = DiscontinuousSpectralElementGrid(
+        topology,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = polynomialorder,
+        meshwarp = topo == Sphere ? cubedshellwarp : (x...) -> identity(x),
+    )
 
-  problems = (p=TestProblem{adv, diff, EveryDirection(), topo()}(),
-              vp=TestProblem{adv, diff, VerticalDirection(), topo()}(),
-              hp=TestProblem{adv, diff, HorizontalDirection(), topo()}())
+    problems = (
+        p = TestProblem{adv, diff, EveryDirection(), topo()}(),
+        vp = TestProblem{adv, diff, VerticalDirection(), topo()}(),
+        hp = TestProblem{adv, diff, HorizontalDirection(), topo()}(),
+    )
 
-  models = map(AdvectionDiffusion{3, false}, problems)
+    models = map(AdvectionDiffusion{3, false}, problems)
 
-  dgmodels = map(models) do m
-    (dg=create_dg(m, grid, EveryDirection()),
-     vdg=create_dg(m, grid, VerticalDirection()),
-     hdg=create_dg(m, grid, HorizontalDirection()))
-  end
+    dgmodels = map(models) do m
+        (
+            dg = create_dg(m, grid, EveryDirection()),
+            vdg = create_dg(m, grid, VerticalDirection()),
+            hdg = create_dg(m, grid, HorizontalDirection()),
+        )
+    end
 
-  Q = init_ode_state(dgmodels.p.dg, FT(0), init_on_cpu=true)
+    Q = init_ode_state(dgmodels.p.dg, FT(0), init_on_cpu = true)
 
-  # evaluate all combinations
-  dQ = map(x->map(dg->(dQ=similar(Q); dg(dQ, Q, nothing, FT(0)); dQ), x), dgmodels)
+    # evaluate all combinations
+    dQ = map(
+        x -> map(dg -> (dQ = similar(Q); dg(dQ, Q, nothing, FT(0)); dQ), x),
+        dgmodels,
+    )
 
-  # set up tolerances
-  atolm = 6e-13
-  atolv = 5e-5 / 5 ^ (level - 1)
-  atolh = 0.0002 / 5 ^ (level - 1)
+    # set up tolerances
+    atolm = 6e-13
+    atolv = 5e-5 / 5^(level - 1)
+    atolh = 0.0002 / 5^(level - 1)
 
-  @testset "total" begin
-    atol = topo <: Box || diff == nothing ? atolm : atolh
-    @test isapprox(norm(dQ.p.dg  .- dQ.p.vdg  .- dQ.p.hdg ), 0, atol = atol)
-    @test isapprox(norm(dQ.vp.dg .- dQ.vp.vdg .- dQ.vp.hdg), 0, atol = atol)
-    @test isapprox(norm(dQ.hp.dg .- dQ.hp.vdg .- dQ.hp.hdg), 0, atol = atol)
-  end
+    @testset "total" begin
+        atol = topo <: Box || diff == nothing ? atolm : atolh
+        @test isapprox(norm(dQ.p.dg .- dQ.p.vdg .- dQ.p.hdg), 0, atol = atol)
+        @test isapprox(norm(dQ.vp.dg .- dQ.vp.vdg .- dQ.vp.hdg), 0, atol = atol)
+        @test isapprox(norm(dQ.hp.dg .- dQ.hp.vdg .- dQ.hp.hdg), 0, atol = atol)
+    end
 
-  @testset "vertical" begin
-    atol = topo <: Box ? atolm : atolv
-    @test isapprox(norm(dQ.vp.dg .- dQ.vp.vdg), 0, atol = atol)
-    @test isapprox(norm(dQ.vp.hdg), 0, atol = atol)
-    @test isapprox(norm(dQ.vp.dg .- dQ.p.vdg), 0, atol = atol)
-  end
+    @testset "vertical" begin
+        atol = topo <: Box ? atolm : atolv
+        @test isapprox(norm(dQ.vp.dg .- dQ.vp.vdg), 0, atol = atol)
+        @test isapprox(norm(dQ.vp.hdg), 0, atol = atol)
+        @test isapprox(norm(dQ.vp.dg .- dQ.p.vdg), 0, atol = atol)
+    end
 
-  @testset "horizontal" begin
-    atol = topo <: Box ? atolm : atolh
-    @test isapprox(norm(dQ.hp.dg .- dQ.hp.hdg), 0, atol = atol)
-    @test isapprox(norm(dQ.hp.vdg), 0, atol = atol)
-    @test isapprox(norm(dQ.hp.dg - dQ.p.hdg), 0, atol = atol)
-  end
+    @testset "horizontal" begin
+        atol = topo <: Box ? atolm : atolh
+        @test isapprox(norm(dQ.hp.dg .- dQ.hp.hdg), 0, atol = atol)
+        @test isapprox(norm(dQ.hp.vdg), 0, atol = atol)
+        @test isapprox(norm(dQ.hp.dg - dQ.p.hdg), 0, atol = atol)
+    end
 end
 
 let
-  Random.seed!(44)
-  CLIMA.init()
-  ArrayType = CLIMA.array_type()
-  mpicomm = MPI.COMM_WORLD
-  FT = Float64
-  numlevels = 2
-  polynomialorder = 4
-  base_num_elem = 4
+    Random.seed!(44)
+    CLIMA.init()
+    ArrayType = CLIMA.array_type()
+    mpicomm = MPI.COMM_WORLD
+    FT = Float64
+    numlevels = 2
+    polynomialorder = 4
+    base_num_elem = 4
 
-  @testset "$(@__FILE__)" begin
-    @testset for topo in (Box{2}, Box{3}, Sphere)
-      @testset for (adv, diff) in
-          ((Advection, nothing), (nothing, Diffusion), (Advection, Diffusion))
-        @testset for level = 1:numlevels
-          Ne = 2 ^ (level - 1) * base_num_elem
-          run(adv, diff, topo, mpicomm, ArrayType, FT,
-              polynomialorder, Ne, level)
+    @testset "$(@__FILE__)" begin
+        @testset for topo in (Box{2}, Box{3}, Sphere)
+            @testset for (adv, diff) in (
+                (Advection, nothing),
+                (nothing, Diffusion),
+                (Advection, Diffusion),
+            )
+                @testset for level in 1:numlevels
+                    Ne = 2^(level - 1) * base_num_elem
+                    run(
+                        adv,
+                        diff,
+                        topo,
+                        mpicomm,
+                        ArrayType,
+                        FT,
+                        polynomialorder,
+                        Ne,
+                        level,
+                    )
+                end
+            end
         end
-      end
     end
-  end
 end
 nothing

--- a/test/Numerics/DGmethods/advection_diffusion/hyperdiffusion_model.jl
+++ b/test/Numerics/DGmethods/advection_diffusion/hyperdiffusion_model.jl
@@ -1,22 +1,35 @@
 using StaticArrays
 using CLIMA.VariableTemplates
-import CLIMA.DGmethods: BalanceLaw,
-                        vars_state_auxiliary, vars_state_conservative, vars_state_gradient, vars_state_gradient_flux,
-                        flux_first_order!, flux_second_order!, source!,
-                        compute_gradient_argument!, compute_gradient_flux!,
-                        init_state_auxiliary!, init_state_conservative!,
-                        boundary_state!, wavespeed, LocalGeometry,
-                        vars_gradient_laplacian, vars_hyperdiffusive,
-                        transform_post_gradient_laplacian!
-using CLIMA.DGmethods.NumericalFluxes: NumericalFluxFirstOrder,
-                                       NumericalFluxSecondOrder
+import CLIMA.DGmethods:
+    BalanceLaw,
+    vars_state_auxiliary,
+    vars_state_conservative,
+    vars_state_gradient,
+    vars_state_gradient_flux,
+    flux_first_order!,
+    flux_second_order!,
+    source!,
+    compute_gradient_argument!,
+    compute_gradient_flux!,
+    init_state_auxiliary!,
+    init_state_conservative!,
+    boundary_state!,
+    wavespeed,
+    LocalGeometry,
+    vars_gradient_laplacian,
+    vars_hyperdiffusive,
+    transform_post_gradient_laplacian!
+using CLIMA.DGmethods.NumericalFluxes:
+    NumericalFluxFirstOrder, NumericalFluxSecondOrder
 
 abstract type HyperDiffusionProblem end
 struct HyperDiffusion{dim, P} <: BalanceLaw
-  problem::P
-  function HyperDiffusion{dim}(problem::P) where {dim, P <: HyperDiffusionProblem}
-    new{dim, P}(problem)
-  end
+    problem::P
+    function HyperDiffusion{dim}(
+        problem::P,
+    ) where {dim, P <: HyperDiffusionProblem}
+        new{dim, P}(problem)
+    end
 end
 
 vars_state_auxiliary(::HyperDiffusion, FT) = @vars(D::SMatrix{3, 3, FT, 9})
@@ -31,11 +44,15 @@ vars_gradient_laplacian(::HyperDiffusion, FT) = @vars(ρ::FT)
 
 vars_state_gradient_flux(::HyperDiffusion, FT) = @vars()
 # The hyperdiffusion DG auxiliary variable: D ∇ Δρ
-vars_hyperdiffusive(::HyperDiffusion, FT) = @vars(σ::SVector{3,FT})
+vars_hyperdiffusive(::HyperDiffusion, FT) = @vars(σ::SVector{3, FT})
 
-function flux_first_order!(m::HyperDiffusion, flux::Grad, state::Vars,
-                            aux::Vars, t::Real)
-end
+function flux_first_order!(
+    m::HyperDiffusion,
+    flux::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+) end
 
 """
     flux_second_order!(m::HyperDiffusion, flux::Grad, state::Vars,
@@ -52,10 +69,17 @@ Where
 
  - `σ` is hyperdiffusion DG auxiliary variable (`σ = D ∇ Δρ` with D being the hyperdiffusion tensor)
 """
-function flux_second_order!(m::HyperDiffusion, flux::Grad, state::Vars,
-                         auxDG::Vars, auxHDG::Vars, aux::Vars, t::Real)
-  σ = auxHDG.σ
-  flux.ρ += σ
+function flux_second_order!(
+    m::HyperDiffusion,
+    flux::Grad,
+    state::Vars,
+    auxDG::Vars,
+    auxHDG::Vars,
+    aux::Vars,
+    t::Real,
+)
+    σ = auxHDG.σ
+    flux.ρ += σ
 end
 
 """
@@ -64,17 +88,28 @@ end
 
 Set the variable to take the gradient of (`ρ` in this case)
 """
-function compute_gradient_argument!(m::HyperDiffusion, transform::Vars, state::Vars,
-                        aux::Vars, t::Real)
-  transform.ρ = state.ρ
+function compute_gradient_argument!(
+    m::HyperDiffusion,
+    transform::Vars,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    transform.ρ = state.ρ
 end
 
 compute_gradient_flux!(m::HyperDiffusion, _...) = nothing
-function transform_post_gradient_laplacian!(m::HyperDiffusion, auxHDG::Vars, gradvars::Grad,
-                         state::Vars, aux::Vars, t::Real)
-  ∇Δρ = gradvars.ρ
-  D = aux.D
-  auxHDG.σ = D * ∇Δρ
+function transform_post_gradient_laplacian!(
+    m::HyperDiffusion,
+    auxHDG::Vars,
+    gradvars::Grad,
+    state::Vars,
+    aux::Vars,
+    t::Real,
+)
+    ∇Δρ = gradvars.ρ
+    D = aux.D
+    auxHDG.σ = D * ∇Δρ
 end
 
 """
@@ -89,13 +124,22 @@ source!(m::HyperDiffusion, _...) = nothing
 
 initialize the auxiliary state
 """
-function init_state_auxiliary!(m::HyperDiffusion, aux::Vars, geom::LocalGeometry)
-  init_hyperdiffusion_tensor!(m.problem, aux, geom)
+function init_state_auxiliary!(
+    m::HyperDiffusion,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    init_hyperdiffusion_tensor!(m.problem, aux, geom)
 end
 
-function init_state_conservative!(m::HyperDiffusion, state::Vars, aux::Vars,
-                     coords, t::Real)
-  initial_condition!(m.problem, state, aux, coords, t)
+function init_state_conservative!(
+    m::HyperDiffusion,
+    state::Vars,
+    aux::Vars,
+    coords,
+    t::Real,
+)
+    initial_condition!(m.problem, state, aux, coords, t)
 end
 
 boundary_state!(nf, ::HyperDiffusion, _...) = nothing

--- a/test/Numerics/DGmethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
+++ b/test/Numerics/DGmethods/advection_diffusion/periodic_3D_hyperdiffusion.jl
@@ -14,224 +14,293 @@ using CLIMA.ODESolvers
 using CLIMA.VTK: writevtk, writepvtu
 using CLIMA.Mesh.Grids: min_node_distance
 
-const output = parse(Bool, lowercase(get(ENV,"JULIA_CLIMA_OUTPUT","false")))
+const output = parse(Bool, lowercase(get(ENV, "JULIA_CLIMA_OUTPUT", "false")))
 
 if !@isdefined integration_testing
-  const integration_testing =
-    parse(Bool, lowercase(get(ENV,"JULIA_CLIMA_INTEGRATION_TESTING","false")))
+    const integration_testing = parse(
+        Bool,
+        lowercase(get(ENV, "JULIA_CLIMA_INTEGRATION_TESTING", "false")),
+    )
 end
 
 include("hyperdiffusion_model.jl")
 
 struct ConstantHyperDiffusion{dim, dir, FT} <: HyperDiffusionProblem
-  D::SMatrix{3, 3, FT, 9}
+    D::SMatrix{3, 3, FT, 9}
 end
 
-function init_hyperdiffusion_tensor!(problem::ConstantHyperDiffusion, aux::Vars,
-                                     geom::LocalGeometry)
-  aux.D = problem.D
+function init_hyperdiffusion_tensor!(
+    problem::ConstantHyperDiffusion,
+    aux::Vars,
+    geom::LocalGeometry,
+)
+    aux.D = problem.D
 end
 
-function initial_condition!(problem::ConstantHyperDiffusion{dim, dir}, state, aux, x, t) where {dim, dir}
-  @inbounds begin
-    k = SVector(1, 2, 3)
-    kD = k * k' .* problem.D
-    if dir === EveryDirection()
-      c = sum(abs2, k[SOneTo(dim)]) * sum(kD[SOneTo(dim), SOneTo(dim)])
-    elseif dir === HorizontalDirection()
-      c = sum(abs2, k[SOneTo(dim - 1)]) * sum(kD[SOneTo(dim - 1), SOneTo(dim - 1)])
-    elseif dir === VerticalDirection()
-      c = k[dim] ^ 2 * kD[dim, dim]
+function initial_condition!(
+    problem::ConstantHyperDiffusion{dim, dir},
+    state,
+    aux,
+    x,
+    t,
+) where {dim, dir}
+    @inbounds begin
+        k = SVector(1, 2, 3)
+        kD = k * k' .* problem.D
+        if dir === EveryDirection()
+            c = sum(abs2, k[SOneTo(dim)]) * sum(kD[SOneTo(dim), SOneTo(dim)])
+        elseif dir === HorizontalDirection()
+            c =
+                sum(abs2, k[SOneTo(dim - 1)]) *
+                sum(kD[SOneTo(dim - 1), SOneTo(dim - 1)])
+        elseif dir === VerticalDirection()
+            c = k[dim]^2 * kD[dim, dim]
+        end
+        state.ρ = sin(dot(k[SOneTo(dim)], x[SOneTo(dim)])) * exp(-c * t)
     end
-    state.ρ = sin(dot(k[SOneTo(dim)], x[SOneTo(dim)])) * exp(-c * t)
-  end
 end
 
 function do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model, testname)
-  ## name of the file that this MPI rank will write
-  filename = @sprintf("%s/%s_mpirank%04d_step%04d",
-                      vtkdir, testname, MPI.Comm_rank(mpicomm), vtkstep)
+    ## name of the file that this MPI rank will write
+    filename = @sprintf(
+        "%s/%s_mpirank%04d_step%04d",
+        vtkdir,
+        testname,
+        MPI.Comm_rank(mpicomm),
+        vtkstep
+    )
 
-  statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
-  exactnames = statenames .* "_exact"
+    statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+    exactnames = statenames .* "_exact"
 
-  writevtk(filename, Q, dg, statenames, Qe, exactnames)
+    writevtk(filename, Q, dg, statenames, Qe, exactnames)
 
-  ## Generate the pvtu file for these vtk files
-  if MPI.Comm_rank(mpicomm) == 0
-    ## name of the pvtu file
-    pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
+    ## Generate the pvtu file for these vtk files
+    if MPI.Comm_rank(mpicomm) == 0
+        ## name of the pvtu file
+        pvtuprefix = @sprintf("%s/%s_step%04d", vtkdir, testname, vtkstep)
 
-    ## name of each of the ranks vtk files
-    prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
-      @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        ## name of each of the ranks vtk files
+        prefixes = ntuple(MPI.Comm_size(mpicomm)) do i
+            @sprintf("%s_mpirank%04d_step%04d", testname, i - 1, vtkstep)
+        end
+
+        writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
+
+        @info "Done writing VTK: $pvtuprefix"
     end
-
-    writepvtu(pvtuprefix, prefixes, (statenames..., exactnames...))
-
-    @info "Done writing VTK: $pvtuprefix"
-  end
 end
 
 
-function run(mpicomm, ArrayType, dim, topl, N, timeend, FT, direction,
-             D, vtkdir, outputtime)
+function run(
+    mpicomm,
+    ArrayType,
+    dim,
+    topl,
+    N,
+    timeend,
+    FT,
+    direction,
+    D,
+    vtkdir,
+    outputtime,
+)
 
-  grid = DiscontinuousSpectralElementGrid(topl,
-                                          FloatType = FT,
-                                          DeviceArray = ArrayType,
-                                          polynomialorder = N,
-                                         )
+    grid = DiscontinuousSpectralElementGrid(
+        topl,
+        FloatType = FT,
+        DeviceArray = ArrayType,
+        polynomialorder = N,
+    )
 
-  dx = min_node_distance(grid)
-  dt = dx ^ 4 / 25 / sum(D)
-  @info "time step" dt
-  dt = outputtime / ceil(Int64, outputtime / dt)
+    dx = min_node_distance(grid)
+    dt = dx^4 / 25 / sum(D)
+    @info "time step" dt
+    dt = outputtime / ceil(Int64, outputtime / dt)
 
-  model = HyperDiffusion{dim}(ConstantHyperDiffusion{dim, direction(), FT}(D))
-  dg = DGModel(model,
-               grid,
-               CentralNumericalFluxFirstOrder(),
-               CentralNumericalFluxSecondOrder(),
-               CentralNumericalFluxGradient(),
-               direction=direction())
+    model = HyperDiffusion{dim}(ConstantHyperDiffusion{dim, direction(), FT}(D))
+    dg = DGModel(
+        model,
+        grid,
+        CentralNumericalFluxFirstOrder(),
+        CentralNumericalFluxSecondOrder(),
+        CentralNumericalFluxGradient(),
+        direction = direction(),
+    )
 
-  Q = init_ode_state(dg, FT(0))
+    Q = init_ode_state(dg, FT(0))
 
-  lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
+    lsrk = LSRK54CarpenterKennedy(dg, Q; dt = dt, t0 = 0)
 
-  eng0 = norm(Q)
-  @info @sprintf """Starting
-  norm(Q₀) = %.16e""" eng0
+    eng0 = norm(Q)
+    @info @sprintf """Starting
+    norm(Q₀) = %.16e""" eng0
 
-  # Set up the information callback
-  starttime = Ref(now())
-  cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s=false)
-    if s
-      starttime[] = now()
-    else
-      energy = norm(Q)
-      @info @sprintf("""Update
-                     simtime = %.16e
-                     runtime = %s
-                     norm(Q) = %.16e""", gettime(lsrk),
-                     Dates.format(convert(Dates.DateTime,
-                                          Dates.now()-starttime[]),
-                                  Dates.dateformat"HH:MM:SS"),
-                     energy)
+    # Set up the information callback
+    starttime = Ref(now())
+    cbinfo = EveryXWallTimeSeconds(60, mpicomm) do (s = false)
+        if s
+            starttime[] = now()
+        else
+            energy = norm(Q)
+            @info @sprintf(
+                """Update
+                simtime = %.16e
+                runtime = %s
+                norm(Q) = %.16e""",
+                gettime(lsrk),
+                Dates.format(
+                    convert(Dates.DateTime, Dates.now() - starttime[]),
+                    Dates.dateformat"HH:MM:SS",
+                ),
+                energy
+            )
+        end
     end
-  end
-  callbacks = (cbinfo,)
-  if ~isnothing(vtkdir)
-    # create vtk dir
-    mkpath(vtkdir)
+    callbacks = (cbinfo,)
+    if ~isnothing(vtkdir)
+        # create vtk dir
+        mkpath(vtkdir)
 
-    vtkstep = 0
-    # output initial step
-    do_output(mpicomm, vtkdir, vtkstep, dg, Q, Q, model, "hyperdiffusion")
+        vtkstep = 0
+        # output initial step
+        do_output(mpicomm, vtkdir, vtkstep, dg, Q, Q, model, "hyperdiffusion")
 
-    # setup the output callback
-    cbvtk = EveryXSimulationSteps(floor(outputtime/dt)) do
-      vtkstep += 1
-      Qe = init_ode_state(dg, gettime(lsrk))
-      do_output(mpicomm, vtkdir, vtkstep, dg, Q, Qe, model,
-                "hyperdiffusion")
+        # setup the output callback
+        cbvtk = EveryXSimulationSteps(floor(outputtime / dt)) do
+            vtkstep += 1
+            Qe = init_ode_state(dg, gettime(lsrk))
+            do_output(
+                mpicomm,
+                vtkdir,
+                vtkstep,
+                dg,
+                Q,
+                Qe,
+                model,
+                "hyperdiffusion",
+            )
+        end
+        callbacks = (callbacks..., cbvtk)
     end
-    callbacks = (callbacks..., cbvtk)
-  end
 
-  solve!(Q, lsrk; timeend=timeend, callbacks=callbacks)
+    solve!(Q, lsrk; timeend = timeend, callbacks = callbacks)
 
-  # Print some end of the simulation information
-  engf = norm(Q)
-  Qe = init_ode_state(dg, FT(timeend))
+    # Print some end of the simulation information
+    engf = norm(Q)
+    Qe = init_ode_state(dg, FT(timeend))
 
-  engfe = norm(Qe)
-  errf = euclidean_distance(Q, Qe)
-  @info @sprintf """Finished
-  norm(Q)                 = %.16e
-  norm(Q) / norm(Q₀)      = %.16e
-  norm(Q) - norm(Q₀)      = %.16e
-  norm(Q - Qe)            = %.16e
-  norm(Q - Qe) / norm(Qe) = %.16e
-  """ engf engf/eng0 engf-eng0 errf errf / engfe
-  errf
+    engfe = norm(Qe)
+    errf = euclidean_distance(Q, Qe)
+    @info @sprintf """Finished
+    norm(Q)                 = %.16e
+    norm(Q) / norm(Q₀)      = %.16e
+    norm(Q) - norm(Q₀)      = %.16e
+    norm(Q - Qe)            = %.16e
+    norm(Q - Qe) / norm(Qe) = %.16e
+    """ engf engf / eng0 engf - eng0 errf errf / engfe
+    errf
 end
 
 using Test
 let
-  CLIMA.init()
-  ArrayType = CLIMA.array_type()
-  mpicomm = MPI.COMM_WORLD
+    CLIMA.init()
+    ArrayType = CLIMA.array_type()
+    mpicomm = MPI.COMM_WORLD
 
-  numlevels = integration_testing || CLIMA.Settings.integration_testing ? 3 : 1
+    numlevels =
+        integration_testing || CLIMA.Settings.integration_testing ? 3 : 1
 
-  polynomialorder = 4
-  base_num_elem = 4
+    polynomialorder = 4
+    base_num_elem = 4
 
-  expected_result = Dict()
-  expected_result[2, 1, Float64, EveryDirection] = 7.6772960298563120e-03
-  expected_result[2, 2, Float64, EveryDirection] = 2.3268371815073617e-03
-  expected_result[2, 3, Float64, EveryDirection] = 4.2641957936779901e-05
-  expected_result[2, 1, Float64, HorizontalDirection] = 8.4650675812606650e-04
-  expected_result[2, 2, Float64, HorizontalDirection] = 4.4626814795055979e-05
-  expected_result[2, 3, Float64, HorizontalDirection] = 1.2193396277823764e-06
-  expected_result[2, 1, Float64, VerticalDirection] = 6.1690465335730834e-03
-  expected_result[2, 2, Float64, VerticalDirection] = 2.3407593209031621e-03
-  expected_result[2, 3, Float64, VerticalDirection] = 4.3775160749787010e-05
+    expected_result = Dict()
+    expected_result[2, 1, Float64, EveryDirection] = 7.6772960298563120e-03
+    expected_result[2, 2, Float64, EveryDirection] = 2.3268371815073617e-03
+    expected_result[2, 3, Float64, EveryDirection] = 4.2641957936779901e-05
+    expected_result[2, 1, Float64, HorizontalDirection] = 8.4650675812606650e-04
+    expected_result[2, 2, Float64, HorizontalDirection] = 4.4626814795055979e-05
+    expected_result[2, 3, Float64, HorizontalDirection] = 1.2193396277823764e-06
+    expected_result[2, 1, Float64, VerticalDirection] = 6.1690465335730834e-03
+    expected_result[2, 2, Float64, VerticalDirection] = 2.3407593209031621e-03
+    expected_result[2, 3, Float64, VerticalDirection] = 4.3775160749787010e-05
 
-  expected_result[3, 1, Float64, EveryDirection] = 1.7363355506160003e-01
-  expected_result[3, 2, Float64, EveryDirection] = 7.3049474767548042e-02
-  expected_result[3, 3, Float64, EveryDirection] = 5.8530711333407105e-04
-  expected_result[3, 1, Float64, HorizontalDirection] = 1.9244127301149615e-02
-  expected_result[3, 2, Float64, HorizontalDirection] = 5.8325158696244947e-03
-  expected_result[3, 3, Float64, HorizontalDirection] = 1.0688753745025491e-04
-  expected_result[3, 1, Float64, VerticalDirection] = 1.4412891107361228e-01
-  expected_result[3, 2, Float64, VerticalDirection] = 6.3744013545812925e-02
-  expected_result[3, 3, Float64, VerticalDirection] = 9.0891011404938341e-04
+    expected_result[3, 1, Float64, EveryDirection] = 1.7363355506160003e-01
+    expected_result[3, 2, Float64, EveryDirection] = 7.3049474767548042e-02
+    expected_result[3, 3, Float64, EveryDirection] = 5.8530711333407105e-04
+    expected_result[3, 1, Float64, HorizontalDirection] = 1.9244127301149615e-02
+    expected_result[3, 2, Float64, HorizontalDirection] = 5.8325158696244947e-03
+    expected_result[3, 3, Float64, HorizontalDirection] = 1.0688753745025491e-04
+    expected_result[3, 1, Float64, VerticalDirection] = 1.4412891107361228e-01
+    expected_result[3, 2, Float64, VerticalDirection] = 6.3744013545812925e-02
+    expected_result[3, 3, Float64, VerticalDirection] = 9.0891011404938341e-04
 
-  numlevels = integration_testing ? 3 : 1
-  for FT in (Float64,)
-    D = 1 // 100 * SMatrix{3, 3, FT}(9 // 50, 3 // 50, 5  // 50,
-                                     3 // 50, 7 // 50, 4  // 50,
-                                     5 // 50, 4 // 50, 10 // 50)
+    numlevels = integration_testing ? 3 : 1
+    for FT in (Float64,)
+        D =
+            1 // 100 * SMatrix{3, 3, FT}(
+                9 // 50,
+                3 // 50,
+                5 // 50,
+                3 // 50,
+                7 // 50,
+                4 // 50,
+                5 // 50,
+                4 // 50,
+                10 // 50,
+            )
 
-    result = zeros(FT, numlevels)
-    for dim in (2, 3)
-      for direction in (EveryDirection, HorizontalDirection, VerticalDirection)
-        for l = 1:numlevels
-          Ne = 2^(l-1) * base_num_elem
-          xrange = range(FT(0); length=Ne+1, stop=FT(2pi))
-          brickrange = ntuple(j->xrange, dim)
-          periodicity = ntuple(j->true, dim)
-          topl = StackedBrickTopology(mpicomm, brickrange;
-                                      periodicity = periodicity)
-          timeend = 1
-          outputtime = 1
+        result = zeros(FT, numlevels)
+        for dim in (2, 3)
+            for direction in
+                (EveryDirection, HorizontalDirection, VerticalDirection)
+                for l in 1:numlevels
+                    Ne = 2^(l - 1) * base_num_elem
+                    xrange = range(FT(0); length = Ne + 1, stop = FT(2pi))
+                    brickrange = ntuple(j -> xrange, dim)
+                    periodicity = ntuple(j -> true, dim)
+                    topl = StackedBrickTopology(
+                        mpicomm,
+                        brickrange;
+                        periodicity = periodicity,
+                    )
+                    timeend = 1
+                    outputtime = 1
 
-          @info (ArrayType, FT, dim, direction)
-          vtkdir = output ? "vtk_hyperdiffusion" *
-                            "_poly$(polynomialorder)" *
-                            "_dim$(dim)_$(ArrayType)_$(FT)_$(direction)" *
-                            "_level$(l)" : nothing
-          result[l] = run(mpicomm, ArrayType, dim, topl, polynomialorder,
-                          timeend, FT, direction, D, vtkdir,
-                          outputtime)
+                    @info (ArrayType, FT, dim, direction)
+                    vtkdir = output ?
+                        "vtk_hyperdiffusion" *
+                    "_poly$(polynomialorder)" *
+                    "_dim$(dim)_$(ArrayType)_$(FT)_$(direction)" *
+                    "_level$(l)" :
+                        nothing
+                    result[l] = run(
+                        mpicomm,
+                        ArrayType,
+                        dim,
+                        topl,
+                        polynomialorder,
+                        timeend,
+                        FT,
+                        direction,
+                        D,
+                        vtkdir,
+                        outputtime,
+                    )
 
-          @test result[l] ≈ FT(expected_result[dim, l, FT, direction])
+                    @test result[l] ≈ FT(expected_result[dim, l, FT, direction])
+                end
+                @info begin
+                    msg = ""
+                    for l in 1:(numlevels - 1)
+                        rate = log2(result[l]) - log2(result[l + 1])
+                        msg *= @sprintf("\n  rate for level %d = %e\n", l, rate)
+                    end
+                    msg
+                end
+            end
         end
-        @info begin
-          msg = ""
-          for l = 1:numlevels-1
-            rate = log2(result[l]) - log2(result[l+1])
-            msg *= @sprintf("\n  rate for level %d = %e\n", l, rate)
-          end
-          msg
-        end
-      end
     end
-  end
 end
 
 nothing
-

--- a/test/Numerics/DGmethods/compressible_Navier_Stokes/ref_state.jl
+++ b/test/Numerics/DGmethods/compressible_Navier_Stokes/ref_state.jl
@@ -66,7 +66,12 @@ function run1(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
 
     mkpath("vtk")
     outprefix = @sprintf("vtk/refstate")
-    writevtk(outprefix, dg.state_auxiliary, dg, flattenednames(vars_state_auxiliary(model, FT)))
+    writevtk(
+        outprefix,
+        dg.state_auxiliary,
+        dg,
+        flattenednames(vars_state_auxiliary(model, FT)),
+    )
     return FT(0)
 end
 
@@ -103,7 +108,12 @@ function run2(mpicomm, ArrayType, dim, topl, N, timeend, FT, dt)
 
     mkpath("vtk")
     outprefix = @sprintf("vtk/refstate")
-    writevtk(outprefix, dg.state_auxiliary, dg, flattenednames(vars_state_auxiliary(model, FT)))
+    writevtk(
+        outprefix,
+        dg.state_auxiliary,
+        dg,
+        flattenednames(vars_state_auxiliary(model, FT)),
+    )
     return FT(0)
 end
 

--- a/test/Numerics/DGmethods/conservation/sphere.jl
+++ b/test/Numerics/DGmethods/conservation/sphere.jl
@@ -52,7 +52,11 @@ vars_state_conservative(::ConservationTestModel, T) = @vars(q::T, p::T)
 vars_state_gradient(::ConservationTestModel, T) = @vars()
 vars_state_gradient_flux(::ConservationTestModel, T) = @vars()
 
-function init_state_auxiliary!(::ConservationTestModel, aux::Vars, g::LocalGeometry)
+function init_state_auxiliary!(
+    ::ConservationTestModel,
+    aux::Vars,
+    g::LocalGeometry,
+)
     x, y, z = g.coord
     r = x^2 + y^2 + z^2
     aux.vel = SVector(
@@ -62,7 +66,13 @@ function init_state_auxiliary!(::ConservationTestModel, aux::Vars, g::LocalGeome
     )
 end
 
-function init_state_conservative!(::ConservationTestModel, state::Vars, aux::Vars, coord, t)
+function init_state_conservative!(
+    ::ConservationTestModel,
+    state::Vars,
+    aux::Vars,
+    coord,
+    t,
+)
     state.q = rand()
     state.p = rand()
 end

--- a/test/Numerics/DGmethods/courant.jl
+++ b/test/Numerics/DGmethods/courant.jl
@@ -10,7 +10,9 @@ using Printf
 using LinearAlgebra
 using CLIMA.DGmethods: DGModel, init_ode_state, LocalGeometry, courant
 using CLIMA.DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxGradient, CentralNumericalFluxSecondOrder
+    RusanovNumericalFlux,
+    CentralNumericalFluxGradient,
+    CentralNumericalFluxSecondOrder
 using CLIMA.Courant
 using CLIMA.Atmos:
     AtmosModel,

--- a/test/Numerics/DGmethods/integral_test.jl
+++ b/test/Numerics/DGmethods/integral_test.jl
@@ -171,10 +171,14 @@ function run(mpicomm, dim, Ne, N, FT, ArrayType)
     dg(dQdt, Q, nothing, 0.0)
 
     # Wrapping in Array ensure both GPU and CPU code use same approx
-    @test Array(dg.state_auxiliary.data[:, 1, :]) ≈ Array(dg.state_auxiliary.data[:, 8, :])
-    @test Array(dg.state_auxiliary.data[:, 2, :]) ≈ Array(dg.state_auxiliary.data[:, 9, :])
-    @test Array(dg.state_auxiliary.data[:, 3, :]) ≈ Array(dg.state_auxiliary.data[:, 10, :])
-    @test Array(dg.state_auxiliary.data[:, 4, :]) ≈ Array(dg.state_auxiliary.data[:, 11, :])
+    @test Array(dg.state_auxiliary.data[:, 1, :]) ≈
+          Array(dg.state_auxiliary.data[:, 8, :])
+    @test Array(dg.state_auxiliary.data[:, 2, :]) ≈
+          Array(dg.state_auxiliary.data[:, 9, :])
+    @test Array(dg.state_auxiliary.data[:, 3, :]) ≈
+          Array(dg.state_auxiliary.data[:, 10, :])
+    @test Array(dg.state_auxiliary.data[:, 4, :]) ≈
+          Array(dg.state_auxiliary.data[:, 11, :])
 end
 
 let

--- a/test/Numerics/DGmethods/integral_test_sphere.jl
+++ b/test/Numerics/DGmethods/integral_test_sphere.jl
@@ -72,7 +72,11 @@ boundary_state!(_, ::IntegralTestSphereModel, _...) = nothing
 init_state_conservative!(::IntegralTestSphereModel, _...) = nothing
 wavespeed(::IntegralTestSphereModel, _...) = 1
 
-function init_state_auxiliary!(m::IntegralTestSphereModel, aux::Vars, g::LocalGeometry)
+function init_state_auxiliary!(
+    m::IntegralTestSphereModel,
+    aux::Vars,
+    g::LocalGeometry,
+)
 
     x, y, z = g.coord
     aux.r = hypot(x, y, z)

--- a/test/Numerics/DGmethods/vars_test.jl
+++ b/test/Numerics/DGmethods/vars_test.jl
@@ -34,7 +34,8 @@ import CLIMA.DGmethods:
 struct VarsTestModel{dim} <: BalanceLaw end
 
 vars_state_conservative(::VarsTestModel, T) = @vars(x::T, coord::SVector{3, T})
-vars_state_auxiliary(m::VarsTestModel, T) = @vars(coord::SVector{3, T}, polynomial::T)
+vars_state_auxiliary(m::VarsTestModel, T) =
+    @vars(coord::SVector{3, T}, polynomial::T)
 vars_state_gradient_flux(m::VarsTestModel, T) = @vars()
 
 flux_first_order!(::VarsTestModel, _...) = nothing
@@ -43,7 +44,13 @@ source!(::VarsTestModel, _...) = nothing
 boundary_state!(_, ::VarsTestModel, _...) = nothing
 wavespeed(::VarsTestModel, _...) = 1
 
-function init_state_conservative!(m::VarsTestModel, state::Vars, aux::Vars, coord, t::Real)
+function init_state_conservative!(
+    m::VarsTestModel,
+    state::Vars,
+    aux::Vars,
+    coord,
+    t::Real,
+)
     @inbounds state.x = coord[1]
     state.coord = coord
 end
@@ -87,7 +94,8 @@ function run(mpicomm, dim, Ne, N, FT, ArrayType)
     x = Array(Q.coord)[:, 1, :]
     y = Array(Q.coord)[:, 2, :]
     z = Array(Q.coord)[:, 3, :]
-    @test Array(dg.state_auxiliary.polynomial)[:, 1, :] ≈ x .* y + x .* z + y .* z
+    @test Array(dg.state_auxiliary.polynomial)[:, 1, :] ≈
+          x .* y + x .* z + y .* z
 end
 
 let

--- a/test/Numerics/LinearSolvers/bandedsystem.jl
+++ b/test/Numerics/LinearSolvers/bandedsystem.jl
@@ -7,10 +7,17 @@ using Logging
 using LinearAlgebra
 using Random
 using StaticArrays
-using CLIMA.DGmethods: DGModel, Vars, vars_state_conservative, number_state_conservative, init_ode_state
+using CLIMA.DGmethods:
+    DGModel,
+    Vars,
+    vars_state_conservative,
+    number_state_conservative,
+    init_ode_state
 using CLIMA.ColumnwiseLUSolver: banded_matrix, banded_matrix_vector_product!
 using CLIMA.DGmethods.NumericalFluxes:
-    RusanovNumericalFlux, CentralNumericalFluxSecondOrder, CentralNumericalFluxGradient
+    RusanovNumericalFlux,
+    CentralNumericalFluxSecondOrder,
+    CentralNumericalFluxGradient
 using CLIMA.MPIStateArrays: MPIStateArray, euclidean_distance
 
 using Test

--- a/test/Numerics/LinearSolvers/columnwiselu.jl
+++ b/test/Numerics/LinearSolvers/columnwiselu.jl
@@ -6,7 +6,8 @@ using KernelAbstractions, StaticArrays
 
 using CLIMA
 using CLIMA.LinearSolvers
-using CLIMA.ColumnwiseLUSolver: band_lu_kernel!, band_forward_kernel!, band_back_kernel!
+using CLIMA.ColumnwiseLUSolver:
+    band_lu_kernel!, band_forward_kernel!, band_back_kernel!
 
 
 CLIMA.init()

--- a/test/Numerics/LinearSolvers/poisson.jl
+++ b/test/Numerics/LinearSolvers/poisson.jl
@@ -74,7 +74,8 @@ end
 struct PenaltyNumFluxDiffusive <: NumericalFluxSecondOrder end
 
 # There is no boundary since we are periodic
-numerical_boundary_flux_second_order!(nf::PenaltyNumFluxDiffusive, _...) = nothing
+numerical_boundary_flux_second_order!(nf::PenaltyNumFluxDiffusive, _...) =
+    nothing
 
 function numerical_flux_second_order!(
     ::PenaltyNumFluxDiffusive,
@@ -142,7 +143,11 @@ sol1d(x) = sin(2pi * x)^4 - 3 / 8
 dxx_sol1d(x) =
     -16 * pi^2 * sin(2pi * x)^2 * (sin(2pi * x)^2 - 3 * cos(2pi * x)^2)
 
-function init_state_auxiliary!(::PoissonModel{dim}, aux::Vars, g::LocalGeometry) where {dim}
+function init_state_auxiliary!(
+    ::PoissonModel{dim},
+    aux::Vars,
+    g::LocalGeometry,
+) where {dim}
     aux.rhs_ϕ = 0
     @inbounds for d in 1:dim
         x1 = g.coord[d]

--- a/test/Numerics/Mesh/filter.jl
+++ b/test/Numerics/Mesh/filter.jl
@@ -184,7 +184,8 @@ end
     end
 end
 
-CLIMA.DGmethods.vars_state_conservative(::FilterTestModel{1}, FT) where {N} = @vars(q::FT)
+CLIMA.DGmethods.vars_state_conservative(::FilterTestModel{1}, FT) where {N} =
+    @vars(q::FT)
 function CLIMA.DGmethods.init_state_conservative!(
     ::FilterTestModel{1},
     state::Vars,

--- a/test/Ocean/ShallowWater/GyreDriver.jl
+++ b/test/Ocean/ShallowWater/GyreDriver.jl
@@ -139,7 +139,8 @@ function run(mpicomm, topl, ArrayType, N, dt, FT, model, test)
                 step[1]
             )
             @debug "doing VTK output" outprefix
-            statenames = flattenednames(vars_state_conservative(model, eltype(Q)))
+            statenames =
+                flattenednames(vars_state_conservative(model, eltype(Q)))
             auxnames = flattenednames(vars_state_auxiliary(model, eltype(Q)))
             writevtk(outprefix, Q, dg, statenames, dg.state_auxiliary, auxnames)
             step[1] += 1

--- a/tutorials/Microphysics/KinematicModel.jl
+++ b/tutorials/Microphysics/KinematicModel.jl
@@ -126,7 +126,11 @@ vars_state_gradient(m::KinematicModel, FT) = @vars()
 
 vars_state_gradient_flux(m::KinematicModel, FT) = @vars()
 
-function init_state_auxiliary!(m::KinematicModel, aux::Vars, geom::LocalGeometry)
+function init_state_auxiliary!(
+    m::KinematicModel,
+    aux::Vars,
+    geom::LocalGeometry,
+)
 
     FT = eltype(aux)
     x, y, z = geom.coord
@@ -170,7 +174,14 @@ function update_auxiliary_state!(
     t::Real,
     elems::UnitRange,
 )
-    nodal_update_auxiliary_state!(kinematic_model_nodal_update_auxiliary_state!, dg, m, Q, t, elems)
+    nodal_update_auxiliary_state!(
+        kinematic_model_nodal_update_auxiliary_state!,
+        dg,
+        m,
+        Q,
+        t,
+        elems,
+    )
     return true
 end
 


### PR DESCRIPTION
# Description

The formatter seems to have not been run on PR #961, this corrects that.

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [x] Updated the documentation to reflect changes from this PR.

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [x] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
