### PR TITLE
Add tests for initializing small planet

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -204,6 +204,15 @@ steps:
   - label: "cpu_vars_test"
     key: "cpu_vars_test"
     command:
+      - "mpiexec julia --color=yes --project test/Numerics/DGMethods/test_planet_sizes.jl "
+    agents:
+      config: cpu
+      queue: central
+      slurm_ntasks: 1
+
+  - label: "cpu_vars_test"
+    key: "cpu_vars_test"
+    command:
       - "mpiexec julia --color=yes --project test/Numerics/DGMethods/vars_test.jl "
     agents:
       config: cpu

--- a/test/Numerics/DGMethods/test_planet_sizes.jl
+++ b/test/Numerics/DGMethods/test_planet_sizes.jl
@@ -1,0 +1,55 @@
+using ClimateMachine
+using Test
+using ClimateMachine.Atmos
+using ClimateMachine.ConfigTypes
+using ClimateMachine.Diagnostics
+using ClimateMachine.Mesh.Interpolation
+using CLIMAParameters
+using CLIMAParameters.Planet: planet_radius
+import CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = 1
+function initialize_planet_size(domain_height)
+    FT, n_horz, n_vert, poly_order = Float64, 12, 6, 3
+    model = AtmosModel{FT}(
+        AtmosGCMConfigType,
+        param_set;
+        init_state_prognostic = x -> x,
+    )
+    _planet_radius = FT(planet_radius(param_set))
+    driver_config = ClimateMachine.AtmosGCMConfiguration(
+        "SmallPlanet",
+        poly_order,
+        (n_horz, n_vert),
+        domain_height,
+        param_set,
+        x -> x;
+        model = model,
+    )
+    info = driver_config.config_info
+    boundaries = [
+        FT(-90) FT(-180) _planet_radius
+        FT(90) FT(180) FT(_planet_radius + info.domain_height)
+    ]
+    resolution = (FT(2), FT(2), FT(1000)) # in (deg, deg, m)
+    interpol = ClimateMachine.InterpolationConfiguration(
+        driver_config,
+        boundaries,
+        resolution,
+    )
+    return nothing
+end
+
+let
+    ClimateMachine.init()
+    for planet_rad in 10.0 .^ (0:7)
+        CLIMAParameters.Planet.planet_radius(::EarthParameterSet) = planet_rad
+        for aspect_ratio in 10.0 .^ (-2.33:0.6:0.3)
+            domain_height = aspect_ratio * planet_radius(param_set)
+            initialize_planet_size(domain_height)
+        end
+    end
+end
+
+nothing


### PR DESCRIPTION
# Description

When playing around with the solid-body rotation problem, one thing I was messing around with was changing the planet size. This PR adds a test to demonstrate the range of planet sizes that can be initialized. Therefore, no `@tests` are technically added, but failures should still pop up if initialization fails.

<!--- Please fill out the following section --->

I have

- [ ] Written and run all necessary tests with CLIMA by including `tests/runtests.jl`
- [ ] Followed all necessary [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and run `julia .dev/climaformat.jl .`
- [ ] Updated the documentation to reflect changes from this PR.

<!--- Please leave the following section --->

# For review by CLIMA developers

- [ ] There are no open pull requests for this already
- [ ] CLIMA developers with relevant expertise have been assigned to review this submission
- [ ] The code conforms to the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) and has consistent naming conventions. `julia .dev/format.jl` has been run in a separate commit.
- [ ] This code does what it is technically intended to do (all numerics make sense physically and/or computationally)
