### PR TITLE
Call HBModel functions in LinearHBModel to guarantee consistency

### DIFF
--- a/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
+++ b/src/Ocean/HydrostaticBoussinesq/LinearHBModel.jl
@@ -42,106 +42,16 @@ vars_integrals(lm::LinearHBModel, FT) = @vars()
 """
     No need to init, initialize by full model
 """
-init_state_auxiliary!(lm::LinearHBModel, A::Vars, geom::LocalGeometry) = nothing
-init_state_conservative!(lm::LinearHBModel, Q::Vars, A::Vars, coords, t) =
-    nothing
+init_state_auxiliary!(lm::LinearHBModel, _...) = nothing
+init_state_conservative!(lm::LinearHBModel, _...) = nothing
 
 """
-    compute_gradient_argument!(::LinearHBModel)
-
-copy u and θ to var_gradient
-this computation is done pointwise at each nodal point
-
-# arguments:
-- `m`: model in this case HBModel
-- `G`: array of gradient variables
-- `Q`: array of state variables
-- `A`: array of aux variables
-- `t`: time, not used
+    Copy over second-order term computation from ocean model
 """
-@inline function compute_gradient_argument!(
-    m::LinearHBModel,
-    G::Vars,
-    Q::Vars,
-    A,
-    t,
-)
-    G.∇u = Q.u
-    G.∇θ = Q.θ
-
-    return nothing
-end
-
-"""
-    compute_gradient_flux!(::LinearHBModel)
-
-copy ν∇u and κ∇θ to var_diffusive
-this computation is done pointwise at each nodal point
-
-# arguments:
-- `m`: model in this case HBModel
-- `D`: array of diffusive variables
-- `G`: array of gradient variables
-- `Q`: array of state variables
-- `A`: array of aux variables
-- `t`: time, not used
-"""
-@inline function compute_gradient_flux!(
-    lm::LinearHBModel,
-    D::Vars,
-    G::Grad,
-    Q::Vars,
-    A::Vars,
-    t,
-)
-    ν = viscosity_tensor(lm.ocean)
-    D.ν∇u = ν * G.∇u
-
-    κ = diffusivity_tensor(lm.ocean, G.∇θ[3])
-    D.κ∇θ = κ * G.∇θ
-
-    return nothing
-end
-
-"""
-    flux_second_order!(::HBModel)
-
-calculates the parabolic flux contribution to state variables
-this computation is done pointwise at each nodal point
-
-# arguments:
-- `m`: model in this case HBModel
-- `F`: array of fluxes for each state variable
-- `Q`: array of state variables
-- `D`: array of diff variables
-- `A`: array of aux variables
-- `t`: time, not used
-
-# computations
-∂ᵗu = -∇⋅(ν∇u)
-∂ᵗθ = -∇⋅(κ∇θ)
-"""
-@inline function flux_second_order!(
-    lm::LinearHBModel,
-    F::Grad,
-    Q::Vars,
-    D::Vars,
-    HD::Vars,
-    A::Vars,
-    t::Real,
-)
-    F.u -= D.ν∇u
-    F.θ -= D.κ∇θ
-
-    return nothing
-end
-
-"""
-    wavespeed(::LinaerHBModel)
-
-calculates the wavespeed for rusanov flux
-"""
-function wavespeed(lm::LinearHBModel, n⁻, _...)
-    C = abs(SVector(lm.ocean.cʰ, lm.ocean.cʰ, lm.ocean.cᶻ)' * n⁻)
-    return C
-end
+compute_gradient_argument!(lm::LinearHBModel, args...) =
+    compute_gradient_argument!(lm.ocean, args...)
+compute_gradient_flux!(lm::LinearHBModel, args...) =
+    compute_gradient_argument!(lm.ocean, args...)
+flux_second_order!(lm::LinearHBModel, args...) =
+    flux_second_order!(lm.ocean, args...)
+wavespeed(lm::LinearHBModel, args...) = wavespeed(lm.ocean, args...)


### PR DESCRIPTION
# Description

Use dispatch to guarantee LinearHBModel always matches full HBModel for second-order terms.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://CliMA.github.io/CLIMA/latest/CodingConventions.html) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
