### PR TITLE
BalanceLaw Documentation consistent with #961

### DIFF
--- a/docs/src/ExtendingCLIMA/Numerics/DGmethods/how_to_make_a_balance_law.md
+++ b/docs/src/ExtendingCLIMA/Numerics/DGmethods/how_to_make_a_balance_law.md
@@ -8,31 +8,62 @@ Defining the set of solved PDEs in CLIMA revolve around defining a [`BalanceLaw`
 ∂t
 ```
 
-Here, `Y`, `Σ`, `F_{first_order}`, `F_{second_order}`, , and `S_{non_conservative}` can be thought of column vectors[^1] expressing:
+Here, `Y`, `Σ`, `F_{first_order}`, `F_{second_order}`, and `S_{non_conservative}` can be thought of column vectors[^1] expressing:
 
- - `Y` the state variables, or unknowns of the PDEs to be solved
- - `Σ` gradients of variables
- - `F_{diffusive}` is non-diffusive fluxes (are **not** functions of gradients of any variables)
- - `F_{non_diffusive}` is diffusive fluxes (are functions of gradients of any variables)
+ - `Y` the conservative state variables, or unknowns of the PDEs to be solved
+ - `Σ` the gradients of functions of the conservative state variables
+ - `F_{first-order}` contains all first-order fluxes (e.g. **not** functions of gradients of any variables)
+ - `F_{second-order}` contains all second-order and higher-order fluxes (e.g. functions of gradients of any variables)
  - `S_{non_conservative}` non-conservative sources[^2]
 
-In order to alleviate users from being concerned with the burden of spatial discretization, users must provide their own implementations of the following methods:
+In order to alleviate users from being concerned with the burden of spatial discretization, users must provide their own implementations of the following methods, which are computed locally at each nodal point:
 
 ## Variable name specification methods
+| **Method** | Necessary | Purpose |
+|:-----|:-|:----|
+| [`vars_state_conservative`](@ref)         | **YES** |  specify the names of the variables in the conservative state vector, typically mass, momentum, and various tracers. |
+| [`vars_state_auxiliary`](@ref)           | **YES** |  specify the names of any variables required for the balance law that aren't related to derivatives of the state variables (e.g. spatial coordinates or various integrals) or those needed to solve expensive auxiliary equations (e.g., temperature via a non-linear equation solve)     |
+| [`vars_state_gradient`](@ref)         | **YES** |  specify the names of the gradients of functions of the conservative state variables. used to represent values before **and** after differentiation |
+| [`vars_state_gradient_flux`](@ref)         | **YES** |  specify the names of the gradient fluxes necessary to impose Neumann boundary conditions. typically the product of a diffusivity tensor with a gradient state variable, potentially equivalent to the second-order flux for a conservative state variable |
+| [`vars_integrals`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integrals from **bottom to top** of the domain required for the balance law. used to represent both the integrand **and** the resulting indefinite integral |
+| [`vars_reverse_integrals`](@ref)         | **NO** |  specify the names of any one-dimensional vertical integral from **top to bottom** of the domain required for the balance law. each variable here must also exist in `vars_integrals` since the reverse integral kernels use subtraction to reverse the integral instead of performing a new integral. use to represent the value before **and** after reversing direction |
+
+## Methods to compute gradients and integrals
+| **Method** |  Purpose |
+|:-----|:-----|
+| [`compute_gradient_argument!`](@ref) | specify how to compute the arguments to the gradients. can be functions of conservative state  and auxiliary variables. |
+| [`compute_gradient_flux!`](@ref) | specify how to compute gradient fluxes. can be a functions of the gradient state, the conservative state, and auxiliary variables.|
+| [`integral_load_auxiliary_state!`](@ref) | specify how to compute integrands. can be functions of the conservative state and auxiliary variables. |
+| [`integral_set_auxiliary_state!`](@ref) | specify which auxiliary variables are used to store the output of the integrals. |
+| [`reverse_integral_load_auxiliary_state!`](@ref) | specify auxiliary variables need their integrals reversed. |
+| [`reverse_integral_set_auxiliary_state!`](@ref) | specify which auxiliary variables are used to store the output of the reversed integrals. |
+| [`update_auxiliary_state!`](@ref) | perform any updates to the auxiliary variables needed at the beginning of each time-step. Can be used to solve non-linear equations, calculate integrals, and apply filters. |
+| [`update_auxiliary_state_gradient!`](@ref) | same as above, but after computing gradients and gradient fluxes in case these variables are needed during the update. |
+
+
+## Methods to compute fluxes and sources
 | **Method** | Purpose |
 |:-----|:-----|
-| [`vars_state_conservative`](@ref)         |  specify the names of the unknowns |
-| [`vars_state_auxiliary`](@ref)           |  specify variable names needed to solve expensive auxiliary equations (e.g., temperature via a non-linear equation solve)     |
+| [`flux_first_order!`](@ref) |  specify `F_{first_order}` for each conservative state variable. can be functions of the conservative state and auxiliary variables. |
+| [`flux_second_order!`](@ref)    |  specify `F_{second_order}` for each conservative state variable. can be functions of the conservative state, gradient flux state, and auxiliary variables. |
+| [`source!`](@ref)            |  specify `S_{non_conservative}`  for each conservative state variable. can be functions of the conservative state, gradient flux state, and auxiliary variables. |
 
-## Methods to compute RHS source terms / BCs
+## Methods to compute numerical fluxes
 | **Method** | Purpose |
 |:-----|:-----|
-| [`flux_first_order!`](@ref) |  specify `F_{first_order}`       |
-| [`flux_second_order!`](@ref)    |  specify `F_{second_order}`           |
-| [`source!`](@ref)            |  specify `S_{non_conservative}`    |
+| [`wavespeed`](@ref) | specify how to compute the local wavespeed if using the `RusanovNumericalFlux`. |
+| [`boundary_state!`](@ref) | define exterior nodal values of the conservative state and gradient flux state used to compute the numerical boundary fluxes. |
+
+## Methods to set initial conditions
+| **Method** | Purpose |
+|:-----|:-----|
+| [`init_state_conservative!`](@ref) | provide initial values for the conservative state as a function of time and space. |
+| [`init_state_auxiliary!`](@ref) | provide initial values for the auxiliary variables as a function of the geometry. |
 
 
-While `Y` can be thought of a column vector (each _row_ of which corresponding to each equation), the _second_ function argument inside these methods behave as dictionaries, for example:
+## General Remarks
+
+While `Y` can be thought of a column vector (each _row_ of which corresponds to each state variable and its prognostic equation), the _second_ function argument inside these methods behave as dictionaries, for example:
 
 ```
 struct MyModel <: BalanceLaw end

--- a/src/Numerics/DGmethods/balancelaw.jl
+++ b/src/Numerics/DGmethods/balancelaw.jl
@@ -69,8 +69,8 @@ function flux_first_order! end
 function flux_second_order! end
 function source! end
 
-function compute_gradient_argument! end
-function compute_gradient_flux! end
+compute_gradient_argument!(::BalanceLaw, args...) = nothing
+compute_gradient_flux!(::BalanceLaw, args...) = nothing
 function transform_post_gradient_laplacian! end
 
 function wavespeed end

--- a/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/HydrostaticBoussinesqModel.jl
@@ -153,17 +153,13 @@ helper variables for computation
 first half is because there is no dedicated integral kernels
 these variables are used to compute vertical integrals
 w = vertical velocity
-w_reverse = w but integrated in the opposite direction
 wz0 = w at z = 0
 pkin = bulk hydrostatic pressure contribution
-pkin_reverse = pkin but integrated in the opposite direction
+
 
 second half of these are fields that are used for computation
-θʳ = relaxation value of the sea surface temperature
-f = coriolis force
-τ = wind stress
-ν = vector of viscosities (zonal, meridional, vertical)
-κ = vector of diffusivities (zonal, meridional, vertical)
+y = north-south coordinate
+
 """
 # If this order is changed check update_auxiliary_state!
 function vars_state_auxiliary(m::HBModel, T)


### PR DESCRIPTION
# Description

Updates the documentation for "How to make a Balance Law" with all the functions necessary and descriptions, with terminology updated to match #961. Improvements can be made upon this, but this should be good as a quick start guide.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
