### PR TITLE
Add docs file filter

### DIFF
--- a/docs/list_of_tutorials.jl
+++ b/docs/list_of_tutorials.jl
@@ -22,6 +22,7 @@ if generate_tutorials
         for (root, dirs, files) in Base.Filesystem.walkdir(tutorials_dir)
         for f in files
     ]
+    filter!(x -> endswith(x, ".jl"), tutorials_jl) # only grab .jl files
 
     filter!(x -> !occursin("topo.jl", x), tutorials_jl)                       # currently broken, TODO: Fix me!
     filter!(x -> !occursin("dry_rayleigh_benard.jl", x), tutorials_jl)        # currently broken, TODO: Fix me!


### PR DESCRIPTION
# Description

The existing
```julia
tutorials_jl = [
        joinpath(root, f)
        for (root, dirs, files) in Base.Filesystem.walkdir(tutorials_dir)
        for f in files
    ]
```
in `docs/list_of_tutorials.jl` is sometimes picking up local temporary files, and this should only be a list of Julia files. This PR adds a filter to prevent picking up unwanted files:

```julia
filter!(x -> endswith(x, ".jl"), tutorials_jl) # only grab .jl files
```

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
