### PR TITLE
Extend `norm` and `euclidean_distance` to work on subsets of MPIStateArrays

### DIFF
--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -539,13 +539,7 @@ function LinearAlgebra.norm(
         W = @view Q.weights[:, :, Q.realelems]
 
         # Check that the arrays are the right dimensionality
-        @assert ndims(realdata) in (2, 3)
-
-        # Reshape to 3 dimensions is necessary
-        if ndims(realdata) == 2
-            realdata =
-                reshape(realdata, size(realdata, 1), 1, size(realdata, 2))
-        end
+        @assert ndims(realdata) == 3
 
         # Check that these are broadcastable
         @assert size(realdata, 1) == size(W, 1)
@@ -599,16 +593,8 @@ function euclidean_distance(
     BrealQ = B.realdata,
 )
     # Check the the arrays are the right dimensionality
-    @assert ndims(ArealQ) in (2, 3)
-    @assert ndims(BrealQ) in (2, 3)
-
-    # Reshape to 3 dimensions is necessary
-    if ndims(ArealQ) == 2
-        ArealQ = reshape(ArealQ, size(ArealQ, 1), 1, size(ArealQ, 2))
-    end
-    if ndims(BrealQ) == 2
-        BrealQ = reshape(BrealQ, size(BrealQ, 1), 1, size(BrealQ, 2))
-    end
+    @assert ndims(ArealQ) == 3
+    @assert ndims(BrealQ) == 3
 
     # Check that these are broadcastable
     @assert size(ArealQ, 1) == size(BrealQ, 1)

--- a/src/Arrays/MPIStateArrays.jl
+++ b/src/Arrays/MPIStateArrays.jl
@@ -537,6 +537,20 @@ function LinearAlgebra.norm(
 )
     if weighted && ~isempty(Q.weights) && isfinite(p)
         W = @view Q.weights[:, :, Q.realelems]
+
+        # Check that the arrays are the right dimensionality
+        @assert ndims(realdata) in (2, 3)
+
+        # Reshape to 3 dimensions is necessary
+        if ndims(realdata) == 2
+            realdata =
+                reshape(realdata, size(realdata, 1), 1, size(realdata, 2))
+        end
+
+        # Check that these are broadcastable
+        @assert size(realdata, 1) == size(W, 1)
+        @assert size(realdata, 3) == size(W, 3)
+
         locnorm = weighted_norm_impl(realdata, W, Val(p), dims)
     else
         locnorm = norm_impl(realdata, Val(p), dims)
@@ -584,6 +598,25 @@ function euclidean_distance(
     ArealQ = A.realdata,
     BrealQ = B.realdata,
 )
+    # Check the the arrays are the right dimensionality
+    @assert ndims(ArealQ) in (2, 3)
+    @assert ndims(BrealQ) in (2, 3)
+
+    # Reshape to 3 dimensions is necessary
+    if ndims(ArealQ) == 2
+        ArealQ = reshape(ArealQ, size(ArealQ, 1), 1, size(ArealQ, 2))
+    end
+    if ndims(BrealQ) == 2
+        BrealQ = reshape(BrealQ, size(BrealQ, 1), 1, size(BrealQ, 2))
+    end
+
+    # Check that these are broadcastable
+    @assert size(ArealQ, 1) == size(BrealQ, 1)
+    @assert size(ArealQ, 3) == size(BrealQ, 3)
+    @assert size(ArealQ, 2) == 1 ||
+            size(BrealQ, 2) == 1 ||
+            size(ArealQ, 2) == size(BrealQ, 2)
+
     # work around https://github.com/JuliaArrays/LazyArrays.jl/issues/66
     E = @~ (ArealQ .- BrealQ) .^ 2
 

--- a/test/Arrays/reductions.jl
+++ b/test/Arrays/reductions.jl
@@ -42,61 +42,33 @@ mpirank = MPI.Comm_rank(mpicomm)
     @test isapprox(dot(QA, QB), dot(globalA, globalB))
 
     # Test partial data views with 1 index
-    PA_2d = @view QA.realdata[:, 1, QA.realelems]
-    PA_3d = reshape(PA_2d, localsize[1], 1, localsize[3])
+    PA = @view QA.realdata[:, 1:1, QA.realelems]
     glosize = size(globalA)
     globalPA = @view globalA[:, 1:1, :]
 
-    PB_2d = @view QB.realdata[:, 2, QB.realelems]
-    PB_3d = reshape(PB_2d, localsize[1], 1, localsize[3])
+    PB = @view QB.realdata[:, 2:2, QB.realelems]
     globalPB = @view globalB[:, 2:2, :]
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA_2d),
+        euclidean_distance(QA, QB; ArealQ = PA),
         norm(globalPA .- globalB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; BrealQ = PB_2d),
+        euclidean_distance(QA, QB; BrealQ = PB),
         norm(globalA .- globalPB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA_2d, BrealQ = PB_2d),
+        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB),
         norm(globalPA .- globalPB),
     )
-    @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA_3d),
-        norm(globalPA .- globalB),
-    )
-    @test isapprox(
-        euclidean_distance(QA, QB; BrealQ = PB_3d),
-        norm(globalA .- globalPB),
-    )
-    @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA_3d, BrealQ = PB_3d),
-        norm(globalPA .- globalPB),
-    )
-    @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA_2d, BrealQ = PB_3d),
-        norm(globalPA .- globalPB),
-    )
-    @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA_3d, BrealQ = PB_2d),
-        norm(globalPA .- globalPB),
-    )
-    @test norm(QA; realdata = PA_2d) ≈ norm(globalPA)
-    @test norm(QA; realdata = PA_3d) ≈ norm(globalPA)
+    @test norm(QA; realdata = PA) ≈ norm(globalPA)
 
     # Test partial data views with 2 indices and 1 index
     PA = @view QA.realdata[:, 1:2, QA.realelems]
     globalPA = @view globalA[:, 1:2, :]
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB_2d),
+        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB),
         norm(globalPA .- globalPB),
     )
