### PR TITLE
Fix second order numerical boundary flux for dirichlet boundary conditions

### DIFF
--- a/src/Atmos/Model/AtmosModel.jl
+++ b/src/Atmos/Model/AtmosModel.jl
@@ -52,7 +52,6 @@ import CLIMA.DGmethods:
     reverse_integral_set_auxiliary_state!
 import ..DGmethods.NumericalFluxes:
     boundary_state!,
-    boundary_flux_second_order!,
     normal_boundary_flux_second_order!,
     NumericalFluxFirstOrder,
     NumericalFluxGradient,

--- a/src/Numerics/DGmethods/NumericalFluxes.jl
+++ b/src/Numerics/DGmethods/NumericalFluxes.jl
@@ -564,55 +564,6 @@ function normal_boundary_flux_second_order!(
     diff1⁻,
     aux1⁻,
 ) where {S}
-    FT = eltype(fluxᵀn)
-    num_state_conservative = number_state_conservative(balance_law, FT)
-    fluxᵀn = parent(fluxᵀn)
-
-    flux = similar(fluxᵀn, Size(3, num_state_conservative))
-    fill!(flux, -zero(FT))
-    boundary_flux_second_order!(
-        numerical_flux,
-        balance_law,
-        Grad{S}(flux),
-        state_conservative⁺,
-        state_gradient_flux⁺,
-        state_hyperdiffusive⁺,
-        state_auxiliary⁺,
-        normal_vector,
-        state_conservative⁻,
-        state_gradient_flux⁻,
-        state_hyperdiffusive⁻,
-        state_auxiliary⁻,
-        bctype,
-        t,
-        state1⁻,
-        diff1⁻,
-        aux1⁻,
-    )
-
-    fluxᵀn .+= flux' * normal_vector
-end
-
-# This is the function that my be overloaded for flux-based BCs
-function boundary_flux_second_order!(
-    numerical_flux::NumericalFluxSecondOrder,
-    balance_law,
-    flux,
-    state_conservative⁺,
-    state_gradient_flux⁺,
-    state_hyperdiffusive⁺,
-    state_auxiliary⁺,
-    normal_vector,
-    state_conservative⁻,
-    state_gradient_flux⁻,
-    state_hyperdiffusive⁻,
-    state_auxiliary⁻,
-    bctype,
-    t,
-    state1⁻,
-    diff1⁻,
-    aux1⁻,
-)
     boundary_state!(
         numerical_flux,
         balance_law,
@@ -629,9 +580,15 @@ function boundary_flux_second_order!(
         diff1⁻,
         aux1⁻,
     )
-    flux_second_order!(
+    numerical_flux_second_order!(
+        numerical_flux,
         balance_law,
-        flux,
+        fluxᵀn,
+        normal_vector,
+        state_conservative⁻,
+        state_gradient_flux⁻,
+        state_hyperdiffusive⁻,
+        state_auxiliary⁻,
         state_conservative⁺,
         state_gradient_flux⁺,
         state_hyperdiffusive⁺,


### PR DESCRIPTION
# Description

This PR updates the numerical boundary flux formula for second-order fluxes when specifying Dirichlet boundary conditions. Previously, an upwind numerical boundary flux was applied with `H = n * F(Y+)` and now a central numerical boundary flux of `H = n/2 * (F(Y-) + F(Y+))` is applied instead. For Neumann boundary conditions, the function `normal_boundary_flux_second_order!` is overwritten at the BalanceLaw level. 

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/format.jl`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://climate-machine.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
