### PR TITLE
Fix check for invalid number of vtk sample points

### DIFF
--- a/src/Driver/Callbacks/Callbacks.jl
+++ b/src/Driver/Callbacks/Callbacks.jl
@@ -153,6 +153,13 @@ function vtk(vtk_opt, solver_config, output_dir, number_sample_points)
     cb_constr = CB_constructor(vtk_opt, solver_config)
     cb_constr === nothing && return nothing
 
+    if number_sample_points < 0 || number_sample_points == 1
+        error(
+            "number of vtk sample must be `0` (element interpolation points) " *
+            "or `≥ 2` (use specified numer of equally spaced points)",
+        )
+    end
+
     vtknum = Ref(1)
 
     mpicomm = solver_config.mpicomm

--- a/src/InputOutput/VTK/writemesh.jl
+++ b/src/InputOutput/VTK/writemesh.jl
@@ -122,7 +122,7 @@ function writemesh_highorder(
             compress = false,
         )
     end
-    for (name, v) in fields
+    length(realelems) > 0 && for (name, v) in fields
         vtk_point_data(vtkfile, v, name)
     end
     outfiles = vtk_save(vtkfile)
@@ -170,7 +170,7 @@ function writemesh_highorder(
             compress = false,
         )
     end
-    for (name, v) in fields
+    length(realelems) > 0 && for (name, v) in fields
         vtk_point_data(vtkfile, v, name)
     end
     outfiles = vtk_save(vtkfile)
@@ -205,7 +205,7 @@ function writemesh_highorder(
         cells;
         compress = false,
     )
-    for (name, v) in fields
+    length(realelems) > 0 && for (name, v) in fields
         vtk_point_data(vtkfile, v, name)
     end
     outfiles = vtk_save(vtkfile)
@@ -236,7 +236,7 @@ function writemesh_raw(
     end
 
     vtkfile = vtk_grid("$(base_name)", @view(x1[:]), cells; compress = false)
-    for (name, v) in fields
+    length(realelems) > 0 && for (name, v) in fields
         vtk_point_data(vtkfile, v, name)
     end
     outfiles = vtk_save(vtkfile)
@@ -290,7 +290,7 @@ function writemesh_raw(
             compress = false,
         )
     end
-    for (name, v) in fields
+    length(realelems) > 0 && for (name, v) in fields
         vtk_point_data(vtkfile, v, name)
     end
     outfiles = vtk_save(vtkfile)
@@ -337,7 +337,7 @@ function writemesh_raw(
         cells;
         compress = false,
     )
-    for (name, v) in fields
+    length(realelems) > 0 && for (name, v) in fields
         vtk_point_data(vtkfile, v, name)
     end
     outfiles = vtk_save(vtkfile)

--- a/src/InputOutput/VTK/writevtk.jl
+++ b/src/InputOutput/VTK/writevtk.jl
@@ -119,7 +119,7 @@ function writevtk_helper(
     auxfieldnames = nothing;
     number_sample_points,
 )
-    @assert number_sample_points >= 0
+    @assert number_sample_points == 0 || number_sample_points >= 2
 
     dim = dimensionality(grid)
     N = polynomialorders(grid)


### PR DESCRIPTION
The number of vtk sample points should be either `0` (meaning use the LGL grid) or `>= 2` (meaning use specified number of equally spaced points)

closes #2045 