-    @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB_3d),
-        norm(globalPA .- globalPB),
-    )
-    @test_throws AssertionError euclidean_distance(QA, QB; ArealQ = globalPA)
     @test norm(QA; realdata = PA) ≈ norm(globalPA)
 
     # Test partial data views with 2 indices and 2 indices

--- a/test/Arrays/reductions.jl
+++ b/test/Arrays/reductions.jl
@@ -42,62 +42,68 @@ mpirank = MPI.Comm_rank(mpicomm)
     @test isapprox(dot(QA, QB), dot(globalA, globalB))
 
     # Test partial data views with 1 index
-    PA = @view QA.realdata[:, 1, QA.realelems]
-    globalPA = reshape(PA, localsize[1], 1, localsize[3])
-    PB = @view QB.realdata[:, 2, QB.realelems]
-    globalPB = reshape(PB, localsize[1], 1, localsize[3])
+    PA_2d = @view QA.realdata[:, 1, QA.realelems]
+    PA_3d = reshape(PA_2d, localsize[1], 1, localsize[3])
+    glosize = size(globalA)
+    globalPA = @view globalA[:, 1:1, :]
+
+    PB_2d = @view QB.realdata[:, 2, QB.realelems]
+    PB_3d = reshape(PB_2d, localsize[1], 1, localsize[3])
+    globalPB = @view globalB[:, 2:2, :]
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA),
+        euclidean_distance(QA, QB; ArealQ = PA_2d),
         norm(globalPA .- globalB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; BrealQ = PB),
+        euclidean_distance(QA, QB; BrealQ = PB_2d),
         norm(globalA .- globalPB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB),
+        euclidean_distance(QA, QB; ArealQ = PA_2d, BrealQ = PB_2d),
         norm(globalPA .- globalPB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = globalPA),
+        euclidean_distance(QA, QB; ArealQ = PA_3d),
         norm(globalPA .- globalB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; BrealQ = globalPB),
+        euclidean_distance(QA, QB; BrealQ = PB_3d),
         norm(globalA .- globalPB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = globalPA, BrealQ = globalPB),
+        euclidean_distance(QA, QB; ArealQ = PA_3d, BrealQ = PB_3d),
         norm(globalPA .- globalPB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = globalPB),
+        euclidean_distance(QA, QB; ArealQ = PA_2d, BrealQ = PB_3d),
         norm(globalPA .- globalPB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = globalPA, BrealQ = PB),
+        euclidean_distance(QA, QB; ArealQ = PA_3d, BrealQ = PB_2d),
         norm(globalPA .- globalPB),
     )
-    @test norm(QA; realdata = PA) ≈ norm(globalPA)
-    @test norm(QA; realdata = globalPA) ≈ norm(globalPA)
+    @test norm(QA; realdata = PA_2d) ≈ norm(globalPA)
+    @test norm(QA; realdata = PA_3d) ≈ norm(globalPA)
 
     # Test partial data views with 2 indices and 1 index
-    globalPA = @view QA.realdata[:, 1:2, QA.realelems]
+    PA = @view QA.realdata[:, 1:2, QA.realelems]
+    globalPA = @view globalA[:, 1:2, :]
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = globalPA, BrealQ = globalPB),
+        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB_2d),
         norm(globalPA .- globalPB),
     )
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = globalPA, BrealQ = PB),
+        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB_3d),
         norm(globalPA .- globalPB),
     )
     @test_throws AssertionError euclidean_distance(QA, QB; ArealQ = globalPA)
-    @test norm(QA; realdata = globalPA) ≈ norm(globalPA)
+    @test norm(QA; realdata = PA) ≈ norm(globalPA)
 
     # Test partial data views with 2 indices and 2 indices
-    globalPB = @view QB.realdata[:, 3:4, QA.realelems]
+    PB = @view QB.realdata[:, 3:4, QB.realelems]
+    globalPB = @view globalB[:, 3:4, :]
     @test isapprox(
-        euclidean_distance(QA, QB; ArealQ = globalPA, BrealQ = globalPB),
+        euclidean_distance(QA, QB; ArealQ = PA, BrealQ = PB),
         norm(globalPA .- globalPB),
     )
 

--- a/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
+++ b/test/Ocean/SplitExplicit/test_vertical_integral_model.jl
@@ -15,6 +15,7 @@ using ClimateMachine.Ocean.OceanProblems
 using ClimateMachine.Mesh.Topologies
 using ClimateMachine.Mesh.Grids
 using ClimateMachine.BalanceLaws
+using ClimateMachine.BalanceLaws: number_state_auxiliary
 using ClimateMachine.DGMethods
 using ClimateMachine.DGMethods.NumericalFluxes
 using ClimateMachine.MPIStateArrays


### PR DESCRIPTION
# Description

See title. This would be nice to have to compare values across different MPIStateArrays that don't have the exact same `vars`. In particular, I am trying to use it to compare a 2D solution against part of a 3D solution hence the reshapes in `test/Ocean/SplitExplicit/test_vertical_integral_model.jl`.

<!--- Please fill out the following section --->

I have

- [x] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [x] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [x] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [x] There are no open pull requests for this already
- [x] CLIMA developers with relevant expertise have been assigned to review this submission
- [x] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
