### PR TITLE
Add vars wrappers for numerical fluxes

### DIFF
--- a/docs/src/APIs/BalanceLaws/BalanceLaws.md
+++ b/docs/src/APIs/BalanceLaws/BalanceLaws.md
@@ -51,6 +51,7 @@ GradientLaplacian
 Hyperdiffusive
 UpwardIntegrals
 DownwardIntegrals
+WrapVars
 ```
 
 ## Variable specification methods

--- a/src/BalanceLaws/BalanceLaws.jl
+++ b/src/BalanceLaws/BalanceLaws.jl
@@ -27,7 +27,8 @@ export BalanceLaw,
     reverse_indefinite_stack_integral!,
     reverse_integral_load_auxiliary_state!,
     reverse_integral_set_auxiliary_state!,
-    parameter_set
+    parameter_set,
+    WrapVars
 
 include("state_types.jl")
 include("interface.jl")

--- a/src/BalanceLaws/vars_wrappers.jl
+++ b/src/BalanceLaws/vars_wrappers.jl
@@ -1,5 +1,15 @@
 
-function init_state_prognostic_arr!(
+"""
+    WrapVars
+
+A singleton used to indicate that the called
+method will wrap arguments in `Vars`/`Grad`
+types.
+"""
+struct WrapVars end
+
+function init_state_prognostic!(
+    ::WrapVars,
     balance_law,
     state::AbstractArray,
     aux::AbstractArray,
@@ -17,7 +27,8 @@ function init_state_prognostic_arr!(
 
 end
 
-function source_arr!(
+function source!(
+    ::WrapVars,
     balance_law,
     source::AbstractArray,
     state::AbstractArray,
@@ -38,7 +49,8 @@ function source_arr!(
     )
 end
 
-function flux_first_order_arr!(
+function flux_first_order!(
+    ::WrapVars,
     balance_law,
     flux::AbstractArray,
     state::AbstractArray,
@@ -57,7 +69,8 @@ function flux_first_order_arr!(
     )
 end
 
-function flux_second_order_arr!(
+function flux_second_order!(
+    ::WrapVars,
     balance_law,
     flux::AbstractArray,
     state::AbstractArray,
@@ -78,7 +91,8 @@ function flux_second_order_arr!(
     )
 end
 
-function compute_gradient_argument_arr!(
+function compute_gradient_argument!(
+    ::WrapVars,
     balance_law,
     transform::AbstractArray,
     state::AbstractArray,
@@ -95,7 +109,8 @@ function compute_gradient_argument_arr!(
     )
 end
 
-function compute_gradient_flux_arr!(
+function compute_gradient_flux!(
+    ::WrapVars,
     balance_law,
     diffusive::AbstractArray,
     ∇transform::AbstractArray,
@@ -115,7 +130,8 @@ function compute_gradient_flux_arr!(
     )
 end
 
-function integral_load_auxiliary_state_arr!(
+function integral_load_auxiliary_state!(
+    ::WrapVars,
     balance_law,
     local_kernel::AbstractArray,
     state_prognostic::AbstractArray,
@@ -130,7 +146,8 @@ function integral_load_auxiliary_state_arr!(
     )
 end
 
-function integral_set_auxiliary_state_arr!(
+function integral_set_auxiliary_state!(
+    ::WrapVars,
     balance_law,
     state_auxiliary::AbstractArray,
     local_kernel::AbstractArray,
@@ -144,7 +161,8 @@ function integral_set_auxiliary_state_arr!(
     )
 end
 
-function reverse_integral_load_auxiliary_state_arr!(
+function reverse_integral_load_auxiliary_state!(
+    ::WrapVars,
     balance_law,
     l_T::AbstractArray,
     state::AbstractArray,
@@ -161,7 +179,8 @@ function reverse_integral_load_auxiliary_state_arr!(
 
 end
 
-function reverse_integral_set_auxiliary_state_arr!(
+function reverse_integral_set_auxiliary_state!(
+    ::WrapVars,
     balance_law,
     state_auxiliary::AbstractArray,
     l_V::AbstractArray,
@@ -175,7 +194,8 @@ function reverse_integral_set_auxiliary_state_arr!(
     )
 end
 
-function transform_post_gradient_laplacian_arr!(
+function transform_post_gradient_laplacian!(
+    ::WrapVars,
     balance_law,
     hyperdiffusion::AbstractArray,
     l_grad_lap::AbstractArray,

--- a/src/Numerics/DGMethods/DGFVModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGFVModel_kernels.jl
@@ -341,7 +341,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
             local_state_face_auxiliary_neighbor .= local_state_face_auxiliary[1]
 
 
-            numerical_boundary_flux_first_order!(
+            numerical_boundary_flux_first_order_loop!(
                 numerical_flux_first_order,
                 bctag,
                 balance_law,
@@ -370,7 +370,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
             local_state_auxiliary[stencil_center - 1] .=
                 local_state_auxiliary[stencil_center]
 
-            numerical_boundary_flux_second_order!(
+            numerical_boundary_flux_second_order_loop!(
                 numerical_flux_second_order,
                 bctag,
                 balance_law,
@@ -542,6 +542,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
             # considering
             fill!(local_flux, -zero(FT))
             numerical_flux_first_order!(
+                WrapVars(),
                 numerical_flux_first_order,
                 balance_law,
                 local_flux,
@@ -556,6 +557,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
 
 
             numerical_flux_second_order!(
+                WrapVars(),
                 numerical_flux_second_order,
                 balance_law,
                 local_flux,
@@ -574,7 +576,8 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
 
             if add_source
                 fill!(local_source, -zero(eltype(local_source)))
-                source_arr!(
+                source!(
+                    WrapVars(),
                     balance_law,
                     local_source,
                     local_state_prognostic[stencil_center - 1],
@@ -616,7 +619,8 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
             if eV_up == nvertelem
                 if add_source
                     fill!(local_source, -zero(eltype(local_source)))
-                    source_arr!(
+                    source!(
+                        WrapVars(),
                         balance_law,
                         local_source,
                         local_state_prognostic[stencil_center],
@@ -663,7 +667,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                         local_state_face_prognostic[2]
                     local_state_face_auxiliary_neighbor .=
                         local_state_face_auxiliary[2]
-                    numerical_boundary_flux_first_order!(
+                    numerical_boundary_flux_first_order_loop!(
                         numerical_flux_first_order,
                         bctag,
                         balance_law,
@@ -693,7 +697,7 @@ A finite volume reconstruction is used to construction `Fⁱⁿᵛ⋆`
                         local_state_hyperdiffusive[stencil_center]
                     local_state_auxiliary[stencil_center - 1] .=
                         local_state_auxiliary[stencil_center]
-                    numerical_boundary_flux_second_order!(
+                    numerical_boundary_flux_second_order_loop!(
                         numerical_flux_second_order,
                         bctag,
                         balance_law,
@@ -862,7 +866,8 @@ end
         # gradient of)
         @unroll for k in 1:3
             fill!(l_grad_arg[k], -zero(eltype(l_grad_arg[k])))
-            compute_gradient_argument_arr!(
+            compute_gradient_argument!(
+                WrapVars(),
                 balance_law,
                 l_grad_arg[k],
                 local_state_prognostic[k],
@@ -895,7 +900,7 @@ end
                 end
             else
                 # Computes G* incorporating boundary conditions
-                numerical_boundary_flux_gradient!(
+                numerical_boundary_flux_gradient_loop!(
                     CentralNumericalFluxGradient(),
                     bctag[f],
                     balance_law,
@@ -922,7 +927,8 @@ end
 
         # Applies linear transformation of gradients to the diffusive variables
         # for storage
-        compute_gradient_flux_arr!(
+        compute_gradient_flux!(
+            WrapVars(),
             balance_law,
             local_state_gradient_flux,
             l_nG,

--- a/src/Numerics/DGMethods/DGMethods.jl
+++ b/src/Numerics/DGMethods/DGMethods.jl
@@ -27,14 +27,14 @@ using ..BalanceLaws:
 
 import ..BalanceLaws:
     BalanceLaw,
-    init_state_prognostic_arr!,
+    init_state_prognostic!,
     init_state_auxiliary!,
-    flux_first_order_arr!,
-    flux_second_order_arr!,
-    compute_gradient_flux_arr!,
-    compute_gradient_argument_arr!,
-    source_arr!,
-    transform_post_gradient_laplacian_arr!,
+    flux_first_order!,
+    flux_second_order!,
+    compute_gradient_flux!,
+    compute_gradient_argument!,
+    source!,
+    transform_post_gradient_laplacian!,
     wavespeed,
     boundary_conditions,
     boundary_state!,
@@ -42,12 +42,12 @@ import ..BalanceLaws:
     update_auxiliary_state_gradient!,
     nodal_update_auxiliary_state!,
     nodal_init_state_auxiliary!,
-    integral_load_auxiliary_state_arr!,
-    integral_set_auxiliary_state_arr!,
+    integral_load_auxiliary_state!,
+    integral_set_auxiliary_state!,
     indefinite_stack_integral!,
     reverse_indefinite_stack_integral!,
-    reverse_integral_load_auxiliary_state_arr!,
-    reverse_integral_set_auxiliary_state_arr!
+    reverse_integral_load_auxiliary_state!,
+    reverse_integral_set_auxiliary_state!
 
 export DGModel,
     DGFVModel,

--- a/src/Numerics/DGMethods/DGModel_kernels.jl
+++ b/src/Numerics/DGMethods/DGModel_kernels.jl
@@ -5,11 +5,15 @@ using .NumericalFluxes:
     numerical_flux_divergence!,
     numerical_flux_higher_order!,
     numerical_boundary_flux_gradient!,
+    numerical_boundary_flux_gradient_loop!,
     numerical_boundary_flux_first_order!,
+    numerical_boundary_flux_first_order_loop!,
     numerical_boundary_flux_second_order!,
+    numerical_boundary_flux_second_order_loop!,
     numerical_boundary_flux_divergence!,
     numerical_boundary_flux_higher_order!,
     CentralNumericalFluxGradient
+
 
 using ..Mesh.Geometry
 
@@ -169,7 +173,8 @@ fluxes, respectively.
 
             # Computes the local inviscid fluxes Fⁱⁿᵛ
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_first_order_arr!(
+            flux_first_order!(
+                WrapVars(),
                 balance_law,
                 local_flux,
                 local_state_prognostic,
@@ -186,7 +191,8 @@ fluxes, respectively.
 
             # Computes the local viscous fluxes Fᵛⁱˢᶜ
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_second_order_arr!(
+            flux_second_order!(
+                WrapVars(),
                 balance_law,
                 local_flux,
                 local_state_prognostic,
@@ -224,7 +230,8 @@ fluxes, respectively.
             if model_direction isa EveryDirection && balance_law isa RemBL
                 if rembl_has_subs_direction(HorizontalDirection(), balance_law)
                     fill!(local_flux, -zero(eltype(local_flux)))
-                    flux_first_order_arr!(
+                    flux_first_order!(
+                        WrapVars(),
                         balance_law,
                         local_flux,
                         local_state_prognostic,
@@ -259,7 +266,8 @@ fluxes, respectively.
             # Computes the contribution due to the source term S
             if add_source
                 fill!(local_source, -zero(eltype(local_source)))
-                source_arr!(
+                source!(
+                    WrapVars(),
                     balance_law,
                     local_source,
                     local_state_prognostic,
@@ -417,7 +425,8 @@ end
 
             # Computes the local inviscid fluxes Fⁱⁿᵛ
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_first_order_arr!(
+            flux_first_order!(
+                WrapVars(),
                 balance_law,
                 local_flux,
                 local_state_prognostic,
@@ -434,7 +443,8 @@ end
 
             # Computes the local viscous fluxes Fᵛⁱˢᶜ
             fill!(local_flux, -zero(eltype(local_flux)))
-            flux_second_order_arr!(
+            flux_second_order!(
+                WrapVars(),
                 balance_law,
                 local_flux,
                 local_state_prognostic,
@@ -468,7 +478,8 @@ end
             if model_direction isa EveryDirection && balance_law isa RemBL
                 if rembl_has_subs_direction(VerticalDirection(), balance_law)
                     fill!(local_flux, -zero(eltype(local_flux)))
-                    flux_first_order_arr!(
+                    flux_first_order!(
+                        WrapVars(),
                         balance_law,
                         local_flux,
                         local_state_prognostic,
@@ -504,7 +515,8 @@ end
             # Computes the contribution due to the source term S
             if add_source
                 fill!(local_source, -zero(eltype(local_source)))
-                source_arr!(
+                source!(
+                    WrapVars(),
                     balance_law,
                     local_source,
                     local_state_prognostic,
@@ -732,54 +744,32 @@ fluxes, respectively.
         fill!(local_flux, -zero(eltype(local_flux)))
         if bctag == 0
             numerical_flux_first_order!(
+                WrapVars(),
                 numerical_flux_first_order,
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                SVector(normal_vector),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺nondiff,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺nondiff,
-                ),
+                local_flux,
+                normal_vector,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺nondiff,
+                local_state_auxiliary⁺nondiff,
                 t,
                 face_direction,
             )
             numerical_flux_second_order!(
+                WrapVars(),
                 numerical_flux_second_order,
                 balance_law,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                local_flux,
                 normal_vector,
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux⁻,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺diff,
-                ),
-                Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                    local_state_gradient_flux⁺,
-                ),
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺diff,
-                ),
+                local_state_prognostic⁻,
+                local_state_gradient_flux⁻,
+                local_state_hyperdiffusion⁻,
+                local_state_auxiliary⁻,
+                local_state_prognostic⁺diff,
+                local_state_gradient_flux⁺,
+                local_state_hyperdiffusion⁺,
+                local_state_auxiliary⁺diff,
                 t,
             )
         else
@@ -820,72 +810,40 @@ fluxes, respectively.
             Base.Cartesian.@nif 7 d -> bctag == d <= length(bcs) d -> begin
                 bc = bcs[d]
                 numerical_boundary_flux_first_order!(
+                    WrapVars(),
                     numerical_flux_first_order,
                     bc,
                     balance_law,
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
-                    SVector(normal_vector),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁻,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁻,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁺nondiff,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁺nondiff,
-                    ),
+                    local_flux,
+                    normal_vector,
+                    local_state_prognostic⁻,
+                    local_state_auxiliary⁻,
+                    local_state_prognostic⁺nondiff,
+                    local_state_auxiliary⁺nondiff,
                     t,
                     face_direction,
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic_bottom1,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary_bottom1,
-                    ),
+                    local_state_prognostic_bottom1,
+                    local_state_auxiliary_bottom1,
                 )
                 numerical_boundary_flux_second_order!(
+                    WrapVars(),
                     numerical_flux_second_order,
                     bc,
                     balance_law,
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(local_flux),
+                    local_flux,
                     normal_vector,
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁻,
-                    ),
-                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                        local_state_gradient_flux⁻,
-                    ),
-                    Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                        local_state_hyperdiffusion⁻,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁻,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁺diff,
-                    ),
-                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                        local_state_gradient_flux⁺,
-                    ),
-                    Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                        local_state_hyperdiffusion⁺,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁺diff,
-                    ),
+                    local_state_prognostic⁻,
+                    local_state_gradient_flux⁻,
+                    local_state_hyperdiffusion⁻,
+                    local_state_auxiliary⁻,
+                    local_state_prognostic⁺diff,
+                    local_state_gradient_flux⁺,
+                    local_state_hyperdiffusion⁺,
+                    local_state_auxiliary⁺diff,
                     t,
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic_bottom1,
-                    ),
-                    Vars{vars_state(balance_law, GradientFlux(), FT)}(
-                        local_state_gradient_flux_bottom1,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary_bottom1,
-                    ),
+                    local_state_prognostic_bottom1,
+                    local_state_gradient_flux_bottom1,
+                    local_state_auxiliary_bottom1,
                 )
             end d -> throw(BoundsError(bcs, bctag))
         end
@@ -1007,7 +965,8 @@ gradient flux.
         # Compute G(q) and write the result into shared memory
         @unroll for k in 1:Nq3
             fill!(local_transform, -zero(eltype(local_transform)))
-            compute_gradient_argument_arr!(
+            compute_gradient_argument!(
+                WrapVars(),
                 balance_law,
                 local_transform,
                 local_state_prognostic[:, k],
@@ -1105,7 +1064,8 @@ gradient flux.
                 )
 
                 # Applies a linear transformation of gradients to the diffusive variables
-                compute_gradient_flux_arr!(
+                compute_gradient_flux!(
+                    WrapVars(),
                     balance_law,
                     local_state_gradient_flux,
                     local_transform_gradient[:, :, k],
@@ -1225,7 +1185,8 @@ end
         # Compute G(q) and write the result into shared memory
         @unroll for k in 1:Nq3
             fill!(local_transform, -zero(eltype(local_transform)))
-            compute_gradient_argument_arr!(
+            compute_gradient_argument!(
+                WrapVars(),
                 balance_law,
                 local_transform,
                 local_state_prognostic[:, k],
@@ -1303,7 +1264,8 @@ end
                 )
 
                 # Applies a linear transformation of gradients to the diffusive variables
-                compute_gradient_flux_arr!(
+                compute_gradient_flux!(
+                    WrapVars(),
                     balance_law,
                     local_state_gradient_flux,
                     local_transform_gradient[:, :, k],
@@ -1470,7 +1432,8 @@ auxiliary gradient flux, and G* is the associated numerical flux.
 
         # Compute G(q) on the minus side write the result into registers
         fill!(local_transform⁻, -zero(eltype(local_transform⁻)))
-        compute_gradient_argument_arr!(
+        compute_gradient_argument!(
+            WrapVars(),
             balance_law,
             local_transform⁻,
             local_state_prognostic⁻,
@@ -1489,7 +1452,8 @@ auxiliary gradient flux, and G* is the associated numerical flux.
 
         # Compute G(q) on the plus side and write the result into registers
         fill!(local_transform⁺, -zero(eltype(local_transform⁺)))
-        compute_gradient_argument_arr!(
+        compute_gradient_argument!(
+            WrapVars(),
             balance_law,
             local_transform⁺,
             local_state_prognostic⁺,
@@ -1521,7 +1485,8 @@ auxiliary gradient flux, and G* is the associated numerical flux.
             if num_state_gradient_flux > 0
                 # Applies linear transformation of gradients to the diffusive variables
                 # on the minus side
-                compute_gradient_flux_arr!(
+                compute_gradient_flux!(
+                    WrapVars(),
                     balance_law,
                     local_state_gradient_flux,
                     local_transform_gradient,
@@ -1562,41 +1527,27 @@ auxiliary gradient flux, and G* is the associated numerical flux.
                 bc = bcs[d]
                 # Computes G* incorporating boundary conditions
                 numerical_boundary_flux_gradient!(
+                    WrapVars(),
                     numerical_flux_gradient,
                     bc,
                     balance_law,
                     local_transform_gradient,
-                    SVector(normal_vector),
-                    Vars{vars_state(balance_law, Gradient(), FT)}(
-                        local_transform⁻,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁻,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁻,
-                    ),
-                    Vars{vars_state(balance_law, Gradient(), FT)}(
-                        local_transform⁺,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁺,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁺,
-                    ),
+                    normal_vector,
+                    local_transform⁻,
+                    local_state_prognostic⁻,
+                    local_state_auxiliary⁻,
+                    local_transform⁺,
+                    local_state_prognostic⁺,
+                    local_state_auxiliary⁺,
                     t,
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic_bottom1,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary_bottom1,
-                    ),
+                    local_state_prognostic_bottom1,
+                    local_state_auxiliary_bottom1,
                 )
                 if num_state_gradient_flux > 0
                     # Applies linear transformation of gradients to the diffusive variables
                     # on the minus side
-                    compute_gradient_flux_arr!(
+                    compute_gradient_flux!(
+                        WrapVars(),
                         balance_law,
                         local_state_gradient_flux,
                         local_transform_gradient,
@@ -1628,7 +1579,8 @@ auxiliary gradient flux, and G* is the associated numerical flux.
 
         # Applies linear transformation of gradients to the diffusive variables
         # on the minus side
-        compute_gradient_flux_arr!(
+        compute_gradient_flux!(
+            WrapVars(),
             balance_law,
             local_state_prognostic⁻visc,
             l_nG⁻,
@@ -1683,7 +1635,8 @@ end
         @unroll for s in 1:num_state_prognostic
             l_state[s] = state[n, s, e]
         end
-        init_state_prognostic_arr!(
+        init_state_prognostic!(
+            WrapVars(),
             balance_law,
             l_state,
             local_state_auxiliary,
@@ -1968,7 +1921,8 @@ See [`BalanceLaw`](@ref) for usage.
                     local_state_auxiliary[s] = state_auxiliary[ijk, s, e]
                 end
 
-                integral_load_auxiliary_state_arr!(
+                integral_load_auxiliary_state!(
+                    WrapVars(),
                     balance_law,
                     view(local_kernel, :, k),
                     local_state_prognostic,
@@ -1996,7 +1950,8 @@ See [`BalanceLaw`](@ref) for usage.
                     local_kernel[s, k] = local_integral[s, k]
                 end
                 ijk = i + Nq1 * ((j - 1) + Nq2 * (k - 1))
-                integral_set_auxiliary_state_arr!(
+                integral_set_auxiliary_state!(
+                    WrapVars(),
                     balance_law,
                     view(state_auxiliary, ijk, :, e),
                     view(local_kernel, :, k),
@@ -2044,7 +1999,8 @@ end
         # (i, j, Nq3)
         ijk = i + Nq1 * ((j - 1) + Nq2 * (Nq3 - 1))
         et = nvertelem + (eh - 1) * nvertelem
-        reverse_integral_load_auxiliary_state_arr!(
+        reverse_integral_load_auxiliary_state!(
+            WrapVars(),
             balance_law,
             l_T,
             view(state, ijk, :, et),
@@ -2067,14 +2023,16 @@ end
             e = ev + (eh - 1) * nvertelem
             @unroll for k in 1:Nq3
                 ijk = i + Nq1 * ((j - 1) + Nq2 * (k - 1))
-                reverse_integral_load_auxiliary_state_arr!(
+                reverse_integral_load_auxiliary_state!(
+                    WrapVars(),
                     balance_law,
                     l_V,
                     view(state, ijk, :, e),
                     view(state_auxiliary, ijk, :, e),
                 )
                 l_V .= l_T .- l_V
-                reverse_integral_set_auxiliary_state_arr!(
+                reverse_integral_set_auxiliary_state!(
+                    WrapVars(),
                     balance_law,
                     view(
                         state_auxiliary,
@@ -2094,7 +2052,8 @@ end
             k = 1
             ijk = i + Nq1 * ((j - 1) + Nq2 * (k - 1))
             e = ev + (eh - 1) * nvertelem
-            reverse_integral_set_auxiliary_state_arr!(
+            reverse_integral_set_auxiliary_state!(
+                WrapVars(),
                 balance_law,
                 view(state_auxiliary, ijk, :, e),
                 l_T,
@@ -2439,12 +2398,13 @@ from volume to face, and (∇G)⋆ is the numerical fluxes for the gradients.
 
         if bctag == 0
             numerical_flux_divergence!(
+                WrapVars(),
                 divgradnumpenalty,
                 balance_law,
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_div),
+                l_div,
                 normal_vector,
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁻),
-                Grad{vars_state(balance_law, GradientLaplacian(), FT)}(l_grad⁺),
+                l_grad⁻,
+                l_grad⁺,
             )
         else
             # load state auxiliary (only needed for bcs !)
@@ -2461,25 +2421,16 @@ from volume to face, and (∇G)⋆ is the numerical fluxes for the gradients.
             Base.Cartesian.@nif 7 d -> bctag == d <= length(bcs) d -> begin
                 bc = bcs[d]
                 numerical_boundary_flux_divergence!(
+                    WrapVars(),
                     divgradnumpenalty,
                     bc,
                     balance_law,
-                    Vars{vars_state(balance_law, GradientLaplacian(), FT)}(
-                        l_div,
-                    ),
+                    l_div,
                     normal_vector,
-                    Grad{vars_state(balance_law, GradientLaplacian(), FT)}(
-                        l_grad⁻,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        l_state_auxiliary⁻,
-                    ),
-                    Grad{vars_state(balance_law, GradientLaplacian(), FT)}(
-                        l_grad⁺,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        l_state_auxiliary⁺,
-                    ),
+                    l_grad⁻,
+                    l_state_auxiliary⁻,
+                    l_grad⁺,
+                    l_state_auxiliary⁺,
                     t,
                 )
             end d -> throw(BoundsError(bcs, bctag))
@@ -2650,7 +2601,8 @@ D is the differentiation matrix and ΔG is the laplacian
             )
 
             # Applies a linear transformation of gradients to the hyperdiffusive variables
-            transform_post_gradient_laplacian_arr!(
+            transform_post_gradient_laplacian!(
+                WrapVars(),
                 balance_law,
                 local_state_hyperdiffusion,
                 l_grad_lap[:, :, k],
@@ -2802,7 +2754,8 @@ end
             )
 
             # Applies a linear transformation of gradients to the hyperdiffusive variables
-            transform_post_gradient_laplacian_arr!(
+            transform_post_gradient_laplacian!(
+                WrapVars(),
                 balance_law,
                 local_state_hyperdiffusion,
                 l_grad_lap[:, :, k],
@@ -2958,26 +2911,17 @@ the associated numerical flux.
 
         if bctag == 0
             numerical_flux_higher_order!(
+                WrapVars(),
                 hyperviscnumflux,
                 balance_law,
-                Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                    local_state_hyperdiffusion,
-                ),
+                local_state_hyperdiffusion,
                 normal_vector,
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁻),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁻,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁻,
-                ),
-                Vars{vars_state(balance_law, GradientLaplacian(), FT)}(l_lap⁺),
-                Vars{vars_state(balance_law, Prognostic(), FT)}(
-                    local_state_prognostic⁺,
-                ),
-                Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                    local_state_auxiliary⁺,
-                ),
+                l_lap⁻,
+                local_state_prognostic⁻,
+                local_state_auxiliary⁻,
+                l_lap⁺,
+                local_state_prognostic⁺,
+                local_state_auxiliary⁺,
                 t,
             )
         else
@@ -2986,31 +2930,18 @@ the associated numerical flux.
             Base.Cartesian.@nif 7 d -> bctag == d <= length(bcs) d -> begin
                 bc = bcs[d]
                 numerical_boundary_flux_higher_order!(
+                    WrapVars(),
                     hyperviscnumflux,
                     bc,
                     balance_law,
-                    Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
-                        local_state_hyperdiffusion,
-                    ),
+                    local_state_hyperdiffusion,
                     normal_vector,
-                    Vars{vars_state(balance_law, GradientLaplacian(), FT)}(
-                        l_lap⁻,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁻,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁻,
-                    ),
-                    Vars{vars_state(balance_law, GradientLaplacian(), FT)}(
-                        l_lap⁺,
-                    ),
-                    Vars{vars_state(balance_law, Prognostic(), FT)}(
-                        local_state_prognostic⁺,
-                    ),
-                    Vars{vars_state(balance_law, Auxiliary(), FT)}(
-                        local_state_auxiliary⁺,
-                    ),
+                    l_lap⁻,
+                    local_state_prognostic⁻,
+                    local_state_auxiliary⁻,
+                    l_lap⁺,
+                    local_state_prognostic⁺,
+                    local_state_auxiliary⁺,
                     t,
                 )
             end d -> throw(BoundsError(bcs, bctag))

--- a/src/Numerics/DGMethods/vars_wrappers_nf.jl
+++ b/src/Numerics/DGMethods/vars_wrappers_nf.jl
@@ -1,0 +1,533 @@
+#####
+##### Vars wrappers
+#####
+
+# For the generic balance laws:
+function numerical_flux_first_order!(
+    ::WrapVars,
+    numerical_flux::NumericalFluxFirstOrder,
+    balance_law::BalanceLaw,
+    fluxᵀn::AbstractArray,
+    normal_vector::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+    direction,
+)
+    FT = eltype(state_prognostic⁺)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    numerical_flux_first_order!(
+        numerical_flux,
+        balance_law,
+        vs_prog(fluxᵀn),
+        SVector(normal_vector),
+        vs_prog(state_prognostic⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_prog(state_prognostic⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+        direction,
+    )
+end
+
+# For the remainder model:
+function numerical_flux_first_order!(
+    ::WrapVars,
+    numerical_fluxes::Tuple{
+        NumericalFluxFirstOrder,
+        NTuple{NumSubFluxes, NumericalFluxFirstOrder},
+    },
+    rem_balance_law,
+    fluxᵀn::AbstractArray,
+    normal_vector::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+    directions::Dirs,
+) where {NumSubFluxes, S, A, Dirs <: NTuple{2, Direction}}
+
+    FT = eltype(state_prognostic⁻)
+    vs_prog = Vars{vars_state(rem_balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(rem_balance_law, Auxiliary(), FT)}
+
+    numerical_flux_first_order!(
+        numerical_fluxes,
+        rem_balance_law,
+        vs_prog(fluxᵀn),
+        SVector(normal_vector),
+        vs_prog(state_prognostic⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_prog(state_prognostic⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+        directions,
+    )
+end
+
+
+function numerical_flux_second_order!(
+    ::WrapVars,
+    numerical_flux,
+    balance_law::BalanceLaw,
+    fluxᵀn::AbstractArray,
+    normal_vector⁻::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_gradient_flux⁻::AbstractArray,
+    state_hyperdiffusive⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_gradient_flux⁺::AbstractArray,
+    state_hyperdiffusive⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+)
+
+    FT = eltype(state_prognostic⁻)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_diff = Vars{vars_state(balance_law, GradientFlux(), FT)}
+    vs_hyperdiff = Vars{vars_state(balance_law, Hyperdiffusive(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+
+    numerical_flux_second_order!(
+        numerical_flux,
+        balance_law,
+        vs_prog(fluxᵀn),
+        SVector(normal_vector⁻),
+        vs_prog(state_prognostic⁻),
+        vs_diff(state_gradient_flux⁻),
+        vs_hyperdiff(state_hyperdiffusive⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_prog(state_prognostic⁺),
+        vs_diff(state_gradient_flux⁺),
+        vs_hyperdiff(state_hyperdiffusive⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+    )
+end
+
+# function numerical_flux_second_order!(
+#     numerical_flux_second_order,
+#     balance_law,
+#     flux::AbstractArray,
+#     normal_vector::AbstractArray,
+#     state_prognostic⁻::AbstractArray,
+#     state_gradient_flux⁻::AbstractArray,
+#     state_hyperdiffusive⁻::AbstractArray,
+#     state_auxiliary⁻::AbstractArray,
+#     state_prognostic⁺::AbstractArray,
+#     state_gradient_flux⁺::AbstractArray,
+#     state_hyperdiffusive⁺::AbstractArray,
+#     state_auxiliary⁺::AbstractArray,
+#     t,
+# )
+#     FT = eltype(flux)
+#     numerical_flux_second_order!(
+#         numerical_flux_second_order,
+#         balance_law,
+#         Vars{vars_state(balance_law, Prognostic(), FT)}(flux),
+#         SVector(normal_vector),
+#         Vars{vars_state(balance_law, Prognostic(), FT)}(state_prognostic⁻),
+#         Vars{vars_state(balance_law, GradientFlux(), FT)}(state_gradient_flux⁻),
+#         Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
+#             state_hyperdiffusive⁻,
+#         ),
+#         Vars{vars_state(balance_law, Auxiliary(), FT)}(state_auxiliary⁻),
+#         Vars{vars_state(balance_law, Prognostic(), FT)}(state_prognostic⁺),
+#         Vars{vars_state(balance_law, GradientFlux(), FT)}(state_gradient_flux⁺),
+#         Vars{vars_state(balance_law, Hyperdiffusive(), FT)}(
+#             state_hyperdiffusive⁺,
+#         ),
+#         Vars{vars_state(balance_law, Auxiliary(), FT)}(state_auxiliary⁺),
+#         t,
+#     )
+# end
+
+function update_penalty!(
+    ::WrapVars,
+    numerical_flux,
+    balance_law,
+    normal_vector,
+    max_wavespeed,
+    penalty::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+)
+    FT = eltype(state_prognostic⁻)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+
+    update_penalty!(
+        numerical_flux,
+        balance_law,
+        SVector(normal_vector),
+        max_wavespeed,
+        vs_prog(penalty),
+        vs_prog(state_prognostic⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_prog(state_prognostic⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+    )
+end
+
+function numerical_flux_divergence!(
+    ::WrapVars,
+    numerical_flux,
+    balance_law::BalanceLaw,
+    div_penalty::AbstractArray,
+    normal_vector::AbstractArray,
+    grad⁻::AbstractArray,
+    grad⁺::AbstractArray,
+)
+    FT = eltype(div_penalty)
+    vs_div_pen = Vars{vars_state(balance_law, GradientLaplacian(), FT)}
+    vs_grad_lap = Grad{vars_state(balance_law, GradientLaplacian(), FT)}
+
+    numerical_flux_divergence!(
+        numerical_flux,
+        balance_law,
+        vs_div_pen(div_penalty),
+        SVector(normal_vector),
+        vs_grad_lap(grad⁻),
+        vs_grad_lap(grad⁺),
+    )
+end
+
+function numerical_boundary_flux_first_order!(
+    ::WrapVars,
+    numerical_flux_first_order,
+    bc,
+    balance_law,
+    local_flux::AbstractArray,
+    normal_vector::AbstractArray,
+    local_state_prognostic⁻::AbstractArray,
+    local_state_auxiliary⁻::AbstractArray,
+    local_state_prognostic⁺nondiff::AbstractArray,
+    local_state_auxiliary⁺nondiff::AbstractArray,
+    t,
+    face_direction,
+    local_state_prognostic_bottom1::AbstractArray,
+    local_state_auxiliary_bottom1::AbstractArray,
+)
+
+    FT = eltype(local_flux)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+
+    numerical_boundary_flux_first_order!(
+        numerical_flux_first_order,
+        bc,
+        balance_law,
+        vs_prog(local_flux),
+        SVector(normal_vector),
+        vs_prog(local_state_prognostic⁻),
+        vs_aux(local_state_auxiliary⁻),
+        vs_prog(local_state_prognostic⁺nondiff),
+        vs_aux(local_state_auxiliary⁺nondiff),
+        t,
+        face_direction,
+        vs_prog(local_state_prognostic_bottom1),
+        vs_aux(local_state_auxiliary_bottom1),
+    )
+
+end
+
+function numerical_boundary_flux_second_order!(
+    ::WrapVars,
+    numerical_flux_second_order,
+    bc,
+    balance_law,
+    local_flux::AbstractArray,
+    normal_vector::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_gradient_flux⁻::AbstractArray,
+    state_hyperdiffusion⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    state_prognostic⁺diff::AbstractArray,
+    state_gradient_flux⁺::AbstractArray,
+    state_hyperdiffusion⁺::AbstractArray,
+    state_auxiliary⁺diff::AbstractArray,
+    t,
+    state_prognostic_bottom1::AbstractArray,
+    state_gradient_flux_bottom1::AbstractArray,
+    state_auxiliary_bottom1::AbstractArray,
+)
+    FT = eltype(local_flux)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_diff = Vars{vars_state(balance_law, GradientFlux(), FT)}
+    vs_hyperdiff = Vars{vars_state(balance_law, Hyperdiffusive(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    numerical_boundary_flux_second_order!(
+        numerical_flux_second_order,
+        bc,
+        balance_law,
+        vs_prog(local_flux),
+        normal_vector,
+        vs_prog(state_prognostic⁻),
+        vs_diff(state_gradient_flux⁻),
+        vs_hyperdiff(state_hyperdiffusion⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_prog(state_prognostic⁺diff),
+        vs_diff(state_gradient_flux⁺),
+        vs_hyperdiff(state_hyperdiffusion⁺),
+        vs_aux(state_auxiliary⁺diff),
+        t,
+        vs_prog(state_prognostic_bottom1),
+        vs_diff(state_gradient_flux_bottom1),
+        vs_aux(state_auxiliary_bottom1),
+    )
+end
+
+function numerical_boundary_flux_gradient!(
+    ::WrapVars,
+    numerical_flux_gradient,
+    bc,
+    balance_law,
+    transform_gradient::AbstractArray,
+    normal_vector::AbstractArray,
+    transform⁻::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    transform⁺::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+    state_prognostic_bottom1::AbstractArray,
+    state_auxiliary_bottom1::AbstractArray,
+)
+
+    FT = eltype(transform_gradient)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    vs_grad = Vars{vars_state(balance_law, Gradient(), FT)}
+
+    numerical_boundary_flux_gradient!(
+        numerical_flux_gradient,
+        bc,
+        balance_law,
+        transform_gradient,
+        SVector(normal_vector),
+        vs_grad(transform⁻),
+        vs_prog(state_prognostic⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_grad(transform⁺),
+        vs_prog(state_prognostic⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+        vs_prog(state_prognostic_bottom1),
+        vs_aux(state_auxiliary_bottom1),
+    )
+
+end
+
+function numerical_boundary_flux_divergence!(
+    ::WrapVars,
+    numerical_flux,
+    bctype,
+    balance_law::BalanceLaw,
+    div_penalty::AbstractArray,
+    normal_vector::AbstractArray,
+    grad⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    grad⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+)
+    FT = eltype(div_penalty)
+    vs_grad_lap = Vars{vars_state(balance_law, GradientLaplacian(), FT)}
+    gs_grad_lap = Grad{vars_state(balance_law, GradientLaplacian(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    numerical_boundary_flux_divergence!(
+        numerical_flux,
+        bctype,
+        balance_law,
+        vs_grad_lap(div_penalty),
+        SVector(normal_vector),
+        gs_grad_lap(grad⁻),
+        vs_aux(state_auxiliary⁻),
+        gs_grad_lap(grad⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+    )
+end
+
+function numerical_flux_higher_order!(
+    ::WrapVars,
+    numerical_flux::GradNumericalFlux,
+    balance_law::BalanceLaw,
+    hyperdiff::AbstractArray,
+    normal_vector::AbstractArray,
+    lap⁻::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    lap⁺::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+)
+
+    FT = eltype(state_prognostic⁻)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    vs_hyperdiff = Vars{vars_state(balance_law, Hyperdiffusive(), FT)}
+    vs_grad_lap = Vars{vars_state(balance_law, GradientLaplacian(), FT)}
+
+    numerical_flux_higher_order!(
+        numerical_flux,
+        balance_law,
+        vs_hyperdiff(hyperdiff),
+        SVector(normal_vector),
+        vs_grad_lap(lap⁻),
+        vs_prog(state_prognostic⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_grad_lap(lap⁺),
+        vs_prog(state_prognostic⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+    )
+end
+
+function numerical_boundary_flux_higher_order!(
+    ::WrapVars,
+    numerical_flux::GradNumericalFlux,
+    bctype,
+    balance_law::BalanceLaw,
+    hyperdiff::AbstractArray,
+    normal_vector::AbstractArray,
+    lap⁻::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    lap⁺::AbstractArray,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    t,
+)
+
+    FT = eltype(hyperdiff)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    vs_hyperdiff = Vars{vars_state(balance_law, Hyperdiffusive(), FT)}
+    vs_grad_lap = Vars{vars_state(balance_law, GradientLaplacian(), FT)}
+
+    numerical_boundary_flux_higher_order!(
+        numerical_flux,
+        bctype,
+        balance_law,
+        vs_hyperdiff(hyperdiff),
+        SVector(normal_vector),
+        vs_grad_lap(lap⁻),
+        vs_prog(state_prognostic⁻),
+        vs_aux(state_auxiliary⁻),
+        vs_grad_lap(lap⁺),
+        vs_prog(state_prognostic⁺),
+        vs_aux(state_auxiliary⁺),
+        t,
+    )
+end
+
+#####
+##### boundary_state!
+#####
+
+# TODO: develop a DG-unaware boundary_state! interface
+
+function boundary_state!(
+    ::WrapVars,
+    numerical_flux,
+    bctype,
+    balance_law,
+    state_prognostic⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    normal_vector::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    t,
+    state1⁻::AbstractArray,
+    aux1⁻::AbstractArray,
+)
+    FT = eltype(state_prognostic⁺)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    boundary_state!(
+        numerical_flux,
+        bctype,
+        balance_law,
+        vs_prog(state_prognostic⁺),
+        vs_aux(state_auxiliary⁺),
+        SVector(normal_vector),
+        vs_prog(state_prognostic⁻),
+        vs_aux(state_auxiliary⁻),
+        t,
+        vs_prog(state1⁻),
+        vs_aux(aux1⁻),
+    )
+
+end
+
+function boundary_state!(
+    ::WrapVars,
+    numerical_flux::NumericalFluxSecondOrder,
+    bctype,
+    balance_law,
+    state_prognostic⁺::AbstractArray,
+    state_gradient_flux⁺::AbstractArray,
+    state_auxiliary⁺::AbstractArray,
+    normal_vector::AbstractArray,
+    state_prognostic⁻::AbstractArray,
+    state_gradient_flux⁻::AbstractArray,
+    state_auxiliary⁻::AbstractArray,
+    t,
+    state1⁻::AbstractArray,
+    diff1⁻::AbstractArray,
+    aux1⁻::AbstractArray,
+)
+
+    FT = eltype(state_prognostic⁺)
+    vs_prog = Vars{vars_state(balance_law, Prognostic(), FT)}
+    vs_aux = Vars{vars_state(balance_law, Auxiliary(), FT)}
+    vs_diff = Vars{vars_state(balance_law, GradientFlux(), FT)}
+
+    boundary_state!(
+        numerical_flux,
+        bctype,
+        balance_law,
+        vs_prog(state_prognostic⁺),
+        vs_diff(state_gradient_flux⁺),
+        vs_aux(state_auxiliary⁺),
+        SVector(normal_vector),
+        vs_prog(state_prognostic⁻),
+        vs_diff(state_gradient_flux⁻),
+        vs_aux(state_auxiliary⁻),
+        t,
+        vs_prog(state1⁻),
+        vs_diff(diff1⁻),
+        vs_aux(aux1⁻),
+    )
+end
+
+function boundary_state!(
+    ::WrapVars,
+    numerical_flux::Union{DivNumericalPenalty},
+    bctype,
+    balance_law,
+    grad⁺,
+    normal_vector,
+    grad⁻,
+)
+    boundary_state!(
+        numerical_flux,
+        bctype,
+        balance_law,
+        grad⁺,
+        normal_vector,
+        grad⁻,
+    )
+end


### PR DESCRIPTION
### Description

This PR:
 - Add vars wrappers for numerical fluxes
 - Adds a `WrapVars` type, to indicate when balance law kernels are wrapped in `Vars`

<!-- Check all the boxes below before taking the PR out of draft -->

- [ ] Code follows the [style guidelines](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) OR N/A.
- [ ] Unit tests are included OR N/A.
- [ ] Code is exercised in an integration test OR N/A.
- [ ] Documentation has been added/updated OR N/A.
